### PR TITLE
fix aggregate api test - spanner

### DIFF
--- a/packages/velo-external-db/package.json
+++ b/packages/velo-external-db/package.json
@@ -17,6 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios-retry": "^3.1.9",
     "compression": "^1.7.4",
     "ejs": "^3.1.6",
     "express": "^4.17.1",
@@ -39,7 +40,6 @@
     "jest-each": "^27.0.6",
     "jest-when": "^3.3.1",
     "test-commons": "^0.0.0",
-    "ts-jest": "^27.0.4",
-    "chance": "^1.1.7"
+    "ts-jest": "^27.0.4"
   }
 }

--- a/packages/velo-external-db/test/drivers/schema_api_rest_test_support.js
+++ b/packages/velo-external-db/test/drivers/schema_api_rest_test_support.js
@@ -1,7 +1,13 @@
 const axios = require('axios').create({
     baseURL: 'http://localhost:8080'
 });
+const axiosRetry = require('axios-retry');
 
+axiosRetry(axios, {
+    retries: 3,
+    retryDelay: (retryCount) => retryCount * 2000,
+    retryCondition: (_error) => true
+});
 
 const givenCollection = async (name, columns, auth) => {
     await axios.post(`/schemas/create`, {collectionName: name}, auth)


### PR DESCRIPTION
The aggregate api test failed because of the `givenCollection` function
`columns.map(async column => await axios.post('/schemas/column/add', {collectionName: name, column: column}, auth)) )` 

The function failed because cloud spanner can only execute one transaction at a time on a session, and we're trying to post column/add before the last transaction have done. 
so I've added retry to this post request, I would love to hear if you think there is a better solution or it's ok for now.