### PR TITLE
moved supported operations logic to each schema provider

### DIFF
--- a/packages/external-db-airtable/lib/airtable_schema_provider.js
+++ b/packages/external-db-airtable/lib/airtable_schema_provider.js
@@ -1,5 +1,5 @@
 const SchemaColumnTranslator = require('./sql_schema_translator')
-const { SystemFields, validateSystemFields, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, AllSchemaOperations } = require('velo-external-db-commons')
 const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist } = require('velo-external-db-commons').errors
 
 const axios = require('axios')
@@ -34,7 +34,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('airtable')
+        return AllSchemaOperations
     }
 
 

--- a/packages/external-db-bigquery/lib/bigquery_schema_provider.js
+++ b/packages/external-db-bigquery/lib/bigquery_schema_provider.js
@@ -1,4 +1,4 @@
-const { SystemFields, validateSystemFields, parseTableData, supportedSchemaOperationsFor, errors } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, parseTableData, AllSchemaOperations, errors } = require('velo-external-db-commons')
 const { translateErrorCodes, createCollectionTranslateErrorCodes, addColumnTranslateErrorCodes } = require('./sql_exception_translator')
 const { escapeIdentifier } = require('./bigquery_utils')
 const SchemaColumnTranslator = require('./sql_schema_translator')
@@ -26,7 +26,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('bigquery')
+        return AllSchemaOperations
     }
 
     async create(collectionName, _columns) {

--- a/packages/external-db-dynamodb/lib/dynamo_schema_provider.js
+++ b/packages/external-db-dynamodb/lib/dynamo_schema_provider.js
@@ -1,6 +1,6 @@
 const { SystemTable, validateTable, reformatFields } = require('./dynamo_utils')
 const { translateErrorCodes } = require('./sql_exception_translator')
-const { SystemFields, validateSystemFields, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, AllSchemaOperations } = require('velo-external-db-commons')
 const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist } = require('velo-external-db-commons').errors
 const { DynamoDBDocument }  = require ('@aws-sdk/lib-dynamodb')
 const dynamoRequests = require ('./dynamo_schema_requests_utils')
@@ -31,7 +31,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('dynamodb')
+        return AllSchemaOperations
     }
 
     async create(collectionName, columns) {

--- a/packages/external-db-firestore/lib/firestore_schema_provider.js
+++ b/packages/external-db-firestore/lib/firestore_schema_provider.js
@@ -1,4 +1,4 @@
-const { SystemFields, validateSystemFields, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, AllSchemaOperations } = require('velo-external-db-commons')
 const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist } = require('velo-external-db-commons').errors
 
 const SystemTable = '_descriptor'
