### PR TITLE
V2 new filter, aggregation

### DIFF
--- a/packages/external-db-airtable/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-airtable/lib/sql_filter_transformer.spec.js
@@ -76,10 +76,7 @@ describe('Sql Parser', () => {
                 '$ne', '$lt', '$lte', '$gt', '$gte', '$eq',
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: o,
-                    fieldName: ctx.fieldName,
-                    value: ctx.fieldValue
+                    [ctx.fieldName]: { [o]: ctx.fieldValue }
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -90,14 +87,11 @@ describe('Sql Parser', () => {
 
             test('correctly extract filter value if value is 0', () => {
                 const filter = {
-                    operator: '$eq',
-                    fieldName: ctx.fieldName,
-                    value: 0
+                    [ctx.fieldName]: { $eq: 0 }
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                    filterExpr: `${ctx.fieldName} = "${filter.value}"`
-                    // parameters: [0]
+                    filterExpr: `${ctx.fieldName} = "0"`
                 }])
 
             })
@@ -105,10 +99,7 @@ describe('Sql Parser', () => {
             // todo: $hasAll ???
             test('correctly transform operator [$hasSome]', () => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: '$hasSome',
-                    fieldName: ctx.fieldName,
-                    value: ctx.fieldListValue
+                    [ctx.fieldName]: { $hasSome: ctx.fieldListValue }
                 }
                 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -118,10 +109,7 @@ describe('Sql Parser', () => {
 
             test('operator [$hasSome] with empty list of values will throw an exception', () => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: '$hasSome',
-                    fieldName: ctx.fieldName,
-                    value: []
+                    [ctx.fieldName]: { $hasSome: [] }
                 }
 
                 expect( () => env.filterParser.parseFilter(filter) ).toThrow(InvalidQuery)
@@ -129,9 +117,7 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$eq] with null value', () => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: '$eq',
-                    fieldName: ctx.fieldName,
+                    [ctx.fieldName]: { $eq: undefined } 
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -141,14 +127,14 @@ describe('Sql Parser', () => {
             })
 
             test('correctly transform operator [$eq] with boolean value', () => {
+                const value = chance.bool()
+                const operator = '$eq'
                 const filter = {
-                    operator: '$eq',
-                    fieldName: ctx.fieldName,
-                    value: chance.bool()
+                    [ctx.fieldName]: { [operator]: value } 
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                    filterExpr: `${ctx.fieldName} = ${env.filterParser.valueForOperator(filter.value, filter.operator)}`
+                    filterExpr: `${ctx.fieldName} = ${env.filterParser.valueForOperator(value, operator)}`
                 }])
 
             })
@@ -156,10 +142,7 @@ describe('Sql Parser', () => {
             describe('handle string operators', () => {
                 test('correctly transform operator [$contains]', () => {
                     const filter = {
-                        // kind: 'filter',
-                        operator: '$contains',
-                        fieldName: ctx.fieldName,
-                        value: ctx.fieldValue
+                        [ctx.fieldName]: { $contains: ctx.fieldValue }
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -170,10 +153,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
-                        operator: '$startsWith',
-                        fieldName: ctx.fieldName,
-                        value: ctx.fieldValue
+                        [ctx.fieldName]: { $startsWith: ctx.fieldValue }
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -184,10 +164,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$endsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
-                        operator: '$endsWith',
-                        fieldName: ctx.fieldName,
-                        value: ctx.fieldValue
+                        [ctx.fieldName]: { $endsWith: ctx.fieldValue }
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -201,9 +178,7 @@ describe('Sql Parser', () => {
                 '$and', '$or'
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: o,
-                    value: [ctx.filter, ctx.anotherFilter]
+                    [o]: [ctx.filter, ctx.anotherFilter]
                 }
                 const op = o === '$and' ? 'AND' : 'OR'
 
@@ -216,9 +191,7 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$not]', () => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: '$not',
-                    value: ctx.filter
+                    $not: [ ctx.filter ]
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -251,8 +224,8 @@ describe('Sql Parser', () => {
         ctx.fieldValue = chance.word()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
 
-        ctx.filter = gen.randomFilter()
-        ctx.anotherFilter = gen.randomFilter()
+        ctx.filter = gen.randomV2Filter()
+        ctx.anotherFilter = gen.randomV2Filter()
     })
 
     beforeAll(function() {

--- a/packages/external-db-mongo/lib/sql_filter_transformer.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.js
@@ -1,5 +1,5 @@
 const { InvalidQuery } = require('velo-external-db-commons').errors
-const { EMPTY_SORT, isObject } = require('velo-external-db-commons')
+const { EMPTY_SORT, isObject, getFilterObject } = require('velo-external-db-commons')
 const { EMPTY_FILTER } = require('./mongo_utils')
 
 class FilterParser {
@@ -21,17 +21,17 @@ class FilterParser {
         const fieldsStatement = {}
         if (isObject(aggregation._id)) {
             const _id = Object.keys(aggregation._id)
-                              .reduce((r, c) => ( { ...r, [aggregation._id[c]]: `$${aggregation._id[c]}` } ), {})
+                              .reduce((r, c) => ( { ...r, [aggregation._id[c].substring(1)]: `${aggregation._id[c]}` } ), {})
             Object.assign(fieldsStatement, { _id } )
         } else {
-            Object.assign(fieldsStatement, { [aggregation._id]: `$${aggregation._id}` })
+            Object.assign(fieldsStatement, { [aggregation._id.substring(1)]: `${aggregation._id}` })
         }
         Object.keys(aggregation)
               .filter(f => f !== '_id')
               .forEach(fieldAlias => {
                   Object.entries(aggregation[fieldAlias])
                         .forEach(([func, field]) => {
-                            Object.assign(fieldsStatement, { [fieldAlias]: { [func]: `$${field}` } })
+                            Object.assign(fieldsStatement, { [fieldAlias]: { [func]: `${field}` } })
                         })
               })
         const filterObj = havingFilter.reduce((r, c) => ( { ...r, ...c } ), {})
@@ -42,32 +42,32 @@ class FilterParser {
     }
 
     parseFilter(filter) {
-        if (!filter || !isObject(filter) || filter.operator === undefined) {
+        if (!filter || !isObject(filter) || Object.keys(filter)[0] === undefined ) {
             return []
         }
-        const operator = this.veloOperatorToMongoOperator(filter.operator)
+        const filterObj = getFilterObject(filter)
+        const operator = this.veloOperatorToMongoOperator(filterObj.operator)
 
         if (this.isMultipleFieldOperator(operator)) {
-            const res = filter.value.map( this.parseFilter.bind(this) )
+            const res = filterObj.value.map( this.parseFilter.bind(this) )
             return [{ filterExpr: { [operator]: res.map(r => r[0].filterExpr) } }]
         }
 
         if (operator === '$not') {
-            const res = this.parseFilter(filter.value)
+            const res = this.parseFilter(filterObj.value[0])
             return [{ filterExpr: { [operator]: res[0].filterExpr } }]
         }
 
         if (this.isSingleFieldStringOperator(operator)) {
-            return [{ filterExpr: { [filter.fieldName]: { $regex: this.valueForStringOperator(operator, filter.value) } } }]
+            return [{ filterExpr: { [filterObj.fieldName]: { $regex: this.valueForStringOperator(operator, filterObj.value) } } }]
         }
 
-        if (filter.operator === '$urlized') {
+        if (operator === '$urlized') {
             return [{
-                filterExpr: { [filter.fieldName]: { $regex: `/${filter.value.map(s => s.toLowerCase()).join('.*')}/i` } }
+                filterExpr: { [filterObj.fieldName]: { $regex: `/${filterObj.value.map(s => s.toLowerCase()).join('.*')}/i` } }
             }]
         }
-
-        return [{ filterExpr: { [filter.fieldName]: { [operator]: this.valueForOperator(filter.value, operator) } } }]
+        return [{ filterExpr: { [filterObj.fieldName]: { [operator]: this.valueForOperator(filterObj.value, operator) } } }]
 
     }
 

--- a/packages/external-db-mongo/lib/sql_filter_transformer.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.js
@@ -26,6 +26,7 @@ class FilterParser {
         } else {
             Object.assign(fieldsStatement, { [aggregation._id.substring(1)]: `${aggregation._id}` })
         }
+
         Object.keys(aggregation)
               .filter(f => f !== '_id')
               .forEach(fieldAlias => {

--- a/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
@@ -90,7 +90,7 @@ describe('Sql Parser', () => {
 
             test('correctly extract filter value if value is 0', () => {
                 const filter = {
-                    [ctx.fieldName]: { '$eq': 0 }
+                    [ctx.fieldName]: { $eq: 0 }
                     /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
@@ -122,7 +122,7 @@ describe('Sql Parser', () => {
 
             test('operator [$hasSome] with empty list of values will throw an exception', () => {
                 const filter = {
-                    [ctx.fieldName]: { '$hasSome': [] }
+                    [ctx.fieldName]: { $hasSome: [] }
                     /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
@@ -135,7 +135,7 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$eq] with null value', () => {
                 const filter = {
-                    [ctx.fieldName]: { '$eq': undefined } 
+                    [ctx.fieldName]: { $eq: undefined } 
                     /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
@@ -150,7 +150,7 @@ describe('Sql Parser', () => {
             test('correctly transform operator [$eq] with boolean value', () => {
                 const value = chance.bool()
                 const filter = {
-                    [ctx.fieldName]: { '$eq': value } 
+                    [ctx.fieldName]: { $eq: value } 
                     /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
@@ -166,7 +166,7 @@ describe('Sql Parser', () => {
             describe('handle string operators', () => {
                 test('correctly transform operator [$contains]', () => {
                     const filter = {
-                        [ctx.fieldName]: { '$contains': ctx.fieldValue }
+                        [ctx.fieldName]: { $contains: ctx.fieldValue }
                         /*
                         operator: '$contains',
                         fieldName: ctx.fieldName,
@@ -180,12 +180,13 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
-                        [ctx.fieldName]: { '$startsWith': ctx.fieldValue }
+                        [ctx.fieldName]: { $startsWith: ctx.fieldValue }
                         /*
                         operator: '$startsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
-                        */                    }
+                        */                    
+                    }
 
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
                         filterExpr: { [ctx.fieldName]: { $regex: `^${ctx.fieldValue}` } }
@@ -194,7 +195,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$endsWith]', () => {
                     const filter = {
-                        [ctx.fieldName]: { '$endsWith': ctx.fieldValue }
+                        [ctx.fieldName]: { $endsWith: ctx.fieldValue }
                         /*
                         operator: '$endsWith',
                         fieldName: ctx.fieldName,
@@ -209,7 +210,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$urlized]', () => {
                     const filter = {
-                        [ctx.fieldName]: { '$urlized': ctx.fieldListValue } 
+                        [ctx.fieldName]: { $urlized: ctx.fieldListValue } 
                         /*
                         operator: '$urlized',
                         fieldName: ctx.fieldName,
@@ -380,6 +381,5 @@ describe('Sql Parser', () => {
     beforeAll(function() {
         env.filterParser = new FilterParser
     })
-
 
 })

--- a/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
@@ -247,7 +247,7 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$not]', () => {
                 const filter = {
-                    '$not' : [ ctx.filter ]
+                    $not: [ ctx.filter ]
                     /*
                     operator: '$not',
                     value: ctx.filter

--- a/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
@@ -61,7 +61,6 @@ describe('Sql Parser', () => {
             expect(env.filterParser.parseFilter(undefined)).toEqual([])
             expect(env.filterParser.parseFilter(null)).toEqual([])
             expect(env.filterParser.parseFilter(555)).toEqual([])
-            expect(env.filterParser.parseFilter([5555])).toEqual([])
         })
 
         test('transform filter', () => {
@@ -75,14 +74,15 @@ describe('Sql Parser', () => {
                 '$ne', '$lt', '$lte', '$gt', '$gte', '$eq',
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    operator: o,
+                    [ctx.fieldName]: { [o]: ctx.fieldValue }
+                    /*operator: o,
                     fieldName: ctx.fieldName,
-                    value: ctx.fieldValue
+                    value: ctx.fieldValue*/
                 }
 
 
                 expect(env.filterParser.parseFilter(filter)).toEqual([{
-                    filterExpr: { [ctx.fieldName]: { [o]: filter.value } }
+                    filterExpr: { [ctx.fieldName]: { [o]: ctx.fieldValue } }
                 }
                 ])
 
@@ -90,13 +90,16 @@ describe('Sql Parser', () => {
 
             test('correctly extract filter value if value is 0', () => {
                 const filter = {
+                    [ctx.fieldName]: { '$eq': 0 }
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
                     value: 0
+                    */
                 }
 
                 expect(env.filterParser.parseFilter(filter)).toEqual([{
-                    filterExpr: { [ctx.fieldName]: { $eq: filter.value } }
+                    filterExpr: { [ctx.fieldName]: { $eq: 0 } }
                 }])
 
             })
@@ -104,9 +107,12 @@ describe('Sql Parser', () => {
             // todo: $hasAll ???
             test('correctly transform operator [$hasSome]', () => {
                 const filter = {
+                    [ctx.fieldName]: { '$hasSome': ctx.fieldListValue }
+                    /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
                     value: ctx.fieldListValue
+                    */
                 }
 
                 expect(env.filterParser.parseFilter(filter)).toEqual([{
@@ -116,9 +122,12 @@ describe('Sql Parser', () => {
 
             test('operator [$hasSome] with empty list of values will throw an exception', () => {
                 const filter = {
+                    [ctx.fieldName]: { '$hasSome': [] }
+                    /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
                     value: []
+                    */
                 }
 
                 expect(() => env.filterParser.parseFilter(filter)).toThrow(InvalidQuery)
@@ -126,8 +135,11 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$eq] with null value', () => {
                 const filter = {
+                    [ctx.fieldName]: { '$eq': undefined } 
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
+                    */
                 }
 
                 expect(env.filterParser.parseFilter(filter)).toEqual([{
@@ -136,61 +148,73 @@ describe('Sql Parser', () => {
             })
 
             test('correctly transform operator [$eq] with boolean value', () => {
+                const value = chance.bool()
                 const filter = {
+                    [ctx.fieldName]: { '$eq': value } 
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
                     value: chance.bool()
+                    */
                 }
 
                 expect(env.filterParser.parseFilter(filter)).toEqual([{
-                    filterExpr: { [ctx.fieldName]: { $eq: filter.value } }
+                    filterExpr: { [ctx.fieldName]: { $eq: value } }
                 }])
             })
 
             describe('handle string operators', () => {
                 test('correctly transform operator [$contains]', () => {
                     const filter = {
+                        [ctx.fieldName]: { '$contains': ctx.fieldValue }
+                        /*
                         operator: '$contains',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
-
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: `${filter.value}` } }
-                        // filterExpr: `${escapeId(ctx.fieldName)} LIKE ${validateLiteral(ctx.fieldName)}`,
-                        // parameters: { [patchFieldName(ctx.fieldName)]: `%${ctx.fieldValue}%` }
+                        filterExpr: { [ctx.fieldName]: { $regex: ctx.fieldValue } }
                     }])
                 })
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
+                        [ctx.fieldName]: { '$startsWith': ctx.fieldValue }
+                        /*
                         operator: '$startsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
-                    }
+                        */                    }
 
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: `^${filter.value}` } }
+                        filterExpr: { [ctx.fieldName]: { $regex: `^${ctx.fieldValue}` } }
                     }])
                 })
 
                 test('correctly transform operator [$endsWith]', () => {
                     const filter = {
+                        [ctx.fieldName]: { '$endsWith': ctx.fieldValue }
+                        /*
                         operator: '$endsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
 
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: `${filter.value}$` } }
+                        filterExpr: { [ctx.fieldName]: { $regex: `${ctx.fieldValue}$` } }
                     }])
                 })
 
                 test('correctly transform operator [$urlized]', () => {
                     const filter = {
+                        [ctx.fieldName]: { '$urlized': ctx.fieldListValue } 
+                        /*
                         operator: '$urlized',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldListValue
+                        */
                     }
 
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
@@ -205,8 +229,11 @@ describe('Sql Parser', () => {
                 '$and', '$or'
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
+                    [o]: [ctx.filter, ctx.anotherFilter]
+                    /*
                     operator: o,
                     value: [ctx.filter, ctx.anotherFilter]
+                    */
                 }
 
                 const filter1 = env.filterParser.parseFilter(ctx.filter)[0]
@@ -219,12 +246,15 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$not]', () => {
                 const filter = {
+                    '$not' : [ ctx.filter ]
+                    /*
                     operator: '$not',
                     value: ctx.filter
+                    */
                 }
 
                 expect(env.filterParser.parseFilter(filter)).toEqual([{
-                    filterExpr: { [filter.operator]: env.filterParser.parseFilter(ctx.filter)[0].filterExpr }
+                    filterExpr: { $not: env.filterParser.parseFilter(ctx.filter)[0].filterExpr }
                 }])
             })
         })
@@ -234,7 +264,7 @@ describe('Sql Parser', () => {
             describe('transform select fields', () => {
                 test('single id field', () => {
                     const aggregation = {
-                        _id: ctx.fieldName
+                        _id: `$${ctx.fieldName}`
                     }
 
                     expect(env.filterParser.parseAggregation(aggregation)).toEqual({
@@ -246,8 +276,8 @@ describe('Sql Parser', () => {
                 test('multiple id fields', () => {
                     const aggregation = {
                         _id: {
-                            field1: ctx.fieldName,
-                            field2: ctx.anotherFieldName
+                            field1: `$${ctx.fieldName}`,
+                            field2: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -266,13 +296,13 @@ describe('Sql Parser', () => {
 
                 test('process having filter', () => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            $avg: ctx.anotherFieldName
+                            $avg: `$${ctx.anotherFieldName}`
                         }
                     }
 
-                    const havingFilter = { operator: '$gt', fieldName: ctx.moreFieldName, value: ctx.fieldValue }
+                    const havingFilter = {  [ctx.moreFieldName]: { $gt: ctx.fieldValue } }
 
                     expect(env.filterParser.parseAggregation(aggregation, havingFilter)).toEqual({
                         // fieldsStatement: `${(ctx.fieldName)}, AVG(${(ctx.anotherFieldName)}) AS ${(ctx.moreFieldName)}`,
@@ -296,9 +326,9 @@ describe('Sql Parser', () => {
                     ['$sum'],
                 ]).test('translate %s function', (wixDataFunction) => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            [wixDataFunction]: ctx.anotherFieldName
+                            [wixDataFunction]: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -341,8 +371,8 @@ describe('Sql Parser', () => {
         ctx.fieldValue = chance.word()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
 
-        ctx.filter = gen.randomFilter()
-        ctx.anotherFilter = gen.randomFilter()
+        ctx.filter = gen.randomV2Filter()
+        ctx.anotherFilter = gen.randomV2Filter()
 
         ctx.offset = chance.natural({ min: 2, max: 20 })
     })

--- a/packages/external-db-mssql/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mssql/lib/sql_filter_transformer.spec.js
@@ -59,17 +59,10 @@ describe('Sql Parser', () => {
 
         test('handles undefined filter', () => {
             expect( env.filterParser.parseFilter('') ).toEqual([])
-            // expect( env.filterParser.parseFilter('    ') ).toEqual(EMPTY_FILTER)
             expect( env.filterParser.parseFilter(undefined) ).toEqual([])
             expect( env.filterParser.parseFilter(null) ).toEqual([])
-            // expect( env.filterParser.parseFilter({invalid: 'object'}) ).toEqual(EMPTY_FILTER)
             expect( env.filterParser.parseFilter(555) ).toEqual([])
             expect( env.filterParser.parseFilter([5555]) ).toEqual([])
-            // expect( env.filterParser.parseFilter(['sdfsdf']) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([null]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([undefined]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([{invalid: 'object'}]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([]) ).toEqual(EMPTY_FILTER)
         })
 
         test('transform filter', () => {
@@ -84,10 +77,10 @@ describe('Sql Parser', () => {
                 '$ne', '$lt', '$lte', '$gt', '$gte', '$eq',
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: o,
+                    [ctx.fieldName]: { [o]: ctx.fieldValue }
+                    /*operator: o,
                     fieldName: ctx.fieldName,
-                    value: ctx.fieldValue
+                    value: ctx.fieldValue*/
                 }
 
 
@@ -100,9 +93,12 @@ describe('Sql Parser', () => {
 
             test('correctly extract filter value if value is 0', () => {
                 const filter = {
+                    [ctx.fieldName]: { $eq: 0 }
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
                     value: 0
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -115,10 +111,12 @@ describe('Sql Parser', () => {
             // todo: $hasAll ???
             test('correctly transform operator [$hasSome]', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { $hasSome: ctx.fieldListValue }
+                    /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
                     value: ctx.fieldListValue
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -135,10 +133,12 @@ describe('Sql Parser', () => {
 
             test('operator [$hasSome] with empty list of values will throw an exception', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { $hasSome: [] }
+                    /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
                     value: []
+                    */
                 }
 
                 expect( () => env.filterParser.parseFilter(filter) ).toThrow(InvalidQuery)
@@ -146,9 +146,11 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$eq] with null value', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { $eq: undefined } 
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -158,25 +160,31 @@ describe('Sql Parser', () => {
             })
 
             test('correctly transform operator [$eq] with boolean value', () => {
+                const value = chance.bool()
                 const filter = {
+                    [ctx.fieldName]: { $eq: value } 
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
                     value: chance.bool()
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
                     filterExpr: `${escapeId(ctx.fieldName)} = ${validateLiteral(ctx.fieldName)}`,
-                    parameters: { [patchFieldName(ctx.fieldName)]: filter.value ? 1 : 0 }
+                    parameters: { [patchFieldName(ctx.fieldName)]: value ? 1 : 0 }
                 }])
             })
 
             describe('handle string operators', () => {
                 test('correctly transform operator [$contains]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { $contains: ctx.fieldValue }
+                        /*
                         operator: '$contains',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -187,10 +195,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { '$startsWith': ctx.fieldValue }
+                        /*
                         operator: '$startsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */   
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -201,10 +211,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$endsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { $endsWith: ctx.fieldValue }
+                        /*
                         operator: '$endsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -215,10 +227,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$urlized]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { $urlized: ctx.fieldListValue } 
+                        /*
                         operator: '$urlized',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldListValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -234,9 +248,11 @@ describe('Sql Parser', () => {
                 '$and', '$or'
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
+                    [o]: [ctx.filter, ctx.anotherFilter]
+                    /*
                     operator: o,
                     value: [ctx.filter, ctx.anotherFilter]
+                    */    
                 }
                 const op = o === '$and' ? 'AND' : 'OR'
 
@@ -250,9 +266,11 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$not]', () => {
                 const filter = {
-                    // kind: 'filter',
+                    $not: [ ctx.filter ]
+                    /*
                     operator: '$not',
                     value: ctx.filter
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -267,7 +285,7 @@ describe('Sql Parser', () => {
             describe('transform select fields', () => {
                 test('single id field', () => {
                     const aggregation = {
-                        _id: ctx.fieldName
+                        _id: `$${ctx.fieldName}`
                     }
 
                     expect( env.filterParser.parseAggregation(aggregation) ).toEqual({
@@ -281,8 +299,8 @@ describe('Sql Parser', () => {
                 test('multiple id fields', () => {
                     const aggregation = {
                         _id: {
-                            field1: ctx.fieldName,
-                            field2: ctx.anotherFieldName
+                            field1: `$${ctx.fieldName}`,
+                            field2: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -296,13 +314,13 @@ describe('Sql Parser', () => {
 
                 test('process having filter', () => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            $avg: ctx.anotherFieldName
+                            $avg: `$${ctx.anotherFieldName}`
                         }
                     }
 
-                    const havingFilter = { operator: '$gt', fieldName: ctx.moreFieldName, value: ctx.fieldValue }
+                    const havingFilter = {  [ctx.moreFieldName]: { $gt: ctx.fieldValue } }
 
                     expect( env.filterParser.parseAggregation(aggregation, havingFilter) ).toEqual({
                         fieldsStatement: `${escapeId(ctx.fieldName)}, AVG(${escapeId(ctx.anotherFieldName)}) AS ${escapeId(ctx.moreFieldName)}`,
@@ -319,9 +337,9 @@ describe('Sql Parser', () => {
                     ['SUM', '$sum'],
                 ]).test('translate %s function', (mySqlFunction, wixDataFunction) => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            [wixDataFunction]: ctx.anotherFieldName
+                            [wixDataFunction]: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -361,8 +379,8 @@ describe('Sql Parser', () => {
         ctx.fieldValue = chance.word()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
 
-        ctx.filter = gen.randomFilter()
-        ctx.anotherFilter = gen.randomFilter()
+        ctx.filter = gen.randomV2Filter()
+        ctx.anotherFilter = gen.randomV2Filter()
 
         ctx.offset = chance.natural({ min: 2, max: 20 })
     })

--- a/packages/external-db-mssql/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mssql/lib/sql_filter_transformer.spec.js
@@ -195,7 +195,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
-                        [ctx.fieldName]: { '$startsWith': ctx.fieldValue }
+                        [ctx.fieldName]: { $startsWith: ctx.fieldValue }
                         /*
                         operator: '$startsWith',
                         fieldName: ctx.fieldName,

--- a/packages/external-db-mysql/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mysql/lib/sql_filter_transformer.spec.js
@@ -59,17 +59,10 @@ describe('Sql Parser', () => {
 
         test('handles undefined filter', () => {
             expect( env.filterParser.parseFilter('') ).toEqual([])
-            // expect( env.filterParser.parseFilter('    ') ).toEqual(EMPTY_FILTER)
             expect( env.filterParser.parseFilter(undefined) ).toEqual([])
             expect( env.filterParser.parseFilter(null) ).toEqual([])
-            // expect( env.filterParser.parseFilter({invalid: 'object'}) ).toEqual(EMPTY_FILTER)
             expect( env.filterParser.parseFilter(555) ).toEqual([])
             expect( env.filterParser.parseFilter([5555]) ).toEqual([])
-            // expect( env.filterParser.parseFilter(['sdfsdf']) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([null]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([undefined]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([{invalid: 'object'}]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([]) ).toEqual(EMPTY_FILTER)
         })
 
         test('transform filter', () => {
@@ -84,10 +77,10 @@ describe('Sql Parser', () => {
                 '$ne', '$lt', '$lte', '$gt', '$gte', '$eq',
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: o,
+                    [ctx.fieldName]: { [o]: ctx.fieldValue }
+                    /*operator: o,
                     fieldName: ctx.fieldName,
-                    value: ctx.fieldValue
+                    value: ctx.fieldValue*/
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -99,9 +92,7 @@ describe('Sql Parser', () => {
 
             test('correctly extract filter value if value is 0', () => {
                 const filter = {
-                    operator: '$eq',
-                    fieldName: ctx.fieldName,
-                    value: 0
+                    [ctx.fieldName]: { $eq: 0 }
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -114,10 +105,7 @@ describe('Sql Parser', () => {
             // todo: $hasAll ???
             test('correctly transform operator [$hasSome]', () => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: '$hasSome',
-                    fieldName: ctx.fieldName,
-                    value: ctx.fieldListValue
+                    [ctx.fieldName]: { $hasSome: ctx.fieldListValue }
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -128,10 +116,7 @@ describe('Sql Parser', () => {
 
             test('operator [$hasSome] with empty list of values will throw an exception', () => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: '$hasSome',
-                    fieldName: ctx.fieldName,
-                    value: []
+                    [ctx.fieldName]: { $hasSome: [] }
                 }
 
                 expect( () => env.filterParser.parseFilter(filter) ).toThrow(InvalidQuery)
@@ -139,9 +124,7 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$eq] with null value', () => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: '$eq',
-                    fieldName: ctx.fieldName,
+                    [ctx.fieldName]: { $eq: undefined } 
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -152,27 +135,22 @@ describe('Sql Parser', () => {
             })
 
             test('correctly transform operator [$eq] with boolean value', () => {
+                const value = chance.bool()
                 const filter = {
-                    operator: '$eq',
-                    fieldName: ctx.fieldName,
-                    value: chance.bool()
+                    [ctx.fieldName]: { $eq: value } 
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
                     filterExpr: `${escapeId(ctx.fieldName)} = ?`,
-                    parameters: [filter.value ? 1 : 0]
+                    parameters: [value ? 1 : 0]
                 }])
 
             })
 
             describe('handle string operators', () => {
-                //'$contains', '', ''
                 test('correctly transform operator [$contains]', () => {
                     const filter = {
-                        // kind: 'filter',
-                        operator: '$contains',
-                        fieldName: ctx.fieldName,
-                        value: ctx.fieldValue
+                        [ctx.fieldName]: { $contains: ctx.fieldValue }
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -184,10 +162,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
-                        operator: '$startsWith',
-                        fieldName: ctx.fieldName,
-                        value: ctx.fieldValue
+                        [ctx.fieldName]: { $startsWith: ctx.fieldValue }
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -199,10 +174,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$endsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
-                        operator: '$endsWith',
-                        fieldName: ctx.fieldName,
-                        value: ctx.fieldValue
+                        [ctx.fieldName]: { $endsWith: ctx.fieldValue }
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -213,10 +185,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$urlized]', () => {
                     const filter = {
-                        // kind: 'filter',
-                        operator: '$urlized',
-                        fieldName: ctx.fieldName,
-                        value: ctx.fieldListValue
+                        [ctx.fieldName]: { $urlized: ctx.fieldListValue } 
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -231,9 +200,7 @@ describe('Sql Parser', () => {
                 '$and', '$or'
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: o,
-                    value: [ctx.filter, ctx.anotherFilter]
+                    [o]: [ctx.filter, ctx.anotherFilter]
                 }
                 const op = o === '$and' ? 'AND' : 'OR'
 
@@ -246,9 +213,7 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$not]', () => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: '$not',
-                    value: ctx.filter
+                    $not: [ ctx.filter ]
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -264,7 +229,7 @@ describe('Sql Parser', () => {
             describe('transform select fields', () => {
                 test('single id field', () => {
                     const aggregation = {
-                        _id: ctx.fieldName
+                        _id: `$${ctx.fieldName}`
                     }
 
                     expect( env.filterParser.parseAggregation(aggregation) ).toEqual({
@@ -278,8 +243,8 @@ describe('Sql Parser', () => {
                 test('multiple id fields', () => {
                     const aggregation = {
                         _id: {
-                            field1: ctx.fieldName,
-                            field2: ctx.anotherFieldName
+                            field1: `$${ctx.fieldName}`,
+                            field2: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -293,13 +258,13 @@ describe('Sql Parser', () => {
 
                 test('process having filter', () => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            $avg: ctx.anotherFieldName
+                            $avg: `$${ctx.anotherFieldName}`
                         }
                     }
 
-                    const havingFilter = { operator: '$gt', fieldName: ctx.moreFieldName, value: ctx.fieldValue }
+                    const havingFilter = {  [ctx.moreFieldName]: { $gt: ctx.fieldValue } }
 
                     expect( env.filterParser.parseAggregation(aggregation, havingFilter) ).toEqual({
                         fieldsStatement: `${escapeId(ctx.fieldName)}, AVG(${escapeId(ctx.anotherFieldName)}) AS ${escapeId(ctx.moreFieldName)}`,
@@ -317,9 +282,9 @@ describe('Sql Parser', () => {
                     ['SUM', '$sum'],
                 ]).test('translate %s function', (mySqlFunction, wixDataFunction) => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            [wixDataFunction]: ctx.anotherFieldName
+                            [wixDataFunction]: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -358,8 +323,8 @@ describe('Sql Parser', () => {
         ctx.fieldValue = chance.word()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
 
-        ctx.filter = gen.randomFilter()
-        ctx.anotherFilter = gen.randomFilter()
+        ctx.filter = gen.randomV2Filter()
+        ctx.anotherFilter = gen.randomV2Filter()
     })
 
     beforeAll(function() {

--- a/packages/external-db-postgres/lib/sql_filter_transformer.js
+++ b/packages/external-db-postgres/lib/sql_filter_transformer.js
@@ -77,10 +77,7 @@ class FilterParser {
 
     parseFilter(filter, offset, inlineFields) {
 
-        if (!filter || !isObject(filter)) {
-            return []
-        }
-        if (Object.keys(filter)[0] === undefined) {
+        if (!filter || !isObject(filter) || Object.keys(filter)[0] === undefined) {
             return []
         }
         

--- a/packages/external-db-postgres/lib/sql_filter_transformer.js
+++ b/packages/external-db-postgres/lib/sql_filter_transformer.js
@@ -1,5 +1,5 @@
 const { InvalidQuery } = require('velo-external-db-commons').errors
-const { EMPTY_FILTER, EMPTY_SORT, isObject } = require('velo-external-db-commons')
+const { EMPTY_FILTER, EMPTY_SORT, isObject, getFilterObject } = require('velo-external-db-commons')
 const { escapeIdentifier } = require('./postgres_utils')
 
 class FilterParser {
@@ -83,7 +83,7 @@ class FilterParser {
             return []
         }
         
-        const filterObj = this.getFilterObject(filter)
+        const filterObj = getFilterObject(filter)
         
         switch (filterObj.operator) {
             case '$and':
@@ -258,31 +258,6 @@ class FilterParser {
             }
         }
         return escapeIdentifier(fieldName)
-    }
-
-    getFilterObject(filter) {
-        if(this.isMultipleFieldOperator(filter)) {
-            const operator = Object.keys(filter)[0]
-            const value = filter[operator]
-            return {
-                operator,
-                value
-            }
-        }
-
-        const fieldName = Object.keys(filter)[0]
-        const operator = Object.keys(filter[fieldName])[0]
-        const value = filter[fieldName][operator]
-
-        return {
-            operator,
-            fieldName,
-            value
-        }
-    }
-    
-    isMultipleFieldOperator(filter) { 
-        return ['$not', '$or', '$and'].includes(Object.keys(filter)[0])
     }
 }
 

--- a/packages/external-db-postgres/lib/sql_filter_transformer.js
+++ b/packages/external-db-postgres/lib/sql_filter_transformer.js
@@ -53,8 +53,9 @@ class FilterParser {
               .forEach(fieldAlias => {
                   Object.entries(aggregation[fieldAlias])
                         .forEach(([func, field]) => {
-                            filterColumnsStr.push(`${this.wixDataFunction2Sql(func)}(${escapeIdentifier(field.substring(1))}) AS ${escapeIdentifier(fieldAlias)}`)
-                            aliasToFunction[fieldAlias] = `${this.wixDataFunction2Sql(func)}(${escapeIdentifier(field.substring(1))})`
+                            field = field.substring(1)
+                            filterColumnsStr.push(`${this.wixDataFunction2Sql(func)}(${escapeIdentifier(field)}) AS ${escapeIdentifier(fieldAlias)}`)
+                            aliasToFunction[fieldAlias] = `${this.wixDataFunction2Sql(func)}(${escapeIdentifier(field)})`
                         })
               })
 

--- a/packages/external-db-postgres/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-postgres/lib/sql_filter_transformer.spec.js
@@ -58,17 +58,10 @@ describe('Sql Parser', () => {
 
         test('handles undefined filter', () => {
             expect( env.filterParser.parseFilter('', ctx.offset) ).toEqual([])
-            // expect( env.filterParser.parseFilter('    ') ).toEqual(EMPTY_FILTER)
             expect( env.filterParser.parseFilter(undefined, ctx.offset) ).toEqual([])
             expect( env.filterParser.parseFilter(null, ctx.offset) ).toEqual([])
-            // expect( env.filterParser.parseFilter({invalid: 'object'}) ).toEqual(EMPTY_FILTER)
             expect( env.filterParser.parseFilter(555, ctx.offset) ).toEqual([])
             expect( env.filterParser.parseFilter([5555], ctx.offset) ).toEqual([])
-            // expect( env.filterParser.parseFilter(['sdfsdf']) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([null]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([undefined]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([{invalid: 'object'}]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([]) ).toEqual(EMPTY_FILTER)
         })
 
         test('transform filter', () => {
@@ -85,10 +78,10 @@ describe('Sql Parser', () => {
                 '$ne', '$lt', '$lte', '$gt', '$gte', '$eq',
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: o,
+                    [ctx.fieldName]: { [o]: ctx.fieldValue }
+                    /*operator: o,
                     fieldName: ctx.fieldName,
-                    value: ctx.fieldValue
+                    value: ctx.fieldValue*/
                 }
 
                 expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -102,9 +95,12 @@ describe('Sql Parser', () => {
 
             test('correctly extract filter value if value is 0', () => {
                 const filter = {
+                    [ctx.fieldName]: { '$eq': 0 }
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
                     value: 0
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -119,10 +115,12 @@ describe('Sql Parser', () => {
             // todo: $hasAll ???
             test('correctly transform operator [$hasSome]', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { '$hasSome': ctx.fieldListValue }
+                    /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
                     value: ctx.fieldListValue
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -135,10 +133,12 @@ describe('Sql Parser', () => {
 
             test('operator [$hasSome] with empty list of values will throw an exception', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { '$hasSome': [] }
+                    /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
                     value: []
+                    */
                 }
 
                 expect( () => env.filterParser.parseFilter(filter, ctx.offset) ).toThrow(InvalidQuery)
@@ -146,9 +146,11 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$eq] with null value', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { '$eq': undefined } 
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -160,27 +162,33 @@ describe('Sql Parser', () => {
             })
 
             test('correctly transform operator [$eq] with boolean value', () => {
+                const value = chance.bool()
                 const filter = {
+                    [ctx.fieldName]: { '$eq': value } 
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
                     value: chance.bool()
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
                     filterExpr: `${escapeIdentifier(ctx.fieldName)} = $${ctx.offset}`,
                     filterColumns: [],
                     offset: ctx.offset + 1,
-                    parameters: [filter.value ? 1 : 0]
+                    parameters: [value ? 1 : 0]
                 }])
             })
 
             describe('handle string operators', () => {
                 test('correctly transform operator [$contains]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { '$contains': ctx.fieldValue }
+                        /*
                         operator: '$contains',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -193,10 +201,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { '$startsWith': ctx.fieldValue }
+                        /*
                         operator: '$startsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -209,10 +219,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$endsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { '$endsWith': ctx.fieldValue }
+                        /*
                         operator: '$endsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -225,10 +237,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$urlized]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { '$urlized': ctx.fieldListValue } 
+                        /*
                         operator: '$urlized',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldListValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -246,9 +260,11 @@ describe('Sql Parser', () => {
                 '$and', '$or'
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
+                    [o]: [ctx.filter, ctx.anotherFilter]
+                    /*
                     operator: o,
                     value: [ctx.filter, ctx.anotherFilter]
+                    */
                 }
                 const op = o === '$and' ? 'AND' : 'OR'
 
@@ -265,9 +281,11 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$not]', () => {
                 const filter = {
-                    // kind: 'filter',
+                    '$not' : [ ctx.filter ]
+                    /*
                     operator: '$not',
                     value: ctx.filter
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -285,7 +303,7 @@ describe('Sql Parser', () => {
             describe('transform select fields', () => {
                 test('single id field', () => {
                     const aggregation = {
-                        _id: ctx.fieldName
+                        _id: `$${ctx.fieldName}`
                     }
 
                     expect( env.filterParser.parseAggregation(aggregation) ).toEqual({
@@ -299,8 +317,8 @@ describe('Sql Parser', () => {
                 test('multiple id fields', () => {
                     const aggregation = {
                         _id: {
-                            field1: ctx.fieldName,
-                            field2: ctx.anotherFieldName
+                            field1: `$${ctx.fieldName}`,
+                            field2: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -314,13 +332,14 @@ describe('Sql Parser', () => {
 
                 test('process having filter', () => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            $avg: ctx.anotherFieldName
+                            $avg: `$${ctx.anotherFieldName}`
                         }
                     }
 
-                    const havingFilter = { operator: '$gt', fieldName: ctx.moreFieldName, value: ctx.fieldValue }
+                    const havingFilter = { [ctx.moreFieldName]: { $gt: ctx.fieldValue } }
+                    /*operator: '$gt', fieldName: ctx.moreFieldName, value: ctx.fieldValue*/
 
                     expect( env.filterParser.parseAggregation(aggregation, havingFilter, ctx.offset) ).toEqual({
                         fieldsStatement: `${escapeIdentifier(ctx.fieldName)}, AVG(${escapeIdentifier(ctx.anotherFieldName)}) AS ${escapeIdentifier(ctx.moreFieldName)}`,
@@ -337,9 +356,9 @@ describe('Sql Parser', () => {
                     ['SUM', '$sum'],
                 ]).test('translate %s function', (mySqlFunction, wixDataFunction) => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            [wixDataFunction]: ctx.anotherFieldName
+                            [wixDataFunction]: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -379,8 +398,8 @@ describe('Sql Parser', () => {
         ctx.fieldValue = chance.word()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
 
-        ctx.filter = gen.randomFilter()
-        ctx.anotherFilter = gen.randomFilter()
+        ctx.filter = gen.randomV2Filter()
+        ctx.anotherFilter = gen.randomV2Filter()
 
         ctx.offset = chance.natural({ min: 2, max: 20 })
     })

--- a/packages/external-db-spanner/lib/sql_filter_transformer.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.js
@@ -1,5 +1,5 @@
 const { InvalidQuery } = require('velo-external-db-commons').errors
-const { EMPTY_FILTER, EMPTY_SORT, isObject } = require('velo-external-db-commons')
+const { EMPTY_FILTER, EMPTY_SORT, isObject, getFilterObject } = require('velo-external-db-commons')
 const { escapeId, validateLiteral, patchFieldName, escapeFieldId } = require('./spanner_utils')
 
 class FilterParser {
@@ -38,19 +38,19 @@ class FilterParser {
         const groupByColumns = []
         const filterColumnsStr = []
         if (isObject(aggregation._id)) {
-            filterColumnsStr.push(...Object.values(aggregation._id).map(f => escapeFieldId(f)))
-            groupByColumns.push(...Object.values(aggregation._id).map(f => patchFieldName(f)))
+            filterColumnsStr.push(...Object.values(aggregation._id).map(f => escapeFieldId(f.substring(1))))
+            groupByColumns.push(...Object.values(aggregation._id).map(f => patchFieldName(f.substring(1))))
         } else {
-            filterColumnsStr.push(escapeFieldId(aggregation._id))
-            groupByColumns.push(patchFieldName(aggregation._id))
+            filterColumnsStr.push(escapeFieldId(aggregation._id.substring(1)))
+            groupByColumns.push(patchFieldName(aggregation._id.substring(1)))
         }
-
         const aliasToFunction = {}
         Object.keys(aggregation)
               .filter(f => f !== '_id')
               .forEach(fieldAlias => {
                   Object.entries(aggregation[fieldAlias])
                         .forEach(([func, field]) => {
+                            field = field.substring(1)
                             filterColumnsStr.push(`${this.wixDataFunction2Sql(func)}(${escapeFieldId(field)}) AS ${escapeFieldId(fieldAlias)}`)
                             aliasToFunction[fieldAlias] = `${this.wixDataFunction2Sql(func)}(${escapeFieldId(field)})`
                         })
@@ -73,53 +73,54 @@ class FilterParser {
     }
 
     parseFilter(filter, inlineFields) {
-        if (!filter || !isObject(filter)|| filter.operator === undefined) {
+        if (!filter || !isObject(filter)|| Object.keys(filter)[0] === undefined) {
             return []
         }
+        const filterObj = getFilterObject(filter)
 
-        switch (filter.operator) {
+        switch (filterObj.operator) {
             case '$and':
             case '$or':
-                const res = filter.value.reduce((o, f) => {
+                const res = filterObj.value.reduce((o, f) => {
                     const res = this.parseFilter.bind(this)(f, inlineFields)
                     return {
                         filter: o.filter.concat( ...res ),
                     }
                 }, { filter: [] })
-                const op = filter.operator === '$and' ? ' AND ' : ' OR '
+                const op = filterObj.operator === '$and' ? ' AND ' : ' OR '
                 return [{
                     filterExpr: res.filter.map(r => r.filterExpr).join( op ),
                     parameters: res.filter.reduce((o, s) => ( { ...o, ...s.parameters } ), {} )
                 }]
             case '$not':
-                const res2 = this.parseFilter( filter.value, inlineFields )
+                const res2 = this.parseFilter( filterObj.value[0], inlineFields )
                 return [{
                     filterExpr: `NOT (${res2[0].filterExpr})`,
                     parameters: res2[0].parameters
                 }]
         }
 
-        if (this.isSingleFieldOperator(filter.operator)) {
-            const params = this.valueForOperator(filter.fieldName, filter.value, filter.operator)
+        if (this.isSingleFieldOperator(filterObj.operator)) {
+            const params = this.valueForOperator(filterObj.fieldName, filterObj.value, filterObj.operator)
 
             return [{
-                filterExpr: `${this.inlineVariableIfNeeded(filter.fieldName, inlineFields)} ${this.veloOperatorToMySqlOperator(filter.operator, filter.value)} ${params.sql}`.trim(),
-                parameters: this.parametersFor(filter.fieldName, filter.value)
+                filterExpr: `${this.inlineVariableIfNeeded(filterObj.fieldName, inlineFields)} ${this.veloOperatorToMySqlOperator(filterObj.operator, filterObj.value)} ${params.sql}`.trim(),
+                parameters: this.parametersFor(filterObj.fieldName, filterObj.value)
             }]
         }
 
 
-        if (this.isSingleFieldStringOperator(filter.operator)) {
+        if (this.isSingleFieldStringOperator(filterObj.operator)) {
             return [{
-                filterExpr: `${this.inlineVariableIfNeeded(filter.fieldName, inlineFields)} LIKE ${validateLiteral(filter.fieldName)}`,
-                parameters: { [filter.fieldName]: this.valueForStringOperator(filter.operator, filter.value) }
+                filterExpr: `${this.inlineVariableIfNeeded(filterObj.fieldName, inlineFields)} LIKE ${validateLiteral(filterObj.fieldName)}`,
+                parameters: { [filterObj.fieldName]: this.valueForStringOperator(filterObj.operator, filterObj.value) }
             }]
         }
 
-        if (filter.operator === '$urlized') {
+        if (filterObj.operator === '$urlized') {
             return [{
-                filterExpr: `LOWER(${escapeId(filter.fieldName)}) RLIKE ${validateLiteral(filter.fieldName)}`,
-                parameters: { [filter.fieldName]: filter.value.map(s => s.toLowerCase()).join('[- ]') }
+                filterExpr: `LOWER(${escapeId(filterObj.fieldName)}) RLIKE ${validateLiteral(filterObj.fieldName)}`,
+                parameters: { [filterObj.fieldName]: filterObj.value.map(s => s.toLowerCase()).join('[- ]') }
             }]
         }
 

--- a/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
@@ -194,7 +194,7 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
-                        [ctx.fieldName]: { '$startsWith': ctx.fieldValue }
+                        [ctx.fieldName]: { $startsWith: ctx.fieldValue }
                         /*
                         operator: '$startsWith',
                         fieldName: ctx.fieldName,

--- a/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
@@ -59,17 +59,10 @@ describe('Sql Parser', () => {
 
         test('handles undefined filter', () => {
             expect( env.filterParser.parseFilter('') ).toEqual([])
-            // expect( env.filterParser.parseFilter('    ') ).toEqual(EMPTY_FILTER)
             expect( env.filterParser.parseFilter(undefined) ).toEqual([])
             expect( env.filterParser.parseFilter(null) ).toEqual([])
-            // expect( env.filterParser.parseFilter({invalid: 'object'}) ).toEqual(EMPTY_FILTER)
             expect( env.filterParser.parseFilter(555) ).toEqual([])
             expect( env.filterParser.parseFilter([5555]) ).toEqual([])
-            // expect( env.filterParser.parseFilter(['sdfsdf']) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([null]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([undefined]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([{invalid: 'object'}]) ).toEqual(EMPTY_FILTER)
-            // expect( env.filterParser.parseFilter([]) ).toEqual(EMPTY_FILTER)
         })
 
         test('transform filter', () => {
@@ -84,10 +77,10 @@ describe('Sql Parser', () => {
                 '$ne', '$lt', '$lte', '$gt', '$gte', '$eq',
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
-                    operator: o,
+                    [ctx.fieldName]: { [o]: ctx.fieldValue }
+                    /*operator: o,
                     fieldName: ctx.fieldName,
-                    value: ctx.fieldValue
+                    value: ctx.fieldValue*/
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -99,9 +92,12 @@ describe('Sql Parser', () => {
 
             test('correctly extract filter value if value is 0', () => {
                 const filter = {
+                    [ctx.fieldName]: { $eq: 0 }
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
                     value: 0
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -114,10 +110,12 @@ describe('Sql Parser', () => {
             // todo: $hasAll ???
             test('correctly transform operator [$hasSome]', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { $hasSome: ctx.fieldListValue }
+                    /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
                     value: ctx.fieldListValue
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -134,10 +132,12 @@ describe('Sql Parser', () => {
 
             test('operator [$hasSome] with empty list of values will throw an exception', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { $hasSome: [] }
+                    /*
                     operator: '$hasSome',
                     fieldName: ctx.fieldName,
                     value: []
+                    */
                 }
 
                 expect( () => env.filterParser.parseFilter(filter) ).toThrow(InvalidQuery)
@@ -145,9 +145,11 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$eq] with null value', () => {
                 const filter = {
-                    // kind: 'filter',
+                    [ctx.fieldName]: { $eq: undefined } 
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -157,25 +159,31 @@ describe('Sql Parser', () => {
             })
 
             test('correctly transform operator [$eq] with boolean value', () => {
+                const value = chance.bool()
                 const filter = {
+                    [ctx.fieldName]: { $eq: value } 
+                    /*
                     operator: '$eq',
                     fieldName: ctx.fieldName,
                     value: chance.bool()
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
                     filterExpr: `${escapeId(ctx.fieldName)} = @${ctx.fieldName}`,
-                    parameters: { [ctx.fieldName]: filter.value ? 1 : 0 }
+                    parameters: { [ctx.fieldName]: value ? 1 : 0 }
                 }])
             })
 
             describe('handle string operators', () => {
                 test('correctly transform operator [$contains]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { $contains: ctx.fieldValue }
+                        /*
                         operator: '$contains',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -186,10 +194,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$startsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { '$startsWith': ctx.fieldValue }
+                        /*
                         operator: '$startsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */       
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -200,10 +210,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$endsWith]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { $endsWith: ctx.fieldValue }
+                        /*
                         operator: '$endsWith',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -214,10 +226,12 @@ describe('Sql Parser', () => {
 
                 test('correctly transform operator [$urlized]', () => {
                     const filter = {
-                        // kind: 'filter',
+                        [ctx.fieldName]: { $urlized: ctx.fieldListValue } 
+                        /*
                         operator: '$urlized',
                         fieldName: ctx.fieldName,
                         value: ctx.fieldListValue
+                        */
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -233,10 +247,11 @@ describe('Sql Parser', () => {
                 '$and', '$or'
             ]).test('correctly transform operator [%s]', (o) => {
                 const filter = {
-                    // kind: 'filter',
+                    [o]: [ctx.filter, ctx.anotherFilter]
+                    /*
                     operator: o,
                     value: [ctx.filter, ctx.anotherFilter]
-                }
+                    */                }
                 const op = o === '$and' ? 'AND' : 'OR'
 
                 const filter1 = env.filterParser.parseFilter(ctx.filter)[0]
@@ -249,9 +264,11 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$not]', () => {
                 const filter = {
-                    // kind: 'filter',
+                    $not : [ ctx.filter ]
+                    /*
                     operator: '$not',
                     value: ctx.filter
+                    */
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
@@ -266,7 +283,7 @@ describe('Sql Parser', () => {
             describe('transform select fields', () => {
                 test('single id field', () => {
                     const aggregation = {
-                        _id: ctx.fieldName
+                        _id: `$${ctx.fieldName}`
                     }
 
                     expect( env.filterParser.parseAggregation(aggregation) ).toEqual({
@@ -280,8 +297,8 @@ describe('Sql Parser', () => {
                 test('multiple id fields', () => {
                     const aggregation = {
                         _id: {
-                            field1: ctx.fieldName,
-                            field2: ctx.anotherFieldName
+                            field1: `$${ctx.fieldName}`,
+                            field2: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -295,13 +312,13 @@ describe('Sql Parser', () => {
 
                 test('process having filter', () => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            $avg: ctx.anotherFieldName
+                            $avg: `$${ctx.anotherFieldName}`
                         }
                     }
 
-                    const havingFilter = { operator: '$gt', fieldName: ctx.moreFieldName, value: ctx.fieldValue }
+                    const havingFilter = {  [ctx.moreFieldName]: { $gt: ctx.fieldValue } }
 
                     expect( env.filterParser.parseAggregation(aggregation, havingFilter) ).toEqual({
                         fieldsStatement: `${escapeId(ctx.fieldName)}, AVG(${escapeId(ctx.anotherFieldName)}) AS ${escapeId(ctx.moreFieldName)}`,
@@ -318,9 +335,9 @@ describe('Sql Parser', () => {
                     ['SUM', '$sum'],
                 ]).test('translate %s function', (mySqlFunction, wixDataFunction) => {
                     const aggregation = {
-                        _id: ctx.fieldName,
+                        _id: `$${ctx.fieldName}`,
                         [ctx.moreFieldName]: {
-                            [wixDataFunction]: ctx.anotherFieldName
+                            [wixDataFunction]: `$${ctx.anotherFieldName}`
                         }
                     }
 
@@ -360,8 +377,8 @@ describe('Sql Parser', () => {
         ctx.fieldValue = chance.word()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
 
-        ctx.filter = gen.randomFilter()
-        ctx.anotherFilter = gen.randomFilter()
+        ctx.filter = gen.randomV2Filter()
+        ctx.anotherFilter = gen.randomV2Filter()
 
         ctx.offset = chance.natural({ min: 2, max: 20 })
     })

--- a/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
@@ -158,7 +158,7 @@ describe('Sql Parser', () => {
                 }])
             })
 
-            test('correctly transform operator [$eq] with boolean value', () => {
+            test.only('correctly transform operator [$eq] with boolean value', () => {
                 const value = chance.bool()
                 const filter = {
                     [ctx.fieldName]: { $eq: value } 
@@ -251,7 +251,8 @@ describe('Sql Parser', () => {
                     /*
                     operator: o,
                     value: [ctx.filter, ctx.anotherFilter]
-                    */                }
+                    */                
+                }
                 const op = o === '$and' ? 'AND' : 'OR'
 
                 const filter1 = env.filterParser.parseFilter(ctx.filter)[0]
@@ -264,7 +265,7 @@ describe('Sql Parser', () => {
 
             test('correctly transform operator [$not]', () => {
                 const filter = {
-                    $not : [ ctx.filter ]
+                    $not: [ ctx.filter ]
                     /*
                     operator: '$not',
                     value: ctx.filter

--- a/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
@@ -158,7 +158,7 @@ describe('Sql Parser', () => {
                 }])
             })
 
-            test.only('correctly transform operator [$eq] with boolean value', () => {
+            test('correctly transform operator [$eq] with boolean value', () => {
                 const value = chance.bool()
                 const filter = {
                     [ctx.fieldName]: { $eq: value } 

--- a/packages/test-commons/lib/gen.js
+++ b/packages/test-commons/lib/gen.js
@@ -117,6 +117,15 @@ const randomFilter = () => {
     }
 }
 
+const randomV2Filter = () => {
+    const op = randomOperator()
+    const fieldName = chance.word()
+    const value = op === '$hasSome' ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
+    return {
+        [fieldName]: { [op]: value } 
+    }
+}
+
 const idFilter = () => {
     const op = randomOperator()
     return {
@@ -167,6 +176,6 @@ const randomConfig = () => ({
 
 module.exports = { randomDbs, randomEntities, randomEntity, randomFilter, idFilter, veloDate, randomObject,
      randomDbEntity, randomDbEntities, randomColumn, randomCollectionName, randomNumberDbEntity, randomObjectFromArray,
-      randomNumberColumns, randomKeyObject, deleteRandomKeyObject, clearRandomKeyObject, randomConfig }
+      randomNumberColumns, randomKeyObject, deleteRandomKeyObject, clearRandomKeyObject, randomConfig, randomV2Filter }
 
 

--- a/packages/test-commons/lib/gen.js
+++ b/packages/test-commons/lib/gen.js
@@ -135,6 +135,14 @@ const idFilter = () => {
     }
 }
 
+const idV2Filter = () => {
+    const op = randomOperator()
+    const value = op === '$hasSome' ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
+    return {
+        _id: { [op]: value}
+    }
+}
+
 const randomOperator = () => (chance.pickone(['$ne', '$lt', '$lte', '$gt', '$gte', '$hasSome', '$eq', '$contains', '$startsWith', '$endsWith']))
 
 const veloDate = () => ( { $date: newDate().toISOString() } )
@@ -176,6 +184,6 @@ const randomConfig = () => ({
 
 module.exports = { randomDbs, randomEntities, randomEntity, randomFilter, idFilter, veloDate, randomObject,
      randomDbEntity, randomDbEntities, randomColumn, randomCollectionName, randomNumberDbEntity, randomObjectFromArray,
-      randomNumberColumns, randomKeyObject, deleteRandomKeyObject, clearRandomKeyObject, randomConfig, randomV2Filter }
+      randomNumberColumns, randomKeyObject, deleteRandomKeyObject, clearRandomKeyObject, randomConfig, randomV2Filter, idV2Filter }
 
 

--- a/packages/velo-external-db-commons/lib/data_commons.js
+++ b/packages/velo-external-db-commons/lib/data_commons.js
@@ -38,5 +38,30 @@ const updateFieldsFor = item => {
     return Object.keys(item).filter(f => f !== '_id')
 }
 
+const getFilterObject = (filter) => {
+    if(isMultipleFieldOperator(filter)) {
+        const operator = Object.keys(filter)[0]
+        const value = filter[operator]
+        return {
+            operator,
+            value
+        }
+    }
 
-module.exports = { EMPTY_FILTER, EMPTY_SORT, patchDateTime, asParamArrays, isObject, updateFieldsFor }
+    const fieldName = Object.keys(filter)[0]
+    const operator = Object.keys(filter[fieldName])[0]
+    const value = filter[fieldName][operator]
+
+    return {
+        operator,
+        fieldName,
+        value
+    }
+}
+
+const isMultipleFieldOperator = (filter) => { 
+    return ['$not', '$or', '$and'].includes(Object.keys(filter)[0])
+}
+
+
+module.exports = { EMPTY_FILTER, EMPTY_SORT, patchDateTime, asParamArrays, isObject, updateFieldsFor, getFilterObject }

--- a/packages/velo-external-db-core/lib/service/data.js
+++ b/packages/velo-external-db-core/lib/service/data.js
@@ -16,10 +16,7 @@ class DataService {
 
     async getById(collectionName, itemId) {
         const result = await this.find(collectionName, {
-            kind: 'filter',
-            operator: '$eq',
-            fieldName: '_id',
-            value: itemId
+            _id: { $eq: itemId }
         }, '', 0, 1)
 
         return { item: result.items[0] }

--- a/packages/velo-external-db-core/lib/service/data.spec.js
+++ b/packages/velo-external-db-core/lib/service/data.spec.js
@@ -23,11 +23,7 @@ describe('Data Service', () => {
 
     test('get by id will issue a call to find and transform the result', async() => {
         driver.givenListResult([ctx.entity], ctx.collectionName,
-                        { kind: 'filter',
-                               operator: '$eq',
-                               fieldName: '_id',
-                               value: ctx.itemId
-                              }, '', 0, 1)
+                        { _id: { $eq: ctx.itemId } }, '', 0, 1)
 
         const actual = await env.dataService.getById(ctx.collectionName, ctx.itemId)
         expect( actual ).toEqual({ item: ctx.entity })

--- a/packages/velo-external-db/lib/router.js
+++ b/packages/velo-external-db/lib/router.js
@@ -38,8 +38,8 @@ const createRouter = () => {
 
     router.post('/data/aggregate', async(req, res, next) => {
         try {
-            const { collectionName, filter, aggregation } = req.body
-            const data = await dataService.aggregate(collectionName, filter, aggregation)
+            const { collectionName, filter, processingStep, postFilteringStep } = req.body
+            const data = await dataService.aggregate(collectionName, filter, { processingStep, postFilteringStep })
             res.json(data)
         } catch (e) {
             next(e)

--- a/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -57,29 +57,27 @@ describe('Velo External DB Data REST API',  () => {
             await data.givenItems([ctx.numberItem, ctx.anotherNumberItem], ctx.collectionName, authAdmin)
 
             expect((await axios.post('/data/aggregate',
-                { collectionName: ctx.collectionName,
-                    filter: { operator: '$eq', fieldName: '_id', value: ctx.numberItem._id },
-                    aggregation: {
-                        processingStep: {
-                            _id: {
-                                field1: '_id',
-                                field2: '_owner',
-                            },
-                            myAvg: {
-                                $avg: ctx.numberColumns[0].name
-                            },
-                            mySum: {
-                                $sum: ctx.numberColumns[1].name
-                            }
+                { 
+                    collectionName: ctx.collectionName,
+                    filter: { _id: { $eq: ctx.numberItem._id }},
+                    processingStep: {
+                        _id: {
+                            field1: '$_id',
+                            field2: '$_owner',
                         },
-                        postFilteringStep: {
-                            operator: '$and', value: [
-                                { operator: '$gt', fieldName: 'myAvg', value: 0 },
-                                { operator: '$gt', fieldName: 'mySum', value: 0 }
-
-                            ],
+                        myAvg: {
+                            $avg: `$${ctx.numberColumns[0].name}`
                         },
-                    }
+                        mySum: {
+                            $sum: `$${ctx.numberColumns[1].name}`
+                        }
+                    },
+                    postFilteringStep: {
+                        $and: [
+                            { myAvg: { $gt: 0 }},
+                            { mySum: { $gt: 0 }}
+                        ],
+                    },
                 }, authAdmin)).data).toEqual({ items: [ { _id: ctx.numberItem._id, _owner: ctx.numberItem._owner, myAvg: ctx.numberItem[ctx.numberColumns[0].name], mySum: ctx.numberItem[ctx.numberColumns[1].name] } ],
                 totalCount: 0 })
         })


### PR DESCRIPTION
Didn't change e2e yet.
Changed filter_parser to work with v2 API

The filter was : 
```
filter: 
{
  operator: '$eq'
  fieldName: 'field'
  value: 'val'
}
```
filter changed to: 
```
filter:
{
  field:  { $eq: 'val' }
}
```

aggregation was:

```
filter: { somefilter },
aggregation: {
    processingStep: {
        _id: {
            field1: 'field',
        },
        myAvg: {
            $avg: 'somefield'
        }
    },
    postFilteringStep: {
        somefilter
    },
}
```

aggregation changed to:
```
filter: { somefilter},
processingStep: {
    _id: {
        field1: '$field',
    },
    myAvg: {
        $avg: `$somefield`
    }
},
postFilteringStep: {
    somefilter
},
```

As you can see, in aggregation:
there's no aggregation object.
The fields are with $ prefix.