### PR TITLE
authorization config reader validator 

### DIFF
--- a/packages/external-db-config/lib/factory.js
+++ b/packages/external-db-config/lib/factory.js
@@ -1,6 +1,7 @@
 const ConfigReader = require('./service/config_reader')
 const CommonConfigReader = require('./readers/common_config_reader')
 const StubConfigReader = require('./readers/stub_config_reader')
+const AwsAuthorizationConfigReader = require ('./readers/aws_authorization_config_reader')
 const AuthorizationConfigReader = require ('./readers/authorization_config_reader')
 const aws = require('./readers/aws_config_reader')
 const gcp = require('./readers/gcp_config_reader')
@@ -12,9 +13,11 @@ const create = () => {
   const common = new CommonConfigReader()
   const { vendor = '', type, secretId, region } = common.readConfig()
   let internalConfigReader
+  let authorizationConfigReader
 
   switch (vendor.toLowerCase()) {
     case 'aws': {
+      authorizationConfigReader = new AwsAuthorizationConfigReader(region, secretId)
       switch(type) {
         case 'dynamodb':
           internalConfigReader = new aws.AwsDynamoConfigReader(region) 
@@ -27,6 +30,7 @@ const create = () => {
     break
       
     case 'gcp': {
+      authorizationConfigReader = new AuthorizationConfigReader()
       switch (type) {
         case 'spanner':
           internalConfigReader = new gcp.GcpSpannerConfigReader()
@@ -55,6 +59,7 @@ const create = () => {
     break
 
     case 'azure': {
+      authorizationConfigReader = new AuthorizationConfigReader()
       switch (type) {
         case 'spanner':
           internalConfigReader = new gcp.GcpSpannerConfigReader()
@@ -87,7 +92,7 @@ const create = () => {
     break
   }
 
-  return new ConfigReader(internalConfigReader || new StubConfigReader, common, new AuthorizationConfigReader())
+  return new ConfigReader(internalConfigReader || new StubConfigReader, common, authorizationConfigReader)
 }
 
 module.exports = { create }

--- a/packages/external-db-config/lib/readers/authorization_config_reader.js
+++ b/packages/external-db-config/lib/readers/authorization_config_reader.js
@@ -11,7 +11,6 @@ class AuthorizationConfigReader {
   async readConfig() {
     const { ROLE_CONFIG } = process.env
     const { collectionLevelConfig } = isJson(ROLE_CONFIG) ? JSON.parse(ROLE_CONFIG) : EMPTY_ROLE_CONFIG
-
     return collectionLevelConfig.filter(collection => this.collectionValidator(collection))
   }
 
@@ -21,7 +20,6 @@ class AuthorizationConfigReader {
     const valid = isJson(ROLE_CONFIG) && this.configValidator(JSON.parse(ROLE_CONFIG))
     let message 
     
-    console.log(this.configValidator.errors)
 
     if (checkRequiredKeys(process.env, ['ROLE_CONFIG']).length)  
       message = 'Role config is not defined, using default'

--- a/packages/external-db-config/lib/readers/authorization_config_reader.js
+++ b/packages/external-db-config/lib/readers/authorization_config_reader.js
@@ -17,12 +17,22 @@ class AuthorizationConfigReader {
 
   validate() {
     const { ROLE_CONFIG } = process.env
+    
+    const valid = isJson(ROLE_CONFIG) && this.configValidator(JSON.parse(ROLE_CONFIG))
+    let message 
+    
+    console.log(this.configValidator.errors)
 
-    return {
-      valid: isJson(ROLE_CONFIG) && this.configValidator(JSON.parse(ROLE_CONFIG)),
-      message: this.configValidator.errors ? this.configValidator.errors.map(e => e.message).join(', ') : 'Authorization config is valid',
-      missingRequiredSecretsKeys: checkRequiredKeys(process.env, ['ROLE_CONFIG'])
-    }
+    if (checkRequiredKeys(process.env, ['ROLE_CONFIG']).length)  
+      message = 'Role config is not defined, using default'
+    else if (!isJson(ROLE_CONFIG)) 
+      message = 'Role config is not valid JSON'
+    else if (!valid)
+      message = this.configValidator.errors.map(err => (`Error in ${err.instancePath}: ${err.message}`)).join(', ')
+    else 
+      message = 'Authorization Config read successfully'
+
+    return { valid, message }
   }
 }
 

--- a/packages/external-db-config/lib/readers/authorization_config_reader.js
+++ b/packages/external-db-config/lib/readers/authorization_config_reader.js
@@ -1,18 +1,27 @@
-const { checkRequiredKeys, isJson, EMPTY_ROLE_CONFIG } = require('../utils/config_utils')
+const { checkRequiredKeys, isJson, EMPTY_ROLE_CONFIG, configPattern, collectionConfigPattern } = require('../utils/config_utils')
+const Avj = require('ajv')
+const ajv = new Avj()
 
 class AuthorizationConfigReader {
   constructor() {
+    this.configValidator = ajv.compile(configPattern)
+    this.collectionValidator = ajv.compile(collectionConfigPattern)
   }
 
   async readConfig() {
     const { ROLE_CONFIG } = process.env
     const { collectionLevelConfig } = isJson(ROLE_CONFIG) ? JSON.parse(ROLE_CONFIG) : EMPTY_ROLE_CONFIG
-    return collectionLevelConfig
+
+    return collectionLevelConfig.filter(collection => this.collectionValidator(collection))
   }
 
   validate() {
+    const { ROLE_CONFIG } = process.env
+
     return {
-      missingRequiredSecretsKeys: checkRequiredKeys(process.env, [])
+      valid: isJson(ROLE_CONFIG) && this.configValidator(JSON.parse(ROLE_CONFIG)),
+      message: this.configValidator.errors ? this.configValidator.errors.map(e => e.message).join(', ') : 'Authorization config is valid',
+      missingRequiredSecretsKeys: checkRequiredKeys(process.env, ['ROLE_CONFIG'])
     }
   }
 }

--- a/packages/external-db-config/lib/readers/aws_authorization_config_reader.js
+++ b/packages/external-db-config/lib/readers/aws_authorization_config_reader.js
@@ -1,0 +1,58 @@
+const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager')
+const { checkRequiredKeys, isJson, EMPTY_ROLE_CONFIG, configPattern, collectionConfigPattern } = require('../utils/config_utils')
+const Avj = require('ajv')
+const ajv = new Avj()
+const EmptyAWSAuthConfig = { ROLE_CONFIG: EMPTY_ROLE_CONFIG }
+
+class AwsAuthorizationConfigReader {
+  constructor(region, secretId) {
+    this.configValidator = ajv.compile(configPattern)
+    this.collectionValidator = ajv.compile(collectionConfigPattern)
+    this.secretId = secretId
+    this.region = region
+  }
+
+  async readConfig() {
+    const { ROLE_CONFIG } = await this.readExternalConfig()
+                          .catch(() => EmptyAWSAuthConfig)
+    
+    const { collectionLevelConfig } = isJson(ROLE_CONFIG) ? JSON.parse(ROLE_CONFIG) : EMPTY_ROLE_CONFIG
+    
+    return collectionLevelConfig.filter(collection => this.collectionValidator(collection))
+  }
+
+  async readExternalConfig() {  
+    const client = new SecretsManagerClient({ region: this.region })
+    const data = await client.send(new GetSecretValueCommand({ SecretId: this.secretId }))
+    return JSON.parse(data.SecretString)
+  }
+
+  async validate() {
+    try{
+        const { ROLE_CONFIG } = await this.readExternalConfig()
+
+        const valid = isJson(ROLE_CONFIG) && this.configValidator(JSON.parse(ROLE_CONFIG))
+
+        let message 
+        
+    
+        if (checkRequiredKeys(process.env, ['ROLE_CONFIG']).length)  
+          message = 'Role config is not defined, using default'
+        else if (!isJson(ROLE_CONFIG)) 
+          message = 'Role config is not valid JSON'
+        else if (!valid)
+          message = this.configValidator.errors.map(err => (`Error in ${err.instancePath}: ${err.message}`)).join(', ')
+        else 
+          message = 'Authorization Config read successfully'
+      
+        return { valid, message }
+    }
+
+    catch(err) {
+      console.log(err)
+        return { valid: false, message: err.message }
+    }
+  }
+}
+
+module.exports = AwsAuthorizationConfigReader 

--- a/packages/external-db-config/lib/service/config_reader.js
+++ b/packages/external-db-config/lib/service/config_reader.js
@@ -13,13 +13,14 @@ class ConfigReader {
 
   async configStatus() {
     const { missingRequiredSecretsKeys } = await this.externalConfigReader.validate()
-    const { missingRequiredSecretsKeys: missingRequiredEnvs, validType, validVendor } = this.commonConfigReader.validate()
+    const { missingRequiredSecretsKeys: missingRequiredEnvs, validType, validVendor } = this.commonConfigReader.validate()  
+    const { valid: validAuthorization, message: authorizationMessage  } = this.authorizationConfig.validate()
 
     const validConfig = missingRequiredSecretsKeys.length === 0 && missingRequiredEnvs.length === 0 && validType && validVendor
     
   
     let message 
-    if (missingRequiredSecretsKeys.length > 0 || missingRequiredEnvs.length > 0)
+    if (missingRequiredSecretsKeys.length || missingRequiredEnvs.length )
       message = `Missing props: ${[...missingRequiredSecretsKeys, ...missingRequiredEnvs].join(', ')}`
     
     else if (!validVendor)
@@ -31,7 +32,7 @@ class ConfigReader {
     else 
       message = 'External DB Config read successfully'
 
-    return { validConfig, message }
+    return { validConfig, message, validAuthorization, authorizationMessage }
   
   }
 }

--- a/packages/external-db-config/lib/service/config_reader.js
+++ b/packages/external-db-config/lib/service/config_reader.js
@@ -14,7 +14,7 @@ class ConfigReader {
   async configStatus() {
     const { missingRequiredSecretsKeys } = await this.externalConfigReader.validate()
     const { missingRequiredSecretsKeys: missingRequiredEnvs, validType, validVendor } = this.commonConfigReader.validate()  
-    const { valid: validAuthorization, message: authorizationMessage  } = this.authorizationConfig.validate()
+    const { valid: validAuthorization, message: authorizationMessage  } = await this.authorizationConfig.validate()
 
     const validConfig = missingRequiredSecretsKeys.length === 0 && missingRequiredEnvs.length === 0 && validType && validVendor
     

--- a/packages/external-db-config/lib/service/config_reader.spec.js
+++ b/packages/external-db-config/lib/service/config_reader.spec.js
@@ -1,7 +1,7 @@
 const ConfigReader = require('./config_reader')
 const { Uninitialized, gen } = require('test-commons')
 const driver = require('../../test/drivers/external_db_config_test_support')
-const { configResponseFor, validConfigStatusResponse, configResponseWithMissingProperties, invalidVendorConfigStatusResponse, invalidDbTypeConfigStatusResponse } = require('./config_reader_matchers')
+const matchers = require('./config_reader_matchers')
 const Chance = require('chance')
 const chance = new Chance()
 
@@ -11,52 +11,73 @@ describe('Config Reader Client', () => {
         driver.givenConfig(ctx.config)
         driver.givenAuthorizationConfig(ctx.authorizationConfig)
 
-        await expect( env.configReader.readConfig() ).resolves.toEqual(configResponseFor(ctx.config, ctx.authorizationConfig))
+        await expect( env.configReader.readConfig() ).resolves.toEqual(matchers.configResponseFor(ctx.config, ctx.authorizationConfig))
     })
 
     test('status call will return successful message in case config is valid', async() => {
         driver.givenValidConfig()
         driver.givenValidCommonConfig()
+        driver.givenValidAuthorizationConfig()
 
-        await expect( env.configReader.configStatus() ).resolves.toEqual( validConfigStatusResponse() )
+        await expect( env.configReader.configStatus() ).resolves.toEqual( matchers.validConfigStatusResponse() )
     })
 
     test('status call will return error message containing list of missing properties', async() => {
         driver.givenInvalidConfigWith(ctx.missingProperties)
         driver.givenValidCommonConfig()
+        driver.givenValidAuthorizationConfig()
 
-        await expect( env.configReader.configStatus() ).resolves.toEqual( configResponseWithMissingProperties(ctx.missingProperties) )
+        await expect( env.configReader.configStatus() ).resolves.toEqual( matchers.configResponseWithMissingProperties(ctx.missingProperties) )
     })
 
     test('status call will return error message containing list of missing properties from common reader', async() => {
         driver.givenValidConfig()
         driver.givenInvalidCommonConfigWith(ctx.missingProperties)
+        driver.givenValidAuthorizationConfig()
 
-        await expect( env.configReader.configStatus() ).resolves.toEqual( configResponseWithMissingProperties(ctx.missingProperties) )
+        await expect( env.configReader.configStatus() ).resolves.toEqual( matchers.configResponseWithMissingProperties(ctx.missingProperties) )
     })
 
     test('status call will return error message containing list of all missing properties from common reader and normal reader', async() => {
         driver.givenInvalidConfigWith(ctx.missingProperties)
         driver.givenInvalidCommonConfigWith(ctx.moreMissingProperties)
+        driver.givenValidAuthorizationConfig()
 
-        await expect( env.configReader.configStatus() ).resolves.toEqual( configResponseWithMissingProperties([...ctx.missingProperties, ...ctx.moreMissingProperties]))
+        await expect( env.configReader.configStatus() ).resolves.toEqual( matchers.configResponseWithMissingProperties([...ctx.missingProperties, ...ctx.moreMissingProperties]))
     })
 
     test('status call with wrong cloud vendor', async() => {
         driver.givenValidConfig()
         driver.givenInvalidCloudVendor()
+        driver.givenValidAuthorizationConfig()
 
-        await expect( env.configReader.configStatus() ).resolves.toEqual( invalidVendorConfigStatusResponse() )
+        await expect( env.configReader.configStatus() ).resolves.toEqual( matchers.invalidVendorConfigStatusResponse() )
 
     })
 
     test('status call with wrong db type', async() => {
         driver.givenValidConfig()
         driver.givenInvalidDBType()
+        driver.givenValidAuthorizationConfig()
 
-        await expect( env.configReader.configStatus() ).resolves.toEqual( invalidDbTypeConfigStatusResponse() )
+        await expect( env.configReader.configStatus() ).resolves.toEqual( matchers.invalidDbTypeConfigStatusResponse() )
     })
 
+    test('status call with empty authorization config', async() => {
+        driver.givenValidConfig()
+        driver.givenValidCommonConfig()
+        driver.givenEmptyAuthorizationConfig()
+
+        await expect( env.configReader.configStatus() ).resolves.toEqual( matchers.emptyAuthorizationConfigStatusResponse() )
+    })
+
+    test('status call with wrong authorization config format', async() => {
+        driver.givenValidConfig()
+        driver.givenValidCommonConfig()
+        driver.givenInvalidAuthorizationConfig()
+
+        await expect( env.configReader.configStatus() ).resolves.toEqual( matchers.invalidAuthorizationConfigStatusResponse() )
+    })
 
     const ctx = {
         config: Uninitialized,

--- a/packages/external-db-config/lib/service/config_reader_matchers.js
+++ b/packages/external-db-config/lib/service/config_reader_matchers.js
@@ -23,5 +23,16 @@ const invalidDbTypeConfigStatusResponse = () => expect.objectContaining({
     message: expect.stringContaining('DB type is not supported'),
 })
 
+const emptyAuthorizationConfigStatusResponse = () => expect.objectContaining({
+    validAuthorization: false,
+    authorizationMessage: expect.stringContaining('Role config is not defined, using default') 
+})
+
+const invalidAuthorizationConfigStatusResponse = () => expect.objectContaining({
+    validAuthorization: false,
+    authorizationMessage: expect.stringContaining('Error in ')
+})
+
 module.exports = { configResponseFor, validConfigStatusResponse, configResponseWithMissingProperties, 
-    invalidVendorConfigStatusResponse, invalidDbTypeConfigStatusResponse }
+    invalidVendorConfigStatusResponse, invalidDbTypeConfigStatusResponse, emptyAuthorizationConfigStatusResponse,
+    invalidAuthorizationConfigStatusResponse }

--- a/packages/external-db-config/lib/utils/config_utils.js
+++ b/packages/external-db-config/lib/utils/config_utils.js
@@ -6,10 +6,30 @@ const supportedDBs = ['postgres', 'spanner', 'firestore', 'mssql', 'mysql', 'mon
 
 const supportedVendors = ['gcp', 'aws', 'azure']
 
+const veloRoles = ['OWNER', 'BACKEND_CODE', 'VISITOR', 'MEMBER']
+
+const collectionConfigPattern = {
+    type: 'object',
+    properties: {
+        id: { type: 'string' },
+        readPolicies: { type: 'array', items: { enum: veloRoles } },
+        writePolicies: { type: 'array', items: { enum: veloRoles } },
+    },
+    required: ['id']
+}
+
+const configPattern = {
+    type: 'object',
+    properties: {
+        collectionLevelConfig: { items: collectionConfigPattern }
+    },
+    required: ['collectionLevelConfig']
+}
+
 const isJson = (str) => { try { JSON.parse(str); return true } catch (e) { return false } }
 
 const EMPTY_ROLE_CONFIG = {
-    collectionLevelRoleConfig: []
+    collectionLevelConfig: []
 }
 
-module.exports = { checkRequiredKeys, supportedDBs, supportedVendors, isJson, EMPTY_ROLE_CONFIG }
+module.exports = { checkRequiredKeys, supportedDBs, supportedVendors, isJson, EMPTY_ROLE_CONFIG, configPattern, collectionConfigPattern }

--- a/packages/external-db-config/package.json
+++ b/packages/external-db-config/package.json
@@ -32,6 +32,7 @@
 		"test-commons": "^0.0.0"
 	},
 	"dependencies": {
-		"@aws-sdk/client-secrets-manager": "^3.52.0"
+		"@aws-sdk/client-secrets-manager": "^3.52.0",
+		"ajv": "^8.10.0"
 	}
 }

--- a/packages/external-db-config/test/drivers/aws_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/aws_mysql_config_test_support.js
@@ -23,6 +23,9 @@ const defineValidConfig = (config) => {
     if (config.secretKey) {
         awsConfig.SECRET_KEY = config.secretKey
     }
+    if (config.authorization) {
+        awsConfig.ROLE_CONFIG = JSON.stringify({ collectionLevelConfig: config.authorization })
+    }
     mockedAwsSdk.on(GetSecretValueCommand).resolves({ SecretString: JSON.stringify(awsConfig) })
 }
 
@@ -36,6 +39,21 @@ const validConfig = () => ({
     secretKey: chance.word(),
 })
 
+const validConfigWithAuthorization = () => ({
+    ...validConfig(),
+    authorization: validAuthorizationConfig.collectionLevelConfig 
+})
+
+const validAuthorizationConfig = {
+    collectionLevelConfig: [
+        {
+            id: chance.word(),
+            readPolicies: ['OWNER'],
+            writePolicies: ['BACKEND_CODE'],
+        }
+    ]
+}
+
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),
     auth: {
@@ -46,7 +64,7 @@ const validConfigWithAuthConfig = () => ({
     } 
 })
 
-const ExpectedProperties = ['host', 'username', 'password', 'DB', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret', 'clientDomain']
+const ExpectedProperties = ['host', 'username', 'password', 'DB', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret', 'clientDomain', 'ROLE_CONFIG']
 
 const reset = () => mockedAwsSdk.reset()
 
@@ -63,6 +81,7 @@ const defaultConfig = {
 module.exports = {
     defineValidConfig,
     validConfigWithAuthConfig,
+    validConfigWithAuthorization,
     defineInvalidConfig,
     defineErroneousConfig,
     validConfig,

--- a/packages/external-db-config/test/drivers/azure_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/azure_mysql_config_test_support.js
@@ -18,6 +18,9 @@ const defineValidConfig = (config) => {
     if (config.secretKey) {
         process.env.SECRET_KEY = config.secretKey
     }
+    if (config.authorization) {
+        process.env.ROLE_CONFIG = JSON.stringify({ collectionLevelConfig: config.authorization })
+    }
     if (config.auth?.clientId) {
         process.env.clientId = config.auth.clientId
     }
@@ -37,6 +40,21 @@ const validConfig = () => ({
     secretKey: chance.word(),
 })
 
+const validConfigWithAuthorization = () => ({
+    ...validConfig(),
+    authorization: validAuthorizationConfig.collectionLevelConfig 
+})
+
+const validAuthorizationConfig = {
+    collectionLevelConfig: [
+        {
+            id: chance.word(),
+            readPolicies: ['OWNER'],
+            writePolicies: ['BACKEND_CODE'],
+        }
+    ]
+}
+
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),
     auth: {
@@ -48,7 +66,7 @@ const validConfigWithAuthConfig = () => ({
 
 const defineInvalidConfig = () => defineValidConfig({})
 
-const ExpectedProperties = ['HOST', 'USER', 'PASSWORD', 'DB', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret']
+const ExpectedProperties = ['HOST', 'USER', 'PASSWORD', 'DB', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret', 'ROLE_CONFIG']
 
 const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 
@@ -57,6 +75,7 @@ const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 module.exports = {
     defineValidConfig,
     validConfigWithAuthConfig,
+    validConfigWithAuthorization,
     defineInvalidConfig,
     validConfig,
     reset,

--- a/packages/external-db-config/test/drivers/external_db_config_test_support.js
+++ b/packages/external-db-config/test/drivers/external_db_config_test_support.js
@@ -64,6 +64,17 @@ const givenInvalidDBType = () =>
     when(commonConfigReader.validate).calledWith()
                                      .mockReturnValueOnce({ missingRequiredSecretsKeys: [], validType: false, validVendor: true })
 
+const givenValidAuthorizationConfig = () => 
+    when(authorizationConfigReader.validate).calledWith()
+                                            .mockReturnValue({ valid: true, message: 'Authorization Config read successfully' })
+
+const givenEmptyAuthorizationConfig = () =>
+    when(authorizationConfigReader.validate).calledWith()
+                                            .mockReturnValue({ valid: false, message: 'Role config is not defined, using default' })
+
+const givenInvalidAuthorizationConfig = () => 
+    when(authorizationConfigReader.validate).calledWith()
+                                            .mockReturnValue({ valid: false, message: 'Error in /collectionLevelConfig/0/readPolicies/0: must be equal to one of the allowed values' })
 const reset = () => {
     configReader.readConfig.mockClear()
     configReader.validate.mockClear()
@@ -73,12 +84,15 @@ const reset = () => {
 
     commonConfigReader.validate.mockClear()
 
-    authorizationConfigReader.readConfig.mockClear()
+    authorizationConfigReader.readConfig.mockClear(
+    authorizationConfigReader.validate.mockClear()
+    )
 }
 
 module.exports = { configReader, commonConfigReader, authConfigReader, authorizationConfigReader, reset,
                    givenValidCommonConfig, 
                    givenValidAuthConfig, givenAuthConfig, givenInvalidAuthConfigWith,
                    givenConfig, givenValidConfig, givenInvalidConfigWith, givenInvalidCommonConfigWith,
-                   givenInvalidCloudVendor, givenInvalidDBType, givenAuthorizationConfig
+                   givenInvalidCloudVendor, givenInvalidDBType, givenAuthorizationConfig, givenValidAuthorizationConfig,
+                   givenEmptyAuthorizationConfig, givenInvalidAuthorizationConfig
 }

--- a/packages/external-db-config/test/drivers/gcp_firestore_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_firestore_config_test_support.js
@@ -9,6 +9,9 @@ const defineValidConfig = (config) => {
     if (config.secretKey) {
         process.env.SECRET_KEY = config.secretKey
     }
+    if (config.roleConfig) {
+        process.env.ROLE_CONFIG = config.roleConfig
+    }
     if (config.auth?.callbackUrl) {
         process.env.callbackUrl = config.auth.callbackUrl
     }
@@ -23,6 +26,19 @@ const defineValidConfig = (config) => {
 const validConfig = () => ({
     projectId: chance.word(),
     secretKey: chance.word(),
+})
+
+const validConfigWithAuthorization = () => ({
+    ...validConfig(),
+    roleConfig: {
+        collectionLevelConfig: [
+            {
+                id: chance.word(),
+                readPolicies: ['OWNER'],
+                writePolicies: ['BACKEND_CODE'],
+            }
+        ]
+    }
 })
 
 const validConfigWithAuthConfig = () => ({
@@ -43,6 +59,7 @@ const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 module.exports = {
     defineValidConfig,
     validConfigWithAuthConfig,
+    validConfigWithAuthorization,
     defineInvalidConfig,
     validConfig,
     reset,

--- a/packages/external-db-config/test/drivers/gcp_firestore_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_firestore_config_test_support.js
@@ -9,8 +9,8 @@ const defineValidConfig = (config) => {
     if (config.secretKey) {
         process.env.SECRET_KEY = config.secretKey
     }
-    if (config.roleConfig) {
-        process.env.ROLE_CONFIG = config.roleConfig
+    if (config.authorization) {
+        process.env.ROLE_CONFIG = JSON.stringify({ collectionLevelConfig: config.authorization })
     }
     if (config.auth?.callbackUrl) {
         process.env.callbackUrl = config.auth.callbackUrl
@@ -30,16 +30,18 @@ const validConfig = () => ({
 
 const validConfigWithAuthorization = () => ({
     ...validConfig(),
-    roleConfig: {
-        collectionLevelConfig: [
-            {
-                id: chance.word(),
-                readPolicies: ['OWNER'],
-                writePolicies: ['BACKEND_CODE'],
-            }
-        ]
-    }
+    authorization: validAuthorizationConfig.collectionLevelConfig 
 })
+
+const validAuthorizationConfig = {
+    collectionLevelConfig: [
+        {
+            id: chance.word(),
+            readPolicies: ['OWNER'],
+            writePolicies: ['BACKEND_CODE'],
+        }
+    ]
+}
 
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),
@@ -52,7 +54,7 @@ const validConfigWithAuthConfig = () => ({
 
 const defineInvalidConfig = () => defineValidConfig({})
 
-const ExpectedProperties = ['PROJECT_ID', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret']
+const ExpectedProperties = ['PROJECT_ID', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret', 'ROLE_CONFIG']
 
 const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 

--- a/packages/external-db-config/test/drivers/gcp_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_mysql_config_test_support.js
@@ -18,6 +18,9 @@ const defineValidConfig = (config) => {
     if (config.secretKey) {
         process.env.SECRET_KEY = config.secretKey
     }
+    if (config.authorization) {
+        process.env.ROLE_CONFIG = JSON.stringify({ collectionLevelConfig: config.authorization })
+    }
     if (config.auth?.callbackUrl) {
         process.env.callbackUrl = config.auth.callbackUrl
     }
@@ -37,6 +40,21 @@ const validConfig = () => ({
     secretKey: chance.word(),
 })
 
+const validConfigWithAuthorization = () => ({
+    ...validConfig(),
+    authorization: validAuthorizationConfig.collectionLevelConfig 
+})
+
+const validAuthorizationConfig = {
+    collectionLevelConfig: [
+        {
+            id: chance.word(),
+            readPolicies: ['OWNER'],
+            writePolicies: ['BACKEND_CODE'],
+        }
+    ]
+}
+
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),
     auth: {
@@ -46,7 +64,7 @@ const validConfigWithAuthConfig = () => ({
     }  
 })
 
-const ExpectedProperties = ['CLOUD_SQL_CONNECTION_NAME', 'USER', 'PASSWORD', 'DB', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret']
+const ExpectedProperties = ['CLOUD_SQL_CONNECTION_NAME', 'USER', 'PASSWORD', 'DB', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret', 'ROLE_CONFIG']
 
 const defineInvalidConfig = () => defineValidConfig({})
 
@@ -58,6 +76,7 @@ const reset = () => {
 module.exports = {
     defineValidConfig,
     validConfigWithAuthConfig,
+    validConfigWithAuthorization,
     defineInvalidConfig,
     ExpectedProperties,
     validConfig,

--- a/packages/external-db-config/test/drivers/gcp_spanner_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_spanner_config_test_support.js
@@ -15,8 +15,8 @@ const defineValidConfig = (config) => {
     if (config.secretKey) {
         process.env.SECRET_KEY = config.secretKey
     }
-    if (config.roleConfig) {
-        process.env.ROLE_CONFIG = config.roleConfig
+    if (config.authorization) {
+        process.env.ROLE_CONFIG = JSON.stringify({ collectionLevelConfig: config.authorization })
     }
     if (config.auth?.callbackUrl) {
         process.env.callbackUrl = config.auth.callbackUrl
@@ -38,17 +38,18 @@ const validConfig = () => ({
 
 const validConfigWithAuthorization = () => ({
     ...validConfig(),
-    roleConfig: {
-        collectionLevelConfig: [
-            {
-                id: chance.word(),
-                readPolicies: ['OWNER'],
-                writePolicies: ['BACKEND_CODE'],
-            }
-        ]
-    }
+    authorization: validAuthorizationConfig.collectionLevelConfig 
 })
 
+const validAuthorizationConfig = {
+    collectionLevelConfig: [
+        {
+            id: chance.word(),
+            readPolicies: ['OWNER'],
+            writePolicies: ['BACKEND_CODE'],
+        }
+    ]
+}
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),
     auth: {
@@ -62,7 +63,7 @@ const validConfigWithAuthConfig = () => ({
 
 const defineInvalidConfig = () => defineValidConfig({})
 
-const ExpectedProperties = ['PROJECT_ID', 'INSTANCE_ID', 'DATABASE_ID', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret']
+const ExpectedProperties = ['PROJECT_ID', 'INSTANCE_ID', 'DATABASE_ID', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret', 'ROLE_CONFIG']
 
 const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 

--- a/packages/external-db-config/test/drivers/gcp_spanner_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_spanner_config_test_support.js
@@ -15,6 +15,9 @@ const defineValidConfig = (config) => {
     if (config.secretKey) {
         process.env.SECRET_KEY = config.secretKey
     }
+    if (config.roleConfig) {
+        process.env.ROLE_CONFIG = config.roleConfig
+    }
     if (config.auth?.callbackUrl) {
         process.env.callbackUrl = config.auth.callbackUrl
     }
@@ -33,6 +36,19 @@ const validConfig = () => ({
     secretKey: chance.word(),
 })
 
+const validConfigWithAuthorization = () => ({
+    ...validConfig(),
+    roleConfig: {
+        collectionLevelConfig: [
+            {
+                id: chance.word(),
+                readPolicies: ['OWNER'],
+                writePolicies: ['BACKEND_CODE'],
+            }
+        ]
+    }
+})
+
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),
     auth: {
@@ -42,6 +58,8 @@ const validConfigWithAuthConfig = () => ({
     }  
 })
 
+
+
 const defineInvalidConfig = () => defineValidConfig({})
 
 const ExpectedProperties = ['PROJECT_ID', 'INSTANCE_ID', 'DATABASE_ID', 'SECRET_KEY', 'callbackUrl', 'clientId', 'clientSecret']
@@ -50,6 +68,7 @@ const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 
 module.exports = {
     defineValidConfig,
+    validConfigWithAuthorization,
     validConfigWithAuthConfig,
     defineInvalidConfig,
     validConfig,

--- a/packages/external-db-config/test/e2e/external_db_config_client.e2e.spec.js
+++ b/packages/external-db-config/test/e2e/external_db_config_client.e2e.spec.js
@@ -23,7 +23,7 @@ each(
 
         beforeEach(async() => {
             reset()
-            ctx.config = env.driver.validConfig()
+            ctx.config = env.driver.validConfigWithAuthorization()
         })
 
 

--- a/packages/external-db-config/test/e2e/external_db_config_client_matcher.js
+++ b/packages/external-db-config/test/e2e/external_db_config_client_matcher.js
@@ -1,6 +1,7 @@
 const invalidConfigStatusResponse = () => expect.objectContaining({
     message: expect.stringContaining('Missing props'),
     validConfig: false,
+    validAuthorization: false,
 })
 
 module.exports = { invalidConfigStatusResponse }

--- a/packages/velo-external-db/lib/health/app_info.js
+++ b/packages/velo-external-db/lib/health/app_info.js
@@ -8,9 +8,11 @@ const maskSensitiveData = (cfg) => {
 const appInfoFor = async(operationService, configReaderClient) => {
     const connectionStatus = await operationService.connectionStatus()
     const config = await configReaderClient.readConfig()
-    const { message: configReaderStatus } = await configReaderClient.configStatus()
+    const { message: configReaderStatus, authorizationMessage: authorizationConfigStatus } = await configReaderClient.configStatus()
+    
     return {
-        configReaderStatus,
+        configReaderStatus: configReaderStatus,
+        authorizationConfigStatus, 
         config: maskSensitiveData(config),
         dbConnectionStatus: connectionStatus.error || connectionStatus.status 
     }

--- a/packages/velo-external-db/views/partials/details.ejs
+++ b/packages/velo-external-db/views/partials/details.ejs
@@ -10,6 +10,14 @@
 <%
 const connectionColor =  dbConnectionStatus === 'Connected to database successfully' ? 'success': 'danger' 
 const configStatusColor = configReaderStatus === 'External DB Config read successfully' ? 'success' : 'danger'
+let authorizationStatusColor
+if (authorizationConfigStatus === 'Authorization Config read successfully') {
+	authorizationStatusColor = 'success'
+} else if (authorizationConfigStatus === 'Role config is not defined, using default') {
+	authorizationStatusColor = 'warning'
+} else {
+	authorizationStatusColor = 'danger'
+}
 %>
 <script>
 	function toggleConfigDisplay() {
@@ -40,6 +48,21 @@ const configStatusColor = configReaderStatus === 'External DB Config read succes
 		<li class="list-group-item">DB name: <%= config.db || config.databaseId  %></li>
 		<li class="list-group-item">Secret Key: <%= config.secretKey %></li>
 	</ul>
+	</div>
+
+	<div class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=authorizationStatusColor%> py-3" aria-current="true"> 
+		<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list"
+			viewBox="0 0 16 16">
+			<path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+		</svg>
+		<div class="d-flex gap-2 w-100 justify-content-between">
+			<div>
+				<h6 class="mb-0">Authorization Config Status</h6>
+				<p class="mb-0 opacity-75">
+					<%= authorizationConfigStatus %>
+				</p>
+			</div>
+		</div>
 	</div>
 
 	<div class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=connectionColor%> py-3" aria-current="true"> 


### PR DESCRIPTION
`AuthorizationConfigReader.readConfig` will read all the valid objects in the config.
A valid object is defined this way: 
```
{
  id: string, required 
  readPolicies: array that includes only velo rules
  readPolicies: array that includes only velo rules
}
```

`AuthorizationConfigReader.validate` will return that the config is valid if it's include `collectionLevelConfig` property, which is an array of valid objects as I described above.
