### PR TITLE
Validate dbtype and cloud vendor

### DIFF
--- a/packages/external-db-config/lib/readers/common_config_reader.js
+++ b/packages/external-db-config/lib/readers/common_config_reader.js
@@ -1,4 +1,4 @@
-const { checkRequiredKeys } = require('../utils/config_utils')
+const { checkRequiredKeys, supportedDBs, supportedVendors } = require('../utils/config_utils')
 
 class CommonConfigReader {
     constructor() { }
@@ -9,7 +9,11 @@ class CommonConfigReader {
     }
 
     validate() {
+        const validType = supportedDBs.includes(process.env.TYPE)
+        const validVendor = supportedVendors.includes(process.env.CLOUD_VENDOR)
         return {
+            validType,
+            validVendor,
             missingRequiredSecretsKeys: checkRequiredKeys(process.env, ['CLOUD_VENDOR', 'TYPE'])
         }
     }

--- a/packages/external-db-config/lib/service/config_reader.js
+++ b/packages/external-db-config/lib/service/config_reader.js
@@ -10,11 +10,21 @@ class ConfigReader {
 
   async configStatus() {
     const { missingRequiredSecretsKeys } = await this.externalConfigReader.validate()
-    const { missingRequiredSecretsKeys: missing } = this.commonConfigReader.validate()
+    const { missingRequiredSecretsKeys: missing, validType, validVendor } = this.commonConfigReader.validate()
 
     if (missingRequiredSecretsKeys.length > 0 || (missing && missing.length > 0)) {
       return `Missing props: ${[...missingRequiredSecretsKeys, missing].join(', ')}`
     }
+    
+    else if (!validVendor) {
+      return 'Cloud type is not supported'
+    }
+
+    else if(!validType) {
+      return 'DB type is not supported'
+    }
+
+
     return 'External DB Config read successfully'
   }
 }

--- a/packages/external-db-config/lib/service/config_reader.spec.js
+++ b/packages/external-db-config/lib/service/config_reader.spec.js
@@ -53,6 +53,24 @@ describe('Config Reader Client', () => {
            .forEach(s => expect( actual ).toContain(s) )
     })
 
+    test('status call with wrong cloud vendor', async() => {
+        driver.givenValidConfig()
+        driver.givenInvalidCloudVendor()
+
+        const actual = await env.configReader.configStatus()
+
+        expect( actual ).toEqual('Cloud type not supported')
+    })
+
+    test('status call with wrong db type', async() => {
+        driver.givenValidConfig()
+        driver.givenInvalidDBType()
+
+        const actual = await env.configReader.configStatus()
+
+        expect( actual ).toEqual('DB type not supported')
+    })
+
 
     const ctx = {
         config: Uninitialized,

--- a/packages/external-db-config/lib/service/config_reader.spec.js
+++ b/packages/external-db-config/lib/service/config_reader.spec.js
@@ -59,7 +59,7 @@ describe('Config Reader Client', () => {
 
         const actual = await env.configReader.configStatus()
 
-        expect( actual ).toEqual('Cloud type not supported')
+        expect( actual ).toEqual('Cloud type is not supported')
     })
 
     test('status call with wrong db type', async() => {
@@ -68,7 +68,7 @@ describe('Config Reader Client', () => {
 
         const actual = await env.configReader.configStatus()
 
-        expect( actual ).toEqual('DB type not supported')
+        expect( actual ).toEqual('DB type is not supported')
     })
 
 

--- a/packages/external-db-config/lib/utils/config_utils.js
+++ b/packages/external-db-config/lib/utils/config_utils.js
@@ -2,4 +2,8 @@ const objectContainsKey = (obj, key) => typeof obj[key] === 'string' && obj[key]
 
 const checkRequiredKeys = (obj, requiredKeys) => requiredKeys.filter(key => !objectContainsKey(obj, key) )
 
-module.exports = { checkRequiredKeys }
+const supportedDBs = ['postgres', 'spanner', 'firestore', 'mssql', 'mysql', 'mongo', 'airtable', 'dynamodb', 'bigquery']
+
+const supportedVendors = ['gcp', 'aws', 'azure']
+
+module.exports = { checkRequiredKeys, supportedDBs, supportedVendors }

--- a/packages/external-db-config/test/drivers/external_db_config_test_support.js
+++ b/packages/external-db-config/test/drivers/external_db_config_test_support.js
@@ -15,11 +15,12 @@ const givenConfig = (config) =>
 
 const givenValidConfig = () =>
     when(configReader.validate).calledWith()
-                               .mockResolvedValue({ missingRequiredSecretsKeys: [] })
+                               .mockResolvedValue({ missingRequiredSecretsKeys: [], validType: true, validVendor: true })
 
 const givenValidCommonConfig = () =>
     when(commonConfigReader.validate).calledWith()
-                                     .mockReturnValueOnce({ missingRequiredSecretsKeys: [] })
+                                     .mockReturnValueOnce({ missingRequiredSecretsKeys: [], validType: true, validVendor: true })
+
 
 const givenInvalidConfigWith = (missing) =>
     when(configReader.validate).calledWith()
@@ -29,6 +30,13 @@ const givenInvalidCommonConfigWith = (missing) =>
     when(commonConfigReader.validate).calledWith()
                                      .mockReturnValueOnce({ missingRequiredSecretsKeys: missing })
 
+const givenInvalidCloudVendor = () =>
+    when(commonConfigReader.validate).calledWith()
+                                     .mockReturnValueOnce({ missingRequiredSecretsKeys: [], validType: true, validVendor: false })
+
+const givenInvalidDBType = () =>
+    when(commonConfigReader.validate).calledWith()
+                                     .mockReturnValueOnce({ missingRequiredSecretsKeys: [], validType: false, validVendor: true })
 
 const reset = () => {
     configReader.readConfig.mockClear()
@@ -39,5 +47,6 @@ const reset = () => {
 
 module.exports = { configReader, commonConfigReader, reset,
                    givenValidCommonConfig,
-                   givenConfig, givenValidConfig, givenInvalidConfigWith, givenInvalidCommonConfigWith
+                   givenConfig, givenValidConfig, givenInvalidConfigWith, givenInvalidCommonConfigWith,
+                   givenInvalidCloudVendor, givenInvalidDBType
 }

--- a/packages/external-db-config/test/provider/config_reader_service.spec.js
+++ b/packages/external-db-config/test/provider/config_reader_service.spec.js
@@ -65,7 +65,7 @@ describe('External DB config client', () => {
 
       const expected = await env.configReaderProvider.validate()
 
-      expect(expected).toEqual({ missingRequiredSecretsKeys: [s] })
+      expect(expected).toMatchObject({ missingRequiredSecretsKeys: [s] })
     })
 
     test('validate will detect config read errors', async() => {

--- a/packages/velo-external-db-commons/lib/errors.js
+++ b/packages/velo-external-db-commons/lib/errors.js
@@ -70,5 +70,11 @@ class UnsupportedOperation extends BaseHttpError {
     }
 }
 
+class UnsupportedDatabase extends BaseHttpError {
+    constructor(message) {
+        super(message, 405)
+    }
+}
+
 module.exports = { UnauthorizedError, CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist, CannotModifySystemField, InvalidQuery,
-                   CollectionAlreadyExists, DbConnectionError, InvalidRequest, ItemNotFound, UnsupportedOperation }
+                   CollectionAlreadyExists, DbConnectionError, InvalidRequest, ItemNotFound, UnsupportedOperation, UnsupportedDatabase }

--- a/packages/velo-external-db/lib/storage/factory.js
+++ b/packages/velo-external-db/lib/storage/factory.js
@@ -52,6 +52,10 @@ const init = async(type, vendor, config) => {
             const { init } = require('external-db-bigquery')
             return append(await init(cfg), cfg.secretKey)
         }
+        default: {
+            const init = require('./stub-db/init')
+            return append(await init(type), cfg.secretKey)
+        }
     }
 }
 

--- a/packages/velo-external-db/lib/storage/factory.js
+++ b/packages/velo-external-db/lib/storage/factory.js
@@ -2,62 +2,54 @@ const append = (res, secretKey) => ( { ...res, secretKey: secretKey } )
 
 const init = async(type, vendor, config) => {
     console.log(`INIT: ${vendor + '/' + type}`)
+    const cfg = await config.readConfig()
     switch ( type.toLowerCase() ) {
         case 'postgres': {
             const { init } = require('external-db-postgres')
-            const cfg = await config.readConfig()
 
             return append(init(cfg), cfg.secretKey)
         }
         case 'spanner': {
             const { init } = require('external-db-spanner')
 
-            const cfg = await config.readConfig()
             return append(init(cfg), cfg.secretKey)
         }
         case 'firestore': {
             const { init } = require('external-db-firestore')
 
-            const { projectId, secretKey } = await config.readConfig()
+            const { projectId, secretKey } = cfg
             return append(init([projectId]), secretKey)
         }
         case 'mssql': {
             const { init } = require('external-db-mssql')
 
-            const cfg = await config.readConfig()
             const res = await init(cfg)
             return append(res, cfg.secretKey)
         }
         case 'mysql': {
             const { init } = require('external-db-mysql')
-            const cfg = await config.readConfig()
 
             return append(init(cfg), cfg.secretKey)
         }
         case 'mongo': {
             const { init } = require('external-db-mongo')
-            const cfg = await config.readConfig()
 
             return append(await init(cfg), cfg.secretKey)
         }
         case 'google-sheet': {
             const { init } = require('external-db-google-sheets')
-            const cfg = await config.readConfig()
             return append(await init(cfg), cfg.secretKey)
         }
         case 'airtable': {
             const { init } = require('external-db-airtable')
-            const cfg = await config.readConfig()
             return append(await init(cfg), cfg.secretKey)
         }
         case 'dynamodb': {
             const { init } = require('external-db-dynamodb')
-            const cfg = await config.readConfig()
             return append(await init(cfg), cfg.secretKey)
         }
         case 'bigquery': {
             const { init } = require('external-db-bigquery')
-            const cfg = await config.readConfig()
             return append(await init(cfg), cfg.secretKey)
         }
     }

--- a/packages/velo-external-db/lib/storage/stub-db/init.js
+++ b/packages/velo-external-db/lib/storage/stub-db/init.js
@@ -1,0 +1,7 @@
+const { StubDataProvider, StubDatabaseOperations, StubSchemaProvider } = require ('./providers')
+
+const init = (type) => (
+    { dataProvider: new StubDataProvider(), schemaProvider: new StubSchemaProvider(), databaseOperations: new StubDatabaseOperations(type), connection: {}, cleanup: {} }
+)
+
+module.exports = init

--- a/packages/velo-external-db/lib/storage/stub-db/providers.js
+++ b/packages/velo-external-db/lib/storage/stub-db/providers.js
@@ -1,0 +1,24 @@
+const { UnsupportedDatabase } = require('velo-external-db-commons').errors
+
+class StubDataProvider {}
+
+class StubDatabaseOperations {
+    constructor(type) {
+        this.type = type
+    }
+
+    validateConnection() {
+        return { valid: false, error: new UnsupportedDatabase(`Unknown db type: ${this.type}`) }
+    }
+}
+
+class StubSchemaProvider {
+    constructor() {
+    }
+
+    list() {
+        return {}
+    }
+}
+
+module.exports = { StubDataProvider, StubDatabaseOperations, StubSchemaProvider }


### PR DESCRIPTION
when filling wrong cloud vendor the message was "External DB config read successfully" 
when filling wrong dbType the adapter was collapsing.
(you can see in the linked issue)

I added in the `CommonConfigReader.validate` another validation - validType, validVendor. 

And I made stub-db with the required classes like every other implementation to allow the adapter to load successfully. 
I'm not sure where it belongs, for now it's in `packages/velo-external-db/lib/storage/stub-db` but i know it's not the right place for it.
do you have an idea where it should be? maybe i should expend it and make it a package like any other implementation? 


![image](https://user-images.githubusercontent.com/82806105/149892088-08aba963-1e6f-4b84-839d-3cb5c9c62632.png)



fix #119 
