### PR TITLE
patch generate _id

### DIFF
--- a/packages/velo-external-db-core/lib/converters/item_transformer.js
+++ b/packages/velo-external-db-core/lib/converters/item_transformer.js
@@ -37,7 +37,7 @@ class ItemTransformer {
                 }
                 return 0  // default for number is 0 
             case 'text':
-                return f.isPrimary ? uuidv4() : ''
+                return f.isPrimary || f.field ==='_id' ? uuidv4() : ''
             case 'datetime':
                 return dateTimeProvider.currentDateTime()
             case 'boolean':

--- a/packages/velo-external-db-core/lib/converters/item_transformer.spec.js
+++ b/packages/velo-external-db-core/lib/converters/item_transformer.spec.js
@@ -17,6 +17,10 @@ describe('Item Transformer', () => {
             expect(validate(env.itemTransformer.defaultValueFor( { type: 'text', isPrimary: true } ), 4)).toBeTruthy()
         })
         
+        test('default value for _id field is a random uuid v4', async() => {
+            expect(validate(env.itemTransformer.defaultValueFor( { type: 'text', field: '_id' } ), 4)).toBeTruthy()
+        })
+        
         test('default value boolean field is false', async() => {
             expect(env.itemTransformer.defaultValueFor( { type: 'boolean' } )).toBeFalsy()
         })


### PR DESCRIPTION
fix #192 
We used `isPrimary` property to decide whether generate uuid or not.
We expect to receive this `isPrimary` property from `schemaProvider` but for now there is no implementation that returns that prop. 
