### PR TITLE
fix content manager scroll issue

### DIFF
--- a/packages/velo-external-db-core/lib/service/data.js
+++ b/packages/velo-external-db-core/lib/service/data.js
@@ -18,10 +18,11 @@ class DataService {
         this.queryValidator.validateFilter(fields, filter)
         
         const items = await this.storage.find(collectionName, filter, sort, skip, limit)
-        
+        const totalCount = await this.storage.count(collectionName)
+
         return {
             items: items.map( asWixData ),
-            totalCount: items.length
+            totalCount
         }
     }
 

--- a/packages/velo-external-db-core/lib/service/data.js
+++ b/packages/velo-external-db-core/lib/service/data.js
@@ -18,7 +18,7 @@ class DataService {
         this.queryValidator.validateFilter(fields, filter)
         
         const items = await this.storage.find(collectionName, filter, sort, skip, limit)
-        const totalCount = await this.storage.count(collectionName)
+        const totalCount = await this.storage.count(collectionName, filter)
 
         return {
             items: items.map( asWixData ),

--- a/packages/velo-external-db-core/lib/service/data.spec.js
+++ b/packages/velo-external-db-core/lib/service/data.spec.js
@@ -20,10 +20,11 @@ describe('Data Service', () => {
         queryValidator.givenValidFilterResponseFor(fields, ctx.transformedFilter)
         
         driver.givenListResult(ctx.entities, ctx.collectionName, ctx.transformedFilter, ctx.sort, ctx.skip, ctx.limit)
-        
+        driver.givenTotalCountResult(ctx.total, ctx.collectionName)
+
         return expect(env.dataService.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit)).resolves.toEqual({
                                                                                                                         items: ctx.entities,
-                                                                                                                        totalCount: ctx.entities.length 
+                                                                                                                        totalCount: ctx.total
                                                                                                                     })
     })
 

--- a/packages/velo-external-db-core/lib/service/data.spec.js
+++ b/packages/velo-external-db-core/lib/service/data.spec.js
@@ -20,7 +20,7 @@ describe('Data Service', () => {
         queryValidator.givenValidFilterResponseFor(fields, ctx.transformedFilter)
         
         driver.givenListResult(ctx.entities, ctx.collectionName, ctx.transformedFilter, ctx.sort, ctx.skip, ctx.limit)
-        driver.givenTotalCountResult(ctx.total, ctx.collectionName)
+        driver.givenCountResult(ctx.total, ctx.collectionName, ctx.transformedFilter)
 
         return expect(env.dataService.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit)).resolves.toEqual({
                                                                                                                         items: ctx.entities,

--- a/packages/velo-external-db-core/test/drivers/data_provider_test_support.js
+++ b/packages/velo-external-db-core/test/drivers/data_provider_test_support.js
@@ -19,6 +19,10 @@ const givenCountResult = (total, forCollectionName, filter) =>
     when(dataProvider.count).calledWith(forCollectionName, filter)
                             .mockResolvedValue(total)
 
+const givenTotalCountResult = (total, forCollectionName) =>
+when(dataProvider.count).calledWith(forCollectionName)
+                        .mockResolvedValue(total)
+                        
 const givenAggregateResult = (total, forCollectionName, filter, andAggregation) =>
     when(dataProvider.aggregate).calledWith(forCollectionName, filter, andAggregation)
                                 .mockResolvedValue(total)
@@ -53,4 +57,4 @@ const reset = () => {
     dataProvider.delete.mockClear()
 }
 
-module.exports = { givenListResult, dataProvider, expectInsertFor, expectUpdateFor, givenCountResult, expectTruncateFor, givenAggregateResult, expectDeleteFor, expectInsertMatchedFor, reset }
+module.exports = { givenListResult, dataProvider, expectInsertFor, expectUpdateFor, givenCountResult, expectTruncateFor, givenAggregateResult, expectDeleteFor, expectInsertMatchedFor, givenTotalCountResult, reset }

--- a/packages/velo-external-db-core/test/drivers/data_provider_test_support.js
+++ b/packages/velo-external-db-core/test/drivers/data_provider_test_support.js
@@ -19,10 +19,6 @@ const givenCountResult = (total, forCollectionName, filter) =>
     when(dataProvider.count).calledWith(forCollectionName, filter)
                             .mockResolvedValue(total)
 
-const givenTotalCountResult = (total, forCollectionName) =>
-when(dataProvider.count).calledWith(forCollectionName)
-                        .mockResolvedValue(total)
-                        
 const givenAggregateResult = (total, forCollectionName, filter, andAggregation) =>
     when(dataProvider.aggregate).calledWith(forCollectionName, filter, andAggregation)
                                 .mockResolvedValue(total)
@@ -57,4 +53,4 @@ const reset = () => {
     dataProvider.delete.mockClear()
 }
 
-module.exports = { givenListResult, dataProvider, expectInsertFor, expectUpdateFor, givenCountResult, expectTruncateFor, givenAggregateResult, expectDeleteFor, expectInsertMatchedFor, givenTotalCountResult, reset }
+module.exports = { givenListResult, dataProvider, expectInsertFor, expectUpdateFor, givenCountResult, expectTruncateFor, givenAggregateResult, expectDeleteFor, expectInsertMatchedFor, reset }


### PR DESCRIPTION
fix #148 
content manager expects the real total count in `data/find` response to know if scrolling is needed.
returning total count instead returned entities count
