### PR TITLE
Collection level role config

### DIFF
--- a/packages/external-db-config/lib/factory.js
+++ b/packages/external-db-config/lib/factory.js
@@ -1,6 +1,7 @@
 const ConfigReader = require('./service/config_reader')
 const CommonConfigReader = require('./readers/common_config_reader')
 const StubConfigReader = require('./readers/stub_config_reader')
+const AuthorizationConfigReader = require ('./readers/authorization_config_reader')
 const aws = require('./readers/aws_config_reader')
 const gcp = require('./readers/gcp_config_reader')
 const azure = require('./readers/azure_config_reader')
@@ -86,7 +87,7 @@ const create = () => {
     break
   }
 
-  return new ConfigReader(internalConfigReader || new StubConfigReader, common)
+  return new ConfigReader(internalConfigReader || new StubConfigReader, common, new AuthorizationConfigReader())
 }
 
 module.exports = { create }

--- a/packages/external-db-config/lib/readers/authorization_config_reader.js
+++ b/packages/external-db-config/lib/readers/authorization_config_reader.js
@@ -1,0 +1,20 @@
+const { checkRequiredKeys, isJson, EMPTY_ROLE_CONFIG } = require('../utils/config_utils')
+
+class AuthorizationConfigReader {
+  constructor() {
+  }
+
+  async readConfig() {
+    const { ROLE_CONFIG } = process.env
+    const { collectionLevelConfig } = isJson(ROLE_CONFIG) ? JSON.parse(ROLE_CONFIG) : EMPTY_ROLE_CONFIG
+    return collectionLevelConfig
+  }
+
+  validate() {
+    return {
+      missingRequiredSecretsKeys: checkRequiredKeys(process.env, [])
+    }
+  }
+}
+
+module.exports = AuthorizationConfigReader 

