### PR TITLE
New validation function for gcp auth

### DIFF
--- a/packages/external-db-authorization/lib/auth-providers/gcp_auth_provider.js
+++ b/packages/external-db-authorization/lib/auth-providers/gcp_auth_provider.js
@@ -10,31 +10,31 @@ class GcpAuthProvider {
       scope: ['email', 'profile']
     }
 
-    return new GoogleStrategy(this.options, this.verify)
+    return new GoogleStrategy(this.options, this.verify.bind(this))
   }
 
   verify(accessToken, tokenSecret, profile, cb) {
-    const usersEmail = profile._json.email
+    const usersEmail = profile._json.email 
 
-    const getProjectOwners = async() => {
-      const authClient = new GoogleAuth({ scopes: 'https://www.googleapis.com/auth/cloud-platform' })
-      const client = await authClient.getClient()
-      const projectId = await authClient.getProjectId()
-      const getIamPolicyRestUrl = `https://cloudresourcemanager.googleapis.com/v1/projects/${projectId}:getIamPolicy`
-  
-      const res = await client.request({ method: 'POST', url: getIamPolicyRestUrl })
-      const { members: allOwners } = res.data.bindings.find(i => i.role === 'roles/owner')
-  
-      const projectOwnersUsers = allOwners.filter(i => i.startsWith('user:')).map(i => i.split(':')[1])
-
-      return projectOwnersUsers
-    }
-
-    getProjectOwners()
-            .then(projectOwners => projectOwners.includes(usersEmail) ? cb(null, profile) : cb('Unauthorized', null))
-            .catch(err => cb(`Error fetching project owners: ${err}`, null) )
+    this.getProjectOwners().then(projectOwners => projectOwners.includes(usersEmail) ? cb(null, profile) : cb('Unauthorized', null))
+                           .catch(err => cb(`Error fetching project owners: ${err}`, null) )
   
   }
+
+  async getProjectOwners() {
+    const authClient = new GoogleAuth({ scopes: 'https://www.googleapis.com/auth/cloud-platform' })
+    const client = await authClient.getClient()
+    const projectId = await authClient.getProjectId()
+    const getIamPolicyRestUrl = `https://cloudresourcemanager.googleapis.com/v1/projects/${projectId}:getIamPolicy`
+
+    const res = await client.request({ method: 'POST', url: getIamPolicyRestUrl })
+    const { members: allOwners } = res.data.bindings.find(i => i.role === 'roles/owner')
+
+    const projectOwnersUsers = allOwners.filter(i => i.startsWith('user:')).map(i => i.split(':')[1])
+
+    return projectOwnersUsers
+  }
+
 
 }
 

--- a/packages/external-db-authorization/lib/auth-providers/gcp_auth_provider.js
+++ b/packages/external-db-authorization/lib/auth-providers/gcp_auth_provider.js
@@ -1,3 +1,4 @@
+const { GoogleAuth } = require('google-auth-library')
 const GoogleStrategy = require('passport-google-oauth20').Strategy
 
 class GcpAuthProvider {
@@ -12,8 +13,27 @@ class GcpAuthProvider {
     return new GoogleStrategy(this.options, this.verify)
   }
 
-  verify(accessToken, tokenSecret, profile, done) {
-        done(null, profile)
+  verify(accessToken, tokenSecret, profile, cb) {
+    const usersEmail = profile._json.email
+
+    const getProjectOwners = async() => {
+      const authClient = new GoogleAuth({ scopes: 'https://www.googleapis.com/auth/cloud-platform' })
+      const client = await authClient.getClient()
+      const projectId = await authClient.getProjectId()
+      const getIamPolicyRestUrl = `https://cloudresourcemanager.googleapis.com/v1/projects/${projectId}:getIamPolicy`
+  
+      const res = await client.request({ method: 'POST', url: getIamPolicyRestUrl })
+      const { members: allOwners } = res.data.bindings.find(i => i.role === 'roles/owner')
+  
+      const projectOwnersUsers = allOwners.filter(i => i.startsWith('user:')).map(i => i.split(':')[1])
+
+      return projectOwnersUsers
+    }
+
+    getProjectOwners()
+            .then(projectOwners => projectOwners.includes(usersEmail) ? cb(null, profile) : cb(new Error('You are not authorized to use this application'), null))
+            .catch(err => cb(new Error('Not authorized', err), null) )
+  
   }
 
 }

--- a/packages/external-db-authorization/lib/auth-providers/gcp_auth_provider.js
+++ b/packages/external-db-authorization/lib/auth-providers/gcp_auth_provider.js
@@ -31,8 +31,8 @@ class GcpAuthProvider {
     }
 
     getProjectOwners()
-            .then(projectOwners => projectOwners.includes(usersEmail) ? cb(null, profile) : cb(new Error('You are not authorized to use this application'), null))
-            .catch(err => cb(new Error('Not authorized', err), null) )
+            .then(projectOwners => projectOwners.includes(usersEmail) ? cb(null, profile) : cb('Unauthorized', null))
+            .catch(err => cb(`Error fetching project owners: ${err}`, null) )
   
   }
 

--- a/packages/external-db-authorization/package.json
+++ b/packages/external-db-authorization/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.47.0",
     "passport-azure-ad-oauth2": "^0.0.4",
+    "google-auth-library": "^7.11.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
     "passport-oauth2": "^1.6.1",


### PR DESCRIPTION
This PR adds validation for GCP authentication mechanism, after the user redirects from Google back to the app, the function ensure that the user is part of the project owner, if so he will pass to the app info screen.
If not, the user will be thrown out and the identification process will not be completed

**breaking change -** new role (Security Reviewer) must be assigned to the cloud run service account, otherwise the authentication in GCP will not work
 