### PR TITLE
Feat:  New schema supported operations api

### DIFF
--- a/packages/velo-external-db-commons/lib/schema_commons.js
+++ b/packages/velo-external-db-commons/lib/schema_commons.js
@@ -80,8 +80,8 @@ const parseTableData = data => data.reduce((o, r) => {
 const SchemaOperations = Object.freeze({
     LIST: 'list',
     LIST_HEADERS: 'list-headers',
-    CREATE: 'create-table',
-    DROP: 'drop-table', 
+    CREATE: 'create-collection',
+    DROP: 'drop-collection', 
     ADD_COLUMN: 'add-column',
     REMOVE_COLUMN: 'remove-column',
     DESCRIBE_COLLECTION: 'describe-collection',
@@ -92,7 +92,6 @@ const supportedSchemaOperationsFor = (impl) => {
 
     switch (impl.toLowerCase()) {
         case 'airtable':
-        case 'bigquery':
         case 'dynamodb':
         case 'firestore':
         case 'mongo':
@@ -103,6 +102,7 @@ const supportedSchemaOperationsFor = (impl) => {
             return [LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, REMOVE_COLUMN, DESCRIBE_COLLECTION]
         
         case 'google-sheet':
+        case 'bigquery':
             return [LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, DESCRIBE_COLLECTION]
     
         default:

--- a/packages/velo-external-db-commons/lib/schema_commons.js
+++ b/packages/velo-external-db-commons/lib/schema_commons.js
@@ -92,6 +92,7 @@ const supportedSchemaOperationsFor = (impl) => {
 
     switch (impl.toLowerCase()) {
         case 'airtable':
+        case 'bigquery':
         case 'dynamodb':
         case 'firestore':
         case 'mongo':
@@ -102,7 +103,6 @@ const supportedSchemaOperationsFor = (impl) => {
             return [LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, REMOVE_COLUMN, DESCRIBE_COLLECTION]
         
         case 'google-sheet':
-        case 'bigquery':
             return [LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, DESCRIBE_COLLECTION]
     
         default:

--- a/packages/velo-external-db-core/lib/service/schema.js
+++ b/packages/velo-external-db-core/lib/service/schema.js
@@ -38,6 +38,10 @@ class SchemaService {
         await this.schemaInformation.refresh()
         return {}
     }
+
+    async supportedOperations() {
+        return this.storage.supportedOperations()
+    }
 }
 
 module.exports = SchemaService

--- a/packages/velo-external-db/lib/router.js
+++ b/packages/velo-external-db/lib/router.js
@@ -143,6 +143,15 @@ const createRouter = () => {
 
 
     // *************** Schema API **********************
+    router.post('/schemas/supported_operations', async(req, res, next) => {
+        try {
+            const data = await schemaService.supportedOperations()
+            res.json(data)
+        } catch (e) {
+            next(e)
+        }
+    })
+
     router.post('/schemas/list', async(req, res, next) => {
         try {
             const data = await schemaService.list()

--- a/packages/velo-external-db/lib/router.js
+++ b/packages/velo-external-db/lib/router.js
@@ -143,7 +143,7 @@ const createRouter = () => {
 
 
     // *************** Schema API **********************
-    router.post('/schemas/supported_operations', async(req, res, next) => {
+    router.get('/schemas/supported_operations', async(req, res, next) => {
         try {
             const data = await schemaService.supportedOperations()
             res.json(data)


### PR DESCRIPTION
# Reason for This PR

This PR adds a new GET endpoint `/schemas/supported_operations`, this endpoint returns the supported operation for the schema service. 