--- a/packages/external-db-config/lib/service/config_reader.js
+++ b/packages/external-db-config/lib/service/config_reader.js
@@ -1,13 +1,14 @@
 class ConfigReader {
-  constructor(externalConfigReader, commonConfigReader) {
+  constructor(externalConfigReader, commonConfigReader, authorizationConfigReader) {
     this.externalConfigReader = externalConfigReader
     this.commonConfigReader = commonConfigReader
+    this.authorizationConfig = authorizationConfigReader
   }
 
   async readConfig() {
     const externalConfig = await this.externalConfigReader.readConfig()
-
-    return externalConfig
+    const authorizationConfig =await this.authorizationConfig.readConfig()
+    return { ...externalConfig, authorization: authorizationConfig }
   }
 
   async configStatus() {

--- a/packages/external-db-config/lib/service/config_reader.spec.js
+++ b/packages/external-db-config/lib/service/config_reader.spec.js
@@ -9,8 +9,9 @@ describe('Config Reader Client', () => {
 
     test('read config will retrieve config from secret provider and validate retrieved data', async() => {
         driver.givenConfig(ctx.config)
+        driver.givenAuthorizationConfig(ctx.authorizationConfig)
 
-        await expect( env.configReader.readConfig() ).resolves.toEqual(configResponseFor(ctx.config, ctx.config))
+        await expect( env.configReader.readConfig() ).resolves.toEqual(configResponseFor(ctx.config, ctx.authorizationConfig))
     })
 
     test('status call will return successful message in case config is valid', async() => {
@@ -71,10 +72,11 @@ describe('Config Reader Client', () => {
     beforeEach(() => {
         driver.reset()
         ctx.config = gen.randomConfig()
+        ctx.authorizationConfig = gen.randomConfig()
         ctx.configStatus = gen.randomConfig()
         ctx.missingProperties = Array.from({ length: 5 }, () => chance.word())
         ctx.moreMissingProperties = Array.from({ length: 5 }, () => chance.word())
 
-        env.configReader = new ConfigReader(driver.configReader, driver.commonConfigReader, driver.authConfigReader)
+        env.configReader = new ConfigReader(driver.configReader, driver.commonConfigReader, driver.authConfigReader, driver.authorizationConfigReader)
     })
 })

--- a/packages/external-db-config/lib/service/config_reader.spec.js
+++ b/packages/external-db-config/lib/service/config_reader.spec.js
@@ -77,6 +77,6 @@ describe('Config Reader Client', () => {
         ctx.missingProperties = Array.from({ length: 5 }, () => chance.word())
         ctx.moreMissingProperties = Array.from({ length: 5 }, () => chance.word())
 
-        env.configReader = new ConfigReader(driver.configReader, driver.commonConfigReader, driver.authConfigReader, driver.authorizationConfigReader)
+        env.configReader = new ConfigReader(driver.configReader, driver.commonConfigReader, driver.authorizationConfigReader)
     })
 })

--- a/packages/external-db-config/lib/service/config_reader_matchers.js
+++ b/packages/external-db-config/lib/service/config_reader_matchers.js
@@ -1,4 +1,7 @@
-const configResponseFor = ( config ) => expect.objectContaining(config)
+const configResponseFor = ( config, authorizationConfig ) => expect.objectContaining({
+    ...config,
+    authorization: authorizationConfig
+})
 
 const validConfigStatusResponse = () => expect.objectContaining({ 
     validConfig: true,

--- a/packages/external-db-config/lib/utils/config_utils.js
+++ b/packages/external-db-config/lib/utils/config_utils.js
@@ -1,9 +1,15 @@
 const objectContainsKey = (obj, key) => typeof obj[key] === 'string' && obj[key].length > 0
 
-const checkRequiredKeys = (obj, requiredKeys) => requiredKeys.filter(key => !objectContainsKey(obj, key) )
+const checkRequiredKeys = (obj, requiredKeys) => requiredKeys.filter(key => !objectContainsKey(obj, key))
 
 const supportedDBs = ['postgres', 'spanner', 'firestore', 'mssql', 'mysql', 'mongo', 'airtable', 'dynamodb', 'bigquery', 'google-sheets']
 
 const supportedVendors = ['gcp', 'aws', 'azure']
 
-module.exports = { checkRequiredKeys, supportedDBs, supportedVendors }
+const isJson = (str) => { try { JSON.parse(str); return true } catch (e) { return false } }
+
+const EMPTY_ROLE_CONFIG = {
+    collectionLevelRoleConfig: []
+}
+
+module.exports = { checkRequiredKeys, supportedDBs, supportedVendors, isJson, EMPTY_ROLE_CONFIG }

--- a/packages/external-db-config/test/drivers/external_db_config_test_support.js
+++ b/packages/external-db-config/test/drivers/external_db_config_test_support.js
@@ -14,13 +14,22 @@ const authConfigReader = {
     validate: jest.fn(),
 }
 
+const authorizationConfigReader = {
+    readConfig: jest.fn(),
+    validate: jest.fn(),
+}
+
 const givenConfig = (config) =>
     when(configReader.readConfig).calledWith()
                                  .mockResolvedValue(config)
 
 const givenAuthConfig = (config) =>
     when(authConfigReader.readConfig).calledWith()
-                                 .mockResolvedValue(config)
+                                     .mockResolvedValue(config)
+
+const givenAuthorizationConfig = (config) => 
+    when(authorizationConfigReader.readConfig).calledWith()
+                                              .mockResolvedValue(config)
 
 const givenValidConfig = () =>
     when(configReader.validate).calledWith()
@@ -63,11 +72,13 @@ const reset = () => {
     authConfigReader.validate.mockClear()
 
     commonConfigReader.validate.mockClear()
+
+    authorizationConfigReader.readConfig.mockClear()
 }
 
-module.exports = { configReader, commonConfigReader, authConfigReader, reset,
+module.exports = { configReader, commonConfigReader, authConfigReader, authorizationConfigReader, reset,
                    givenValidCommonConfig, 
                    givenValidAuthConfig, givenAuthConfig, givenInvalidAuthConfigWith,
                    givenConfig, givenValidConfig, givenInvalidConfigWith, givenInvalidCommonConfigWith,
-                   givenInvalidCloudVendor, givenInvalidDBType
+                   givenInvalidCloudVendor, givenInvalidDBType, givenAuthorizationConfig
 }

--- a/packages/external-db-security/lib/services/role_authorization.js
+++ b/packages/external-db-security/lib/services/role_authorization.js
@@ -3,7 +3,7 @@ const DefaultPolicies = ['OWNER', 'BACKEND_CODE']
 
 class RoleAuthorizationService {
     constructor(config) {
-        this.config = config
+        this.config = config || []
     }
 
     authorizeRead(collectionName, role) {

--- a/packages/velo-external-db/lib/app.js
+++ b/packages/velo-external-db/lib/app.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const path = require('path')
 const { config } = require('../roles-config.json')
-const { collectionLevelConfig } = require ('../collection-level-roles-config.json')
 const compression = require('compression')
 const { DataService, SchemaService, OperationService, CacheableSchemaInformation, FilterTransformer, AggregationTransformer, QueryValidator, SchemaAwareDataService, ItemTransformer } = require('velo-external-db-core')
 const { RoleAuthorizationService } = require ('external-db-security')
@@ -18,6 +17,7 @@ let server, _cleanup
 const load = async() => {
     const { vendor, type: adapterType } = readCommonConfig()
     const configReader = create()
+    const { authorization } = await configReader.readConfig()
     const { dataProvider, schemaProvider, cleanup, databaseOperations, secretKey } = await init(adapterType, vendor, configReader)
     const operationService = new OperationService(databaseOperations)
     const schemaInformation = new CacheableSchemaInformation(schemaProvider)
@@ -28,7 +28,7 @@ const load = async() => {
     const itemTransformer = new ItemTransformer()
     const schemaAwareDataService = new SchemaAwareDataService(dataService, queryValidator, schemaInformation, itemTransformer)
     const schemaService = new SchemaService(schemaProvider, schemaInformation)
-    const roleAuthorizationService = new RoleAuthorizationService(collectionLevelConfig)
+    const roleAuthorizationService = new RoleAuthorizationService(authorization)
     
     initServices(schemaAwareDataService, schemaService, operationService, configReader, { vendor, type: adapterType }, filterTransformer, aggregationTransformer, roleAuthorizationService)
     

--- a/packages/velo-external-db/test/drivers/authorization_test_support.js
+++ b/packages/velo-external-db/test/drivers/authorization_test_support.js
@@ -1,0 +1,24 @@
+const { dbTeardown, initApp } = require('../resources/e2e_resources')
+
+const DefaultPolicies = ['OWNER', 'BACKEND_CODE']
+
+const authRoleConfig = (collectionName, readPolicies, writePolicies) => {
+    const config = {
+        collectionLevelConfig: [
+            {
+                id: collectionName,
+                readPolicies: [...DefaultPolicies, ...readPolicies],
+                writePolicies: [...DefaultPolicies, ...writePolicies]
+            }
+        ]
+    }
+    process.env.ROLE_CONFIG = JSON.stringify(config)
+}
+
+const givenCollectionWithVisitorReadPolicy = async(collectionName) => {
+    await dbTeardown()
+    authRoleConfig(collectionName, ['VISITOR'], [])
+    await initApp()
+}
+
+module.exports = { givenCollectionWithVisitorReadPolicy }

--- a/packages/velo-external-db/test/e2e/app_auth.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_auth.e2e.spec.js
@@ -1,0 +1,40 @@
+const { Uninitialized, gen } = require('test-commons')
+const { authVisitor } = require('../drivers/auth_test_support')
+const each = require('jest-each').default
+const { initApp, teardownApp, dbTeardown, testSuits } = require('../resources/e2e_resources')
+
+
+const axios = require('axios').create({
+    baseURL: 'http://localhost:8080'
+})
+
+describe('Velo External DB authorization', () => {
+    each(testSuits()).describe('%s', (name, setup) => {
+        beforeAll(async() => {
+            await setup()
+
+            await initApp()
+        }, 20000)
+
+        afterAll(async() => {
+            await dbTeardown()
+        }, 20000)
+        
+        each(['data/find', 'data/aggregate', 'data/insert', 'data/insert/bulk', 'data/get', 'data/update',
+              'data/update/bulk', 'data/remove', 'data/remove/bulk', 'data/count'])
+        .test('should throw 401 on a request to %s without the appropriate role', async(api) => {
+                return expect(() => axios.post(api, { collectionName: ctx.collectionName }, authVisitor)).rejects.toThrow('401')
+        })
+    })
+
+
+    const ctx = {
+        collectionName: Uninitialized,
+    }
+
+    beforeEach(async() => {
+        ctx.collectionName = gen.randomCollectionName()
+    })
+
+    afterAll(async() => await teardownApp())
+})

--- a/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -2,7 +2,7 @@ const { Uninitialized, gen, shouldNotRunOn } = require('test-commons')
 const schema = require('../drivers/schema_api_rest_test_support')
 const data = require('../drivers/data_api_rest_test_support')
 const matchers = require('../drivers/schema_api_rest_matchers')
-const { authAdmin, authOwner, authVisitor } = require('../drivers/auth_test_support')
+const { authAdmin, authOwner } = require('../drivers/auth_test_support')
 const Chance = require('chance')
 const each = require('jest-each').default
 const { initApp, teardownApp, dbTeardown, testSuits } = require('../resources/e2e_resources')
@@ -158,11 +158,7 @@ describe('Velo External DB Data REST API',  () => {
                 await expect( data.expectAllDataIn(ctx.collectionName, authAdmin) ).resolves.toEqual({ items: [ ], totalCount: 0 })
             })
         }
-        each(['data/find', 'data/aggregate', 'data/insert', 'data/insert/bulk', 'data/get', 'data/update',
-             'data/update/bulk', 'data/remove', 'data/remove/bulk', 'data/count'])
-        .test('should throw 401 on a request to %s without the appropriate role', async(api) => {
-            return expect(() => axios.post(api, { collectionName: ctx.collectionName }, authVisitor)).rejects.toThrow('401')
-        })
+
     })
 
 

--- a/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -2,7 +2,8 @@ const { Uninitialized, gen, shouldNotRunOn } = require('test-commons')
 const schema = require('../drivers/schema_api_rest_test_support')
 const data = require('../drivers/data_api_rest_test_support')
 const matchers = require('../drivers/schema_api_rest_matchers')
-const { authAdmin, authOwner } = require('../drivers/auth_test_support')
+const { authAdmin, authOwner, authVisitor } = require('../drivers/auth_test_support')
+const authorization = require ('../drivers/authorization_test_support')
 const Chance = require('chance')
 const each = require('jest-each').default
 const { initApp, teardownApp, dbTeardown, testSuits } = require('../resources/e2e_resources')
@@ -30,7 +31,8 @@ describe('Velo External DB Data REST API',  () => {
                 const items = name === 'Google-sheet' ? [ ctx.item, ctx.anotherItem ] : [ ctx.item, ctx.anotherItem ].sort((a, b) => (a[ctx.column.name] > b[ctx.column.name]) ? 1 : -1)
                 await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
                 await data.givenItems([ctx.item, ctx.anotherItem], ctx.collectionName, authAdmin)
-                await expect( axios.post('/data/find', { collectionName: ctx.collectionName, filter: '', sort: [{ fieldName: ctx.column.name }], skip: 0, limit: 25 }, authAdmin) ).resolves.toEqual(
+                await authorization.givenCollectionWithVisitorReadPolicy(ctx.collectionName)
+                await expect( axios.post('/data/find', { collectionName: ctx.collectionName, filter: '', sort: [{ fieldName: ctx.column.name }], skip: 0, limit: 25 }, authVisitor) ).resolves.toEqual(
                     expect.objectContaining({ data: {
                             items,
                             totalCount: 2

--- a/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -26,15 +26,14 @@ describe('Velo External DB Data REST API',  () => {
             await dbTeardown()
         }, 20000)
 
-        if (shouldNotRunOn(['DynamoDb'], name)) {
+        if (shouldNotRunOn(['DynamoDb', 'Google-sheet'], name)) { //todo: create another test without sort for these implementations
             test('find api', async() => {
-                const items = name === 'Google-sheet' ? [ ctx.item, ctx.anotherItem ] : [ ctx.item, ctx.anotherItem ].sort((a, b) => (a[ctx.column.name] > b[ctx.column.name]) ? 1 : -1)
                 await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
                 await data.givenItems([ctx.item, ctx.anotherItem], ctx.collectionName, authAdmin)
                 await authorization.givenCollectionWithVisitorReadPolicy(ctx.collectionName)
                 await expect( axios.post('/data/find', { collectionName: ctx.collectionName, filter: '', sort: [{ fieldName: ctx.column.name }], skip: 0, limit: 25 }, authVisitor) ).resolves.toEqual(
                     expect.objectContaining({ data: {
-                            items,
+                            items: [ ctx.item, ctx.anotherItem ].sort((a, b) => (a[ctx.column.name] > b[ctx.column.name]) ? 1 : -1),
                             totalCount: 2
                         } }))
             })

--- a/packages/velo-external-db/test/resources/engines/google_sheets_resources.js
+++ b/packages/velo-external-db/test/resources/engines/google_sheets_resources.js
@@ -8,7 +8,7 @@ const connection = async() => {
 }   
 
 const cleanup = async() => {
-    
+    // todo: add cleanup logic
 }
 
 const initEnv = async() => {


### PR DESCRIPTION
Get the collection role config from env (need to set them through the secret-manger / app config) 

example for the json that we are expecting in `process.env.ROLE_CONFIG`: 

```
collectionLevelConfig : [
  {
    "id":"collectionName1"
    "readPolicies": ["OWNER","BACKEND_CODE"],
    "writePolicies": ["OWNER","BACKEND_CODE"]
  },
  {
    "id":"collectionName2"
    "readPolicies": ["OWNER","BACKEND_CODE", "VISITOR"],
    "writePolicies": ["OWNER","BACKEND_CODE", "VISITOR"]
  }
]

```