### PR TITLE
authentication tests

### DIFF
--- a/packages/external-db-authorization/lib/strategies/local_strategy.js
+++ b/packages/external-db-authorization/lib/strategies/local_strategy.js
@@ -1,10 +1,19 @@
-const localStrategy = require('passport-local')
-
+const OAuth2Strategy = require('passport-oauth2')
 class LocalStrategy {
-  constructor() {
-    return new localStrategy(this.verify) 
+  constructor({ clientDomain, clientId, clientSecret, callbackUrl, passReqToCallback }) {
+    this.options = {
+      authorizationURL: `${clientDomain}/authorize`,
+      tokenURL: `${clientDomain}/token`,
+      callbackURL: callbackUrl,
+      clientID: clientId,
+      clientSecret,
+      passReqToCallback,
+      scope: [''],
+      state: [],
+  } 
+    return new OAuth2Strategy(this.options, this.verify)
   }
-
+  
   verify(AccessToken, tokenSecret, profile, done) {
         done(null, profile)
   }


### PR DESCRIPTION
So it's not possible to mock google authentication server response, but there is an [oauth2-mock-server](https://www.npmjs.com/package/oauth2-mock-server) package that creates a server that simulates general authentication server.  To use it in tests, we will use general ouath2 strategy (it called local in our app) with the oauth2-mock-server url, this mock server will generate accessToken and redicract us to the callback path that we will supply, in our cause it will be `http://localhost:8080/auth/callback`
