### PR TITLE
new property to schema list response

### DIFF
--- a/packages/test-commons/lib/gen.js
+++ b/packages/test-commons/lib/gen.js
@@ -1,4 +1,5 @@
 const Chance = require('chance')
+const { AllSchemaOperations } = require('velo-external-db-commons')
 const { AdapterOperators } = require('../../velo-external-db-core/node_modules/velo-external-db-commons/lib')
 const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_contains } = AdapterOperators //TODO: extract
 
@@ -44,6 +45,11 @@ const randomArrayOf = (gen) => {
         arr.push(gen())
     }
     return arr
+}
+
+const randomElementsFromArray = (arr) => {
+    const quantity = chance.natural({ min: 1, max: arr.length })
+    return chance.pickset(arr, quantity)
 }
 
 const randomCollectionName = () => chance.word({ length: 5 })
@@ -194,9 +200,14 @@ const randomConfig = () => ({
     db: chance.word(),
 })
 
+const randomSchemaOperation = () => (chance.pickone(AllSchemaOperations))
+
+const randomSchemaOperations = () => randomElementsFromArray(AllSchemaOperations)
+
 module.exports = { randomEntities, randomEntity, randomFilter, idFilter, veloDate, randomObject, randomDbs,
                    randomDbEntity, randomDbEntities, randomColumn, randomCollectionName, randomNumberDbEntity, randomObjectFromArray,
                    randomCollections, randomNumberColumns, randomKeyObject, deleteRandomKeyObject, clearRandomKeyObject, randomConfig,
-                   fieldsArrayToFieldObj, randomFieldName, randomOperator, randomAdapterOperator, randomWrappedFilter }
+                   fieldsArrayToFieldObj, randomFieldName, randomOperator, randomAdapterOperator, randomWrappedFilter,
+                   randomSchemaOperation, randomSchemaOperations }
 
 

--- a/packages/velo-external-db-commons/lib/schema_commons.js
+++ b/packages/velo-external-db-commons/lib/schema_commons.js
@@ -24,7 +24,7 @@ const queryOperatorsFor = {
     object: ['eq', 'ne', 'contains'],
 }
 