@@ -30,7 +30,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('firestore')
+        return AllSchemaOperations
     }
 
     async create(collectionName, columns) {

--- a/packages/external-db-google-sheets/lib/google_sheet_schema_provider.js
+++ b/packages/external-db-google-sheets/lib/google_sheet_schema_provider.js
@@ -1,4 +1,4 @@
-const { SystemFields, validateSystemFields, parseTableData, errors, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, parseTableData, errors, SchemaOperations } = require('velo-external-db-commons')
 const { translateErrorCodes } = require('./google_sheet_exception_translator')
 const { describeSheetHeaders, headersFrom, sheetFor } = require('./google_sheet_utils')
 class SchemaProvider {
@@ -30,7 +30,8 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('google-sheet')
+        const { LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, DESCRIBE_COLLECTION } = SchemaOperations
+        return [LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, DESCRIBE_COLLECTION]
     }
 
     async create(collectionName) {

--- a/packages/external-db-mongo/lib/mongo_schema_provider.js
+++ b/packages/external-db-mongo/lib/mongo_schema_provider.js
@@ -1,4 +1,4 @@
-const { SystemFields, validateSystemFields, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, AllSchemaOperations } = require('velo-external-db-commons')
 const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist } = require('velo-external-db-commons').errors
 const { validateTable, SystemTable } = require ('./mongo_utils')
 
@@ -41,7 +41,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('mongo')
+        return AllSchemaOperations
     }
 
     async create(collectionName, columns) {

--- a/packages/external-db-mssql/lib/mssql_schema_provider.js
+++ b/packages/external-db-mssql/lib/mssql_schema_provider.js
@@ -1,7 +1,7 @@
 const { translateErrorCodes, notThrowingTranslateErrorCodes } = require('./sql_exception_translator')
 const SchemaColumnTranslator = require('./sql_schema_translator')
 const { escapeId, escapeTable } = require('./mssql_utils')
-const { SystemFields, validateSystemFields, parseTableData, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, parseTableData, AllSchemaOperations } = require('velo-external-db-commons')
 const { CollectionDoesNotExists, CollectionAlreadyExists } = require('velo-external-db-commons').errors
 class SchemaProvider {
     constructor(pool) {
@@ -32,7 +32,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('mssql')
+        return AllSchemaOperations
     }
 
     async create(collectionName, columns) {

--- a/packages/external-db-mysql/lib/mysql_schema_provider.js
+++ b/packages/external-db-mysql/lib/mysql_schema_provider.js
@@ -2,7 +2,7 @@ const { promisify } = require('util')
 const { translateErrorCodes } = require('./sql_exception_translator')
 const SchemaColumnTranslator = require('./sql_schema_translator')
 const { escapeId, escapeTable } = require('./mysql_utils')
-const { SystemFields, validateSystemFields, parseTableData, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, parseTableData, AllSchemaOperations } = require('velo-external-db-commons')
 
 class SchemaProvider {
     constructor(pool) {
@@ -31,7 +31,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('mysql')
+        return AllSchemaOperations
     }
 
     async create(collectionName, columns) {

--- a/packages/external-db-postgres/lib/postgres_schema_provider.js
+++ b/packages/external-db-postgres/lib/postgres_schema_provider.js
@@ -2,7 +2,7 @@ const { translateErrorCodes } = require('./sql_exception_translator')
 const SchemaColumnTranslator = require('./sql_schema_translator')
 const { escapeIdentifier } = require('./postgres_utils')
 const { CollectionDoesNotExists } = require('velo-external-db-commons').errors
-const { SystemFields, validateSystemFields, parseTableData, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, parseTableData, AllSchemaOperations } = require('velo-external-db-commons')
 
 class SchemaProvider {
     constructor(pool) {
@@ -28,7 +28,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('postgres')
+        return AllSchemaOperations
     }
 
     async create(collectionName, _columns) {

--- a/packages/external-db-spanner/lib/spanner_schema_provider.js
+++ b/packages/external-db-spanner/lib/spanner_schema_provider.js
@@ -1,4 +1,4 @@
-const { SystemFields, validateSystemFields, parseTableData, supportedSchemaOperationsFor } = require('velo-external-db-commons')
+const { SystemFields, validateSystemFields, parseTableData, AllSchemaOperations } = require('velo-external-db-commons')
 const { CollectionDoesNotExists, CollectionAlreadyExists } = require('velo-external-db-commons').errors
 const SchemaColumnTranslator = require('./sql_schema_translator')
 const { notThrowingTranslateErrorCodes } = require('./sql_exception_translator')
@@ -46,7 +46,7 @@ class SchemaProvider {
     }
 
     supportedOperations() {
-        return supportedSchemaOperationsFor('spanner')
+        return AllSchemaOperations
     }
 
     async create(collectionName, columns) {

--- a/packages/velo-external-db-commons/lib/schema_commons.js
+++ b/packages/velo-external-db-commons/lib/schema_commons.js
@@ -78,33 +78,10 @@ const parseTableData = data => data.reduce((o, r) => {
                                                     return o
                                                 }, {})
 
-const supportedSchemaOperationsFor = (impl) => {
-    const { LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, REMOVE_COLUMN, DESCRIBE_COLLECTION } = SchemaOperations
-
-    switch (impl.toLowerCase()) {
-        case 'airtable':
-        case 'bigquery':
-        case 'dynamodb':
-        case 'firestore':
-        case 'mongo':
-        case 'mssql':
-        case 'mysql':
-        case 'postgres':
-        case 'spanner':
-            return [LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, REMOVE_COLUMN, DESCRIBE_COLLECTION]
-        
-        case 'google-sheet':
-            return [LIST, LIST_HEADERS, CREATE, DROP, ADD_COLUMN, DESCRIBE_COLLECTION]
-    
-        default:
-            throw new Error('Unknown implementation')
-    }
-}
-
 const allowedOperationsFor = ({ fields }) => fields.find(c => c.field === '_id') ? ReadWriteOperations : ReadOnlyOperations 
 
 const appendQueryOperatorsTo = (fields) => fields.map(f => ({ ...f, queryOperators: QueryOperatorsByFieldType[f.type] }))
 
 module.exports = { SystemFields, asWixSchema, validateSystemFields, parseTableData,
-                    asWixSchemaHeaders, SchemaOperations, AllSchemaOperations, supportedSchemaOperationsFor, 
+                    asWixSchemaHeaders, SchemaOperations, AllSchemaOperations,  
                     allowedOperationsFor, appendQueryOperatorsTo }


### PR DESCRIPTION
# Reason for This PR

we agreed that `supportedSchemaOperationsFor` function should not be in `schema_commons.js`,
so I moved back the logic of supported function to each schema provider, for that I created a new constant `AllSchemaOperations` that contains all schema operations 