### PR TITLE
misconfigred Db Operation list example for mysql

### DIFF
--- a/packages/external-db-mysql/tests/drivers/db_operations_test_support.js
+++ b/packages/external-db-mysql/tests/drivers/db_operations_test_support.js
@@ -26,7 +26,12 @@ const dbOperationWithValidDB = () => {
     return { dbOperations, cleanup }
 }
 
+const misconfiguredDbOperationOptions = () => ([   ['pool connection with wrong password.', () => dbOperationWithMisconfiguredPassword()],
+                                            ['pool connection with wrong database', () => dbOperationWithMisconfiguredDatabase()],
+                                            ['pool connection with wrong host', () => dbOperationWithMisconfiguredHost()]
+                                        ])
+
 module.exports = {
     dbOperationWithMisconfiguredPassword, dbOperationWithMisconfiguredDatabase,
-    dbOperationWithMisconfiguredHost, dbOperationWithValidDB
+    dbOperationWithMisconfiguredHost, dbOperationWithValidDB, misconfiguredDbOperationOptions
 }

--- a/packages/velo-external-db/test/resources/operations_resources.js
+++ b/packages/velo-external-db/test/resources/operations_resources.js
@@ -19,6 +19,8 @@ const init = async impl => {
     env.driver = driver
 }
 
+const misconfiguredDbOperation = impl => (impl.opsDriver().misconfiguredDbOperationOptions)
+
 const postgresTestEnvInit = async() => await init(postgres)
 const mysqlTestEnvInit = async() => await init(mysql)
 const spannerTestEnvInit = async() => await init(spanner)
@@ -30,7 +32,7 @@ const dynamoTestEnvInit = async() => await init(dynamo)
 const bigqueryTestEnvInit = async() => await init(bigquery)
 
 const testSuits = () => [
-    ['MySql', mysqlTestEnvInit],
+    ['MySql', mysqlTestEnvInit, misconfiguredDbOperation(mysql)],
     ['Postgres', postgresTestEnvInit],
     ['Spanner', spannerTestEnvInit],
     ['Firestore', firestoreTestEnvInit],

--- a/packages/velo-external-db/test/storage/database_operation.spec.js
+++ b/packages/velo-external-db/test/storage/database_operation.spec.js
@@ -3,11 +3,33 @@ const each = require('jest-each').default
 const { env, testSuits } = require('../resources/operations_resources')
 
 describe('Check Pool Connection', () => {
-    each(testSuits()).describe('%s', (dbType, setup) => {
+    each(testSuits()).describe('%s', (dbType, setup, misconfiguredDbOperationOptions) => {
 
         beforeAll(async() => {
             setup()
         })
+
+        if (dbType === 'MySql') {
+            each(misconfiguredDbOperationOptions())
+            .test.only('%s will return DbConnectionError',async(message, givenMisconfiguredDbOperation) => {
+                const dbOperation = await givenMisconfiguredDbOperation()
+    
+                const validateConnection = await dbOperation.validateConnection()
+    
+                expect(validateConnection.valid).toBeFalsy()
+                expect(validateConnection.error).toBeInstanceOf(DbConnectionError)
+            })
+
+            test.only('pool connection with valid DB will return object with without error', async () => {
+                const { dbOperations, cleanup } = await env.driver.dbOperationWithValidDB()
+    
+                const validateConnection = await dbOperations.validateConnection()
+    
+                expect(validateConnection.valid).toBeTruthy()
+                expect(validateConnection.error).not.toBeDefined()
+                await cleanup()
+            })
+        }
         
         if (dbType !== 'Bigquery') {
             test('pool connection with wrong password will return DbConnectionError.', async() => {
@@ -20,6 +42,16 @@ describe('Check Pool Connection', () => {
             })
         }
             
+
+        test('pool connection with wrong password will return DbConnectionError.', async () => {
+            const dbOperation = await env.driver.dbOperationWithMisconfiguredPassword()
+
+            const validateConnection = await dbOperation.validateConnection()
+
+            expect(validateConnection.valid).toBeFalsy()
+            expect(validateConnection.error).toBeInstanceOf(DbConnectionError)
+        })
+
         if (dbType !== 'Firestore') {
             test('pool connection with wrong database will return DbConnectionError.', async() => {
                 const dbOperation = await env.driver.dbOperationWithMisconfiguredDatabase()


### PR DESCRIPTION
Not sure about that I put the `misconfiguredDbOperationOptions`  In `testSuites` but I didn't find another way to perform each with that list.

The tests should include only the two tests within the if condition.

LMK if you want me to change the other implementations to work that way or to implement this in other way. 