-const asWixSchema = db => {
+const asWixSchema = (db, allowedSchemaOperations) => {
     return {
         id: db.id,
         displayName: db.id,
@@ -36,6 +36,7 @@ const asWixSchema = db => {
             'insert',
             'remove'
         ],
+        allowedSchemaOperations,
         maxPageSize: 50,
         ttl: 3600,
         fields: db.fields.reduce( (o, r) => ( { ...o, [r.field]: {
@@ -79,12 +80,12 @@ const parseTableData = data => data.reduce((o, r) => {
 
 const SchemaOperations = Object.freeze({
     LIST: 'list',
-    LIST_HEADERS: 'list-headers',
-    CREATE: 'create-table',
-    DROP: 'drop-table', 
-    ADD_COLUMN: 'add-column',
-    REMOVE_COLUMN: 'remove-column',
-    DESCRIBE_COLLECTION: 'describe-collection',
+    LIST_HEADERS: 'listHeaders',
+    CREATE: 'createCollection',
+    DROP: 'dropCollection', 
+    ADD_COLUMN: 'addColumn',
+    REMOVE_COLUMN: 'removeColumn',
+    DESCRIBE_COLLECTION: 'describeCollection',
 })
 
 const supportedSchemaOperationsFor = (impl) => {

--- a/packages/velo-external-db-commons/lib/schema_commons.js
+++ b/packages/velo-external-db-commons/lib/schema_commons.js
@@ -88,6 +88,8 @@ const SchemaOperations = Object.freeze({
     DESCRIBE_COLLECTION: 'describeCollection',
 })
 
+const AllSchemaOperations = Object.values(SchemaOperations)
+
 const supportedSchemaOperationsFor = (impl) => {
     const { LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, REMOVE_COLUMN, DESCRIBE_COLLECTION } = SchemaOperations
 
@@ -112,4 +114,4 @@ const supportedSchemaOperationsFor = (impl) => {
 }
 
 module.exports = { SystemFields, asWixSchema, validateSystemFields, parseTableData,
-                        asWixSchemaHeaders, SchemaOperations, supportedSchemaOperationsFor }
+                        asWixSchemaHeaders, SchemaOperations, AllSchemaOperations, supportedSchemaOperationsFor }

--- a/packages/velo-external-db-core/lib/service/schema.js
+++ b/packages/velo-external-db-core/lib/service/schema.js
@@ -8,7 +8,8 @@ class SchemaService {
 
     async list() {
         const dbs = await this.storage.list()
-        return { schemas: dbs.map( asWixSchema ) }
+        const schemaSupportedOperations = await this.storage.supportedOperations()
+        return { schemas: dbs.map( d => asWixSchema(d, schemaSupportedOperations) ) }
     }
 
     async listHeaders() {

--- a/packages/velo-external-db-core/lib/service/schema.js
+++ b/packages/velo-external-db-core/lib/service/schema.js
@@ -9,7 +9,7 @@ class SchemaService {
     async list() {
         const dbs = await this.storage.list()
         const schemaSupportedOperations = await this.storage.supportedOperations()
-        return { schemas: dbs.map( d => asWixSchema(d, schemaSupportedOperations) ) }
+        return { schemas: dbs.map( db => asWixSchema(db, schemaSupportedOperations) ) }
     }
 
     async listHeaders() {
@@ -19,7 +19,8 @@ class SchemaService {
 
     async find(collectionNames) {
         const dbs = await Promise.all(collectionNames.map(async collectionName => ({ id: collectionName, fields: await this.storage.describeCollection(collectionName) })))
-        return { schemas: dbs.map( asWixSchema ) }
+        const schemaSupportedOperations = await this.storage.supportedOperations()
+        return { schemas: dbs.map( db => asWixSchema(db, schemaSupportedOperations) ) }
     }
 
     async create(collectionName) {

--- a/packages/velo-external-db-core/lib/service/schema.spec.js
+++ b/packages/velo-external-db-core/lib/service/schema.spec.js
@@ -8,9 +8,10 @@ describe('Schema Service', () => {
 
     test('retrieve all collections from provider', async() => {
         driver.givenListResult(ctx.dbs)
+        driver.givenSupportedOperations(ctx.schemaOperations)
 
         const actual = await env.schemaService.list()
-        expect( actual ).toEqual({ schemas: ctx.dbs.map( asWixSchema ) })
+        expect( actual ).toEqual({ schemas: ctx.dbs.map( db => asWixSchema(db, ctx.schemaOperations) ) })
     })
 
     test('retrieve short list of all collections from provider', async() => {
@@ -22,9 +23,10 @@ describe('Schema Service', () => {
 
     test('retrieve collections by ids from provider', async() => {
         driver.givenFindResults(ctx.dbs)
+        driver.givenSupportedOperations(ctx.schemaOperations)
 
         const actual = await env.schemaService.find(ctx.dbs.map(db => db.id))
-        expect( actual ).toEqual({ schemas: ctx.dbs.map( asWixSchema ) })
+        expect( actual ).toEqual({ schemas: ctx.dbs.map( db => asWixSchema(db, ctx.schemaOperations) ) })
     })
 
     test('create collection name', async() => {
@@ -53,6 +55,7 @@ describe('Schema Service', () => {
         collections: Uninitialized,
         collectionName: Uninitialized,
         column: Uninitialized,
+        schemaOperations: Uninitialized,
     }
 
     const env = {
@@ -67,6 +70,7 @@ describe('Schema Service', () => {
         ctx.collections = gen.randomCollections()
         ctx.collectionName = gen.randomCollectionName()
         ctx.column = gen.randomColumn()
+        ctx.schemaOperations = gen.randomSchemaOperations()
 
         env.schemaService = new SchemaService(driver.schemaProvider, schema.schemaInformation)
     })

--- a/packages/velo-external-db-core/test/drivers/schema_provider_test_support.js
+++ b/packages/velo-external-db-core/test/drivers/schema_provider_test_support.js
@@ -7,6 +7,7 @@ const schemaProvider = {
     create: jest.fn(),
     addColumn: jest.fn(),
     removeColumn: jest.fn(),
+    supportedOperations: jest.fn()
 }
 
 const givenListResult = (dbs) =>
@@ -14,6 +15,9 @@ const givenListResult = (dbs) =>
 
 const givenListHeadersResult = (collections) =>
     when(schemaProvider.listHeaders).mockResolvedValue(collections)
+
+const givenSupportedOperations = (operations) =>
+    when(schemaProvider.supportedOperations).mockResolvedValue(operations)
 
 const givenFindResults = (dbs) =>
     dbs.forEach(db => when(schemaProvider.describeCollection).calledWith(db.id).mockResolvedValue(db.fields) )
@@ -37,9 +41,10 @@ const reset = () => {
     schemaProvider.create.mockClear()
     schemaProvider.addColumn.mockClear()
     schemaProvider.removeColumn.mockClear()
+    schemaProvider.supportedOperations.mockClear()
 }
 
 
 module.exports = { givenFindResults, expectRemoveColumnOf, givenListResult, givenListHeadersResult,
-                   expectCreateOf, expectCreateColumnOf,
+                   expectCreateOf, expectCreateColumnOf, givenSupportedOperations,
                    schemaProvider, reset }


### PR DESCRIPTION
# Reason for This PR

This PR adds a new property to the schema/list response called `allowedSchemaOperations`, the value of this property is a list with schema operations that can be done in this db.