### PR TITLE
Gen js refactor 

### DIFF
--- a/packages/external-db-config/lib/service/config_reader.spec.js
+++ b/packages/external-db-config/lib/service/config_reader.spec.js
@@ -1,7 +1,8 @@
 const ConfigReader = require('./config_reader')
-const { Uninitialized, gen } = require('test-commons')
+const { Uninitialized } = require('test-commons')
 const driver = require('../../test/drivers/external_db_config_test_support')
 const matchers = require('./config_reader_matchers')
+const gen = require('../../test/gen')
 const Chance = require('chance')
 const chance = new Chance()
 

--- a/packages/external-db-config/test/gen.js
+++ b/packages/external-db-config/test/gen.js
@@ -1,0 +1,12 @@
+const Chance = require('chance')
+const chance = Chance()
+
+const randomConfig = () => ({
+    host: chance.url(),
+    user: chance.first(),
+    password: chance.guid(),
+    secretKey: chance.guid(),
+    db: chance.word(),
+})
+
+module.exports = { randomConfig }

--- a/packages/external-db-dynamodb/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-dynamodb/lib/sql_filter_transformer.spec.js
@@ -2,6 +2,7 @@ const FilterParser = require('./sql_filter_transformer')
 const { Uninitialized, gen } = require('test-commons')
 const { InvalidQuery } = require('velo-external-db-commons').errors
 const { AdapterOperators } = require('velo-external-db-commons')
+const { idFilter } = require('../tests/gen')
 const each = require('jest-each').default
 const Chance = require('chance')
 const chance = Chance()
@@ -266,7 +267,7 @@ describe('Sql Parser', () => {
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
 
         ctx.filter = gen.randomWrappedFilter()
-        ctx.idFilter = gen.idFilter()
+        ctx.idFilter = idFilter()
         ctx.anotherFilter = gen.randomWrappedFilter()
     })
 

--- a/packages/external-db-dynamodb/tests/gen.js
+++ b/packages/external-db-dynamodb/tests/gen.js
@@ -1,0 +1,24 @@
+
+
+const Chance = require('chance')
+
+const {  AdapterOperators } = require('velo-external-db-commons')
+const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_contains } = AdapterOperators 
+
+const chance = Chance()
+
+
+const randomAdapterOperator = () => ( chance.pickone([ne, lt, lte, gt, gte, include, eq, string_contains, string_begins, string_ends]) )
+
+
+const idFilter = () => {
+    const operator = randomAdapterOperator()
+    const value = operator === '$hasSome' ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
+    return {
+        fieldName: '_id',
+        operator,
+        value
+    }
+}
+
+module.exports = { idFilter }

--- a/packages/test-commons/lib/gen.js
+++ b/packages/test-commons/lib/gen.js
@@ -43,10 +43,10 @@ const randomElementsFromArray = (arr) => {
 }
 
 const randomCollectionName = () => chance.word({ length: 5 })
+
 const randomCollections = () => randomArrayOf( randomCollectionName )
 
 const randomFieldName = () => chance.word({ length: 5 })
-
 
 const randomEntity = (columns) => {
     const entity = {
@@ -68,34 +68,6 @@ const veloDate = () => ( { $date: newDate().toISOString() } )
 
 const randomObjectFromArray = (array) => array[chance.integer({ min: 0, max: array.length - 1 })]
 
-const randomKeyObject = (obj) => {
-    const objectKeys = Object.keys(obj)
-    const selectedKey = objectKeys[Math.floor(Math.random() * objectKeys.length)]
-    return selectedKey
-}
-
-const deleteRandomKeyObject = (obj) => {
-    const deletedKey = randomKeyObject(obj)
-    delete obj[deletedKey]
-    return { deletedKey, newObject: obj }
-}
-
-const clearRandomKeyObject = (obj) => {
-    const newObject = { ...obj }
-    const clearedKey = randomKeyObject(newObject)
-    newObject[clearedKey] = ''
-    return { clearedKey, newObject }
-}
-
-
-const randomConfig = () => ({
-    host: chance.url(),
-    user: chance.first(),
-    password: chance.guid(),
-    secretKey: chance.guid(),
-    db: chance.word(),
-})
-
 const randomAdapterOperator = () => ( chance.pickone([ne, lt, lte, gt, gte, include, eq, string_contains, string_begins, string_ends]) )
 
 const randomWrappedFilter = () => {
@@ -110,10 +82,8 @@ const randomWrappedFilter = () => {
 }
 
 module.exports = { randomEntities, randomEntity, veloDate, randomObject, 
-                   randomCollectionName, randomObjectFromArray,
-                   randomCollections, randomKeyObject, deleteRandomKeyObject, clearRandomKeyObject, randomConfig,
+                   randomCollectionName, randomObjectFromArray, randomCollections,
                    randomFieldName, randomAdapterOperator, randomWrappedFilter,
-                   randomArrayOf,
-                   randomElementsFromArray }
+                   randomArrayOf, randomElementsFromArray }
 
 

--- a/packages/test-commons/lib/gen.js
+++ b/packages/test-commons/lib/gen.js
@@ -1,7 +1,6 @@
 const Chance = require('chance')
-const { SystemFields, AllSchemaOperations } = require('velo-external-db-commons')
-const { AdapterOperators } = require('../../velo-external-db-core/node_modules/velo-external-db-commons/lib')
-const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_contains } = AdapterOperators //TODO: extract
+const {  AdapterOperators } = require('velo-external-db-commons')
+const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_contains } = AdapterOperators 
 
 const chance = Chance()
 
@@ -19,15 +18,6 @@ const randomEntities = (columns) => {
     const arr = []
     for (let i = 0; i < num; i++) {
         arr.push(randomEntity(columns))
-    }
-    return arr
-}
-
-const randomDbEntities = (columns) => {
-    const num = chance.natural({ min: 2, max: 20 })
-    const arr = []
-    for (let i = 0; i < num; i++) {
-        arr.push(randomDbEntity(columns))
     }
     return arr
 }
@@ -57,28 +47,6 @@ const randomCollections = () => randomArrayOf( randomCollectionName )
 
 const randomFieldName = () => chance.word({ length: 5 })
 
-const randomDbField = () => ( { field: chance.word(), type: randomWixDataType(), subtype: chance.word(), isPrimary: chance.bool() } )
-
-const randomDbFields = () => randomArrayOf( randomDbField )
-
-const systemFieldsWith = fields => {
-    const systemFields = SystemFields.map(({ name, type, subtype, isPrimary }) => ({ field: name, type, subtype, isPrimary }))
-    return fields.reduce((pV, cV) =>
-        [...pV, 
-        {
-            field: cV.name,
-            type: cV.type,
-            subtype: cV.subtype,
-            isPrimary: cV.isPrimary
-        }]
-        , systemFields)
-}
-
-const randomColumn = () => ( { name: chance.word(), type: 'text', subtype: 'string', precision: '256', isPrimary: false } )
-const randomNumberColumns = () => {
-    return [ { name: chance.word(), type: 'number', subtype: 'int', isPrimary: false },
-             { name: chance.word(), type: 'number', subtype: 'decimal', precision: '10,2', isPrimary: false } ]
-}
 
 const randomEntity = (columns) => {
     const entity = {
@@ -96,85 +64,7 @@ const randomEntity = (columns) => {
     return entity
 }
 
-const randomDbEntity = (columns) => {
-    const entity = {
-        _id: chance.guid(),
-        _createdDate: newDate(),
-        _updatedDate: newDate(),
-        _owner: chance.guid(),
-    }
-
-    const _columns = columns || []
-
-    _columns.forEach(column => entity[column] = chance.word())
-
-    return entity
-}
-
-const randomNumberDbEntity = (columns) => {
-    const entity = {
-        _id: chance.guid(),
-        _createdDate: newDate(),
-        _updatedDate: newDate(),
-        _owner: chance.guid(),
-    }
-
-    const _columns = columns || []
-
-    _columns.forEach(column => {
-        if (column.type === 'number' && column.subtype === 'int') {
-            entity[column.name] = chance.integer({ min: 0, max: 10000 })
-        } else if (column.type === 'number' && column.subtype === 'decimal') {
-            entity[column.name] = chance.floating({ min: 0, max: 10000, fixed: 2 })
-        }
-    })
-
-    return entity
-}
-
-
-const randomFilter = () => {
-    const op = randomOperator()
-    const fieldName = chance.word()
-    const value = op === '$hasSome' ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
-    return {
-        [fieldName]: { [op]: value } 
-    }
-}
-
-const randomWrappedFilter = () => {
-    const operator = randomAdapterOperator()
-    const fieldName = chance.word()
-    const value = operator === AdapterOperators.include ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
-    return {
-        fieldName,
-        operator,
-        value
-    }
-}
-
-const idFilter = () => {
-    const operator = randomAdapterOperator()
-    const value = operator === '$hasSome' ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
-    return {
-        fieldName: '_id',
-        operator,
-        value
-    }
-}
-
-const randomOperator = () => (chance.pickone(['$ne', '$lt', '$lte', '$gt', '$gte', '$hasSome', '$eq', '$contains', '$startsWith', '$endsWith']))
-
-const randomAdapterOperator = () => ( chance.pickone([ne, lt, lte, gt, gte, include, eq, string_contains, string_begins, string_ends]) )
-
 const veloDate = () => ( { $date: newDate().toISOString() } )
-
-const randomDb = () => ( { id: randomCollectionName(),
-                           fields: randomDbFields() })
-
-const randomDbs = () => randomArrayOf( randomDb )
-
-const randomDbsWithIdColumn = () => randomDbs().map(i => ({ ...i, fields: [ ...i.fields, { field: '_id', type: 'text' }] }))
 
 const randomObjectFromArray = (array) => array[chance.integer({ min: 0, max: array.length - 1 })]
 
@@ -206,25 +96,24 @@ const randomConfig = () => ({
     db: chance.word(),
 })
 
+const randomAdapterOperator = () => ( chance.pickone([ne, lt, lte, gt, gte, include, eq, string_contains, string_begins, string_ends]) )
 
-const randomWixType = () => randomObjectFromArray(['number', 'text', 'boolean', 'url', 'datetime', 'object'])
+const randomWrappedFilter = () => {
+    const operator = randomAdapterOperator()
+    const fieldName = chance.word()
+    const value = operator === AdapterOperators.include ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
+    return {
+        fieldName,
+        operator,
+        value
+    }
+}
 
-const invalidOperatorForType = (validOperators) => randomObjectFromArray (
-                                                                Object.values(AdapterOperators).filter(x => !validOperators.includes(x))
-                                                            )
-
-const randomSchemaOperation = () => (chance.pickone(AllSchemaOperations))
-
-const randomSchemaOperations = () => randomElementsFromArray(AllSchemaOperations)
-
-const randomWixDataType = () => chance.pickone(['number', 'text', 'boolean', 'url', 'datetime', 'image', 'object' ])
-
-
-module.exports = { randomEntities, randomEntity, randomFilter, idFilter, veloDate, randomObject, randomDbs,
-                   randomDbEntity, randomDbEntities, randomColumn, randomCollectionName, randomNumberDbEntity, randomObjectFromArray,
-                   randomCollections, randomNumberColumns, randomKeyObject, deleteRandomKeyObject, clearRandomKeyObject, randomConfig,
-                   systemFieldsWith, randomFieldName, randomOperator, randomAdapterOperator, randomWrappedFilter, randomWixType,
-                   invalidOperatorForType, randomSchemaOperation, randomSchemaOperations, randomDbsWithIdColumn, randomArrayOf,
+module.exports = { randomEntities, randomEntity, veloDate, randomObject, 
+                   randomCollectionName, randomObjectFromArray,
+                   randomCollections, randomKeyObject, deleteRandomKeyObject, clearRandomKeyObject, randomConfig,
+                   randomFieldName, randomAdapterOperator, randomWrappedFilter,
+                   randomArrayOf,
                    randomElementsFromArray }
 
 

--- a/packages/velo-external-db-core/lib/converters/filter_transformer.spec.js
+++ b/packages/velo-external-db-core/lib/converters/filter_transformer.spec.js
@@ -1,5 +1,5 @@
 const { Uninitialized } = require('test-commons')
-const gen2 = require('../../test/gen')
+const gen = require('../../test/gen')
 const FilterTransformer = require('./filter_transformer')
 const { EmptyFilter } = require('./utils')
 const Chance = require('chance')
@@ -146,11 +146,11 @@ describe('Filter Transformer', () => {
     }
 
     beforeEach(() => {
-        ctx.filter = gen2.randomFilter()
-        ctx.anotherFilter = gen2.randomFilter()
+        ctx.filter = gen.randomFilter()
+        ctx.anotherFilter = gen.randomFilter()
         ctx.fieldName = chance.word()
         ctx.fieldValue = chance.word()
-        ctx.operator = gen2.randomOperator()
+        ctx.operator = gen.randomOperator()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
     })
 })

--- a/packages/velo-external-db-core/lib/converters/filter_transformer.spec.js
+++ b/packages/velo-external-db-core/lib/converters/filter_transformer.spec.js
@@ -1,4 +1,5 @@
-const { Uninitialized, gen } = require('test-commons')
+const { Uninitialized } = require('test-commons')
+const gen2 = require('../../test/gen')
 const FilterTransformer = require('./filter_transformer')
 const { EMPTY_FILTER } = require('./utils')
 const Chance = require('chance')
@@ -145,11 +146,12 @@ describe('Filter Transformer', () => {
     }
 
     beforeEach(() => {
-        ctx.filter = gen.randomFilter()
-        ctx.anotherFilter = gen.randomFilter()
+        ctx.filter = gen2.randomFilter()
+        ctx.anotherFilter = gen2.randomFilter()
         ctx.fieldName = chance.word()
         ctx.fieldValue = chance.word()
-        ctx.operator = gen.randomOperator()
+        ctx.operator = gen2.randomOperator()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
     })
 })
+

--- a/packages/velo-external-db-core/lib/converters/query_validator.spec.js
+++ b/packages/velo-external-db-core/lib/converters/query_validator.spec.js
@@ -1,5 +1,6 @@
 const { InvalidQuery } = require('velo-external-db-commons').errors
-const { Uninitialized, gen } = require('test-commons')
+const { Uninitialized } = require('test-commons')
+const gen = require('../../test/gen')
 const { EMPTY_FILTER } = require ('../converters/utils')
 const { queryAdapterOperatorsFor } = require ('./query_validator_utils')
 const QueryValidator = require ('./query_validator')

--- a/packages/velo-external-db-core/lib/converters/query_validator_utils.spec.js
+++ b/packages/velo-external-db-core/lib/converters/query_validator_utils.spec.js
@@ -3,7 +3,7 @@ const { extractFieldsAndOperators, queryAdapterOperatorsFor } = require ('./quer
 const { AdapterOperators } = require('velo-external-db-commons')
 const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_contains, urlized, and } = AdapterOperators
 const { EmptyFilter } = require('./utils')
-const gen2 = require('../../test/gen')
+const gen = require('../../test/gen')
 const Chance = require('chance')
 const chance = Chance()
 
@@ -79,7 +79,7 @@ describe('Query Validator utils spec', () => {
         ctx.fieldName = chance.word()
         ctx.anotherFieldName = chance.word()
         ctx.value = chance.word()
-        ctx.operator = gen2.randomOperator()
-        ctx.anotherOperator = gen2.randomOperator()
+        ctx.operator = gen.randomOperator()
+        ctx.anotherOperator = gen.randomOperator()
     })
 })

--- a/packages/velo-external-db-core/lib/converters/query_validator_utils.spec.js
+++ b/packages/velo-external-db-core/lib/converters/query_validator_utils.spec.js
@@ -1,8 +1,9 @@
-const { Uninitialized, gen } = require('test-commons')
+const { Uninitialized } = require('test-commons')
 const { extractFieldsAndOperators, queryAdapterOperatorsFor } = require ('./query_validator_utils')
 const { AdapterOperators } = require('velo-external-db-commons')
 const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_contains, urlized, and } = AdapterOperators
 const { EMPTY_FILTER } = require('./utils')
+const gen2 = require('../../test/gen')
 const Chance = require('chance')
 const chance = Chance()
 
@@ -78,7 +79,7 @@ describe('Query Validator utils spec', () => {
         ctx.fieldName = chance.word()
         ctx.anotherFieldName = chance.word()
         ctx.value = chance.word()
-        ctx.operator = gen.randomOperator()
-        ctx.anotherOperator = gen.randomOperator()
+        ctx.operator = gen2.randomOperator()
+        ctx.anotherOperator = gen2.randomOperator()
     })
 })

--- a/packages/velo-external-db-core/lib/service/schema.spec.js
+++ b/packages/velo-external-db-core/lib/service/schema.spec.js
@@ -5,7 +5,7 @@ const { Uninitialized } = require('test-commons')
 const driver = require('../../test/drivers/schema_provider_test_support')
 const schema = require('../../test/drivers/schema_information_test_support')
 const matchers = require('../../test/drivers/schema_matchers')
-const gen2 = require('../../test/gen')
+const gen = require('../../test/gen')
 const { schemasListFor, schemaHeadersListFor, schemasWithReadOnlyCapabilitiesFor  } = matchers
 const chance = Chance()
 
@@ -88,12 +88,12 @@ describe('Schema Service', () => {
         driver.reset()
         schema.reset()
 
-        ctx.dbsWithoutIdColumn = gen2.randomDbs()
-        ctx.dbsWithIdColumn = gen2.randomDbsWithIdColumn()
+        ctx.dbsWithoutIdColumn = gen.randomDbs()
+        ctx.dbsWithIdColumn = gen.randomDbsWithIdColumn()
 
-        ctx.collections = gen2.randomCollections()
-        ctx.collectionName = gen2.randomCollectionName()
-        ctx.column = gen2.randomColumn()
+        ctx.collections = gen.randomCollections()
+        ctx.collectionName = gen.randomCollectionName()
+        ctx.column = gen.randomColumn()
 
         ctx.invalidOperations = [chance.word(), chance.word()]
         

--- a/packages/velo-external-db-core/lib/service/schema.spec.js
+++ b/packages/velo-external-db-core/lib/service/schema.spec.js
@@ -1,10 +1,11 @@
 const Chance = require('chance')
 const SchemaService = require('./schema')
 const { AllSchemaOperations, errors } = require('velo-external-db-commons')
-const { Uninitialized, gen } = require('test-commons')
+const { Uninitialized } = require('test-commons')
 const driver = require('../../test/drivers/schema_provider_test_support')
 const schema = require('../../test/drivers/schema_information_test_support')
 const matchers = require('../../test/drivers/schema_matchers')
+const gen2 = require('../../test/gen')
 const { schemasListFor, schemaHeadersListFor, schemasWithReadOnlyCapabilitiesFor  } = matchers
 const chance = Chance()
 
@@ -87,12 +88,12 @@ describe('Schema Service', () => {
         driver.reset()
         schema.reset()
 
-        ctx.dbsWithoutIdColumn = gen.randomDbs()
-        ctx.dbsWithIdColumn = gen.randomDbsWithIdColumn()
+        ctx.dbsWithoutIdColumn = gen2.randomDbs()
+        ctx.dbsWithIdColumn = gen2.randomDbsWithIdColumn()
 
-        ctx.collections = gen.randomCollections()
-        ctx.collectionName = gen.randomCollectionName()
-        ctx.column = gen.randomColumn()
+        ctx.collections = gen2.randomCollections()
+        ctx.collectionName = gen2.randomCollectionName()
+        ctx.column = gen2.randomColumn()
 
         ctx.invalidOperations = [chance.word(), chance.word()]
         

--- a/packages/velo-external-db-core/lib/service/schema_information.spec.js
+++ b/packages/velo-external-db-core/lib/service/schema_information.spec.js
@@ -1,7 +1,7 @@
 const { Uninitialized } = require('test-commons')
 const SchemaInformation = require('./schema_information')
 const driver = require('../../test/drivers/schema_provider_test_support')
-const gen2 = require('../../test/gen')
+const gen = require('../../test/gen')
 const { CollectionDoesNotExists } = require('velo-external-db-commons').errors
 
 describe('Schema Information Service', () => {
@@ -61,7 +61,7 @@ describe('Schema Information Service', () => {
         driver.reset()
         env.schemaInformation.clear()
 
-        ctx.dbs = gen2.randomDbs()
-        ctx.collectionName = gen2.randomCollectionName()
+        ctx.dbs = gen.randomDbs()
+        ctx.collectionName = gen.randomCollectionName()
     })
 })

--- a/packages/velo-external-db-core/lib/service/schema_information.spec.js
+++ b/packages/velo-external-db-core/lib/service/schema_information.spec.js
@@ -1,6 +1,7 @@
-const { Uninitialized, gen } = require('test-commons')
+const { Uninitialized } = require('test-commons')
 const SchemaInformation = require('./schema_information')
 const driver = require('../../test/drivers/schema_provider_test_support')
+const gen2 = require('../../test/gen')
 const { CollectionDoesNotExists } = require('velo-external-db-commons').errors
 
 describe('Schema Information Service', () => {
@@ -60,7 +61,7 @@ describe('Schema Information Service', () => {
         driver.reset()
         env.schemaInformation.clear()
 
-        ctx.dbs = gen.randomDbs()
-        ctx.collectionName = gen.randomCollectionName()
+        ctx.dbs = gen2.randomDbs()
+        ctx.collectionName = gen2.randomCollectionName()
     })
 })

--- a/packages/velo-external-db-core/test/gen.js
+++ b/packages/velo-external-db-core/test/gen.js
@@ -1,0 +1,54 @@
+const Chance = require('chance')
+const { AdapterOperators } = require('velo-external-db-commons')
+
+const chance = Chance()
+
+const invalidOperatorForType = (validOperators) => randomObjectFromArray (
+    Object.values(AdapterOperators).filter(x => !validOperators.includes(x))
+)
+
+const randomObjectFromArray = (array) => array[chance.integer({ min: 0, max: array.length - 1 })]
+
+const randomColumn = () => ( { name: chance.word(), type: 'text', subtype: 'string', precision: '256', isPrimary: false } )
+
+
+const randomWixType = () => randomObjectFromArray(['number', 'text', 'boolean', 'url', 'datetime', 'object'])
+
+const randomOperator = () => (chance.pickone(['$ne', '$lt', '$lte', '$gt', '$gte', '$hasSome', '$eq', '$contains', '$startsWith', '$endsWith']))
+
+const randomFilter = () => {
+    const op = randomOperator()
+    const fieldName = chance.word()
+    const value = op === '$hasSome' ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
+    return {
+        [fieldName]: { [op]: value } 
+    }
+}
+
+const randomArrayOf = (gen) => {
+    const arr = []
+    const num = chance.natural({ min: 2, max: 20 })
+    for (let i = 0; i < num; i++) {
+        arr.push(gen())
+    }
+    return arr
+}
+
+const randomCollectionName = () => chance.word({ length: 5 })
+
+const randomCollections = () => randomArrayOf( randomCollectionName )
+
+const randomWixDataType = () => chance.pickone(['number', 'text', 'boolean', 'url', 'datetime', 'image', 'object' ])
+
+const randomDbField = () => ( { field: chance.word(), type: randomWixDataType(), subtype: chance.word(), isPrimary: chance.bool() } )
+
+const randomDbFields = () => randomArrayOf( randomDbField )
+
+const randomDb = () => ( { id: randomCollectionName(), fields: randomDbFields() })
+
+const randomDbs = () => randomArrayOf( randomDb )
+
+const randomDbsWithIdColumn = () => randomDbs().map(i => ({ ...i, fields: [ ...i.fields, { field: '_id', type: 'text' }] }))
+
+
+module.exports = { randomOperator, randomFilter, randomWixType, invalidOperatorForType, randomObjectFromArray, randomColumn, randomDb, randomDbsWithIdColumn, randomCollections, randomDbs, randomCollectionName }

--- a/packages/velo-external-db/lib/health/app_info.spec.js
+++ b/packages/velo-external-db/lib/health/app_info.spec.js
@@ -1,4 +1,4 @@
-const { Uninitialized, gen } = require('test-commons')
+const { Uninitialized, gen: genCommon } = require('test-commons')
 const { appInfoFor, maskSensitiveData } = require ('./app_info')
 const driver = require('../../test/drivers/app_info_test_support')
 
@@ -40,7 +40,7 @@ describe('App info Function', () => {
 
     beforeEach(() => {
         driver.reset()
-        ctx.config = gen.randomConfig()
+        ctx.config = genCommon.randomObject()
     })
 
 

--- a/packages/velo-external-db/test/drivers/app_info_test_support.js
+++ b/packages/velo-external-db/test/drivers/app_info_test_support.js
@@ -1,4 +1,4 @@
-const { gen } = require('test-commons')
+const gen = require('../gen')
 const { when } = require('jest-when')
 
 const operationService = {

--- a/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -5,6 +5,7 @@ const matchers = require('../drivers/schema_api_rest_matchers')
 const { authAdmin, authOwner, authVisitor } = require('../drivers/auth_test_support')
 const authorization = require ('../drivers/authorization_test_support')
 const Chance = require('chance')
+const gen2 = require('../gen')
 const each = require('jest-each').default
 const { initApp, teardownApp, dbTeardown, testSuits } = require('../resources/e2e_resources')
 
@@ -179,15 +180,15 @@ describe('Velo External DB Data REST API',  () => {
     afterAll(async() => await teardownApp())
 
     beforeEach(async() => {
-        ctx.collectionName = gen.randomCollectionName()
-        ctx.column = gen.randomColumn()
-        ctx.numberColumns = gen.randomNumberColumns()
+        ctx.collectionName = gen2.randomCollectionName()
+        ctx.column = gen2. randomColumn()
+        ctx.numberColumns = gen2.randomNumberColumns()
         ctx.item = gen.randomEntity([ctx.column.name])
         ctx.items = Array.from({ length: 10 }, () => gen.randomEntity([ctx.column.name]))
         ctx.modifiedItems = ctx.items.map(i => ( { ...i, [ctx.column.name]: chance.word() } ) )
         ctx.modifiedItem = { ...ctx.item, [ctx.column.name]: chance.word() }
         ctx.anotherItem = gen.randomEntity([ctx.column.name])
-        ctx.numberItem = gen.randomNumberDbEntity(ctx.numberColumns)
-        ctx.anotherNumberItem = gen.randomNumberDbEntity(ctx.numberColumns)
+        ctx.numberItem = gen2.randomNumberDbEntity(ctx.numberColumns)
+        ctx.anotherNumberItem = gen2.randomNumberDbEntity(ctx.numberColumns)
     })
 })

--- a/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -1,12 +1,12 @@
-const { Uninitialized, gen } = require('test-commons')
+const { Uninitialized, gen: genCommon } = require('test-commons')
 const { testIfSchemaSupportsUpdateImmediately, testIfSchemaSupportsDeleteImmediately, testIfSchemaSupportsTruncate, testIfSchemaSupportsAggregate, testIfSchemaSupportsFindWithSort } = require('test-commons')
+const gen = require('../gen')
 const schema = require('../drivers/schema_api_rest_test_support')
 const data = require('../drivers/data_api_rest_test_support')
 const matchers = require('../drivers/schema_api_rest_matchers')
 const { authAdmin, authOwner, authVisitor } = require('../drivers/auth_test_support')
 const authorization = require ('../drivers/authorization_test_support')
 const Chance = require('chance')
-const gen2 = require('../gen')
 const each = require('jest-each').default
 const { env, initApp, teardownApp, dbTeardown, testSuits } = require('../resources/e2e_resources')
 
@@ -168,15 +168,15 @@ describe('Velo External DB Data REST API',  () => {
     afterAll(async() => await teardownApp())
 
     beforeEach(async() => {
-        ctx.collectionName = gen2.randomCollectionName()
-        ctx.column = gen2. randomColumn()
-        ctx.numberColumns = gen2.randomNumberColumns()
-        ctx.item = gen.randomEntity([ctx.column.name])
-        ctx.items = Array.from({ length: 10 }, () => gen.randomEntity([ctx.column.name]))
+        ctx.collectionName = gen.randomCollectionName()
+        ctx.column = gen.randomColumn()
+        ctx.numberColumns = gen.randomNumberColumns()
+        ctx.item = genCommon.randomEntity([ctx.column.name])
+        ctx.items = Array.from({ length: 10 }, () => genCommon.randomEntity([ctx.column.name]))
         ctx.modifiedItems = ctx.items.map(i => ( { ...i, [ctx.column.name]: chance.word() } ) )
         ctx.modifiedItem = { ...ctx.item, [ctx.column.name]: chance.word() }
-        ctx.anotherItem = gen.randomEntity([ctx.column.name])
-        ctx.numberItem = gen2.randomNumberDbEntity(ctx.numberColumns)
-        ctx.anotherNumberItem = gen2.randomNumberDbEntity(ctx.numberColumns)
+        ctx.anotherItem = genCommon.randomEntity([ctx.column.name])
+        ctx.numberItem = gen.randomNumberDbEntity(ctx.numberColumns)
+        ctx.anotherNumberItem = gen.randomNumberDbEntity(ctx.numberColumns)
     })
 })

--- a/packages/velo-external-db/test/e2e/app_schema.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_schema.e2e.spec.js
@@ -1,8 +1,8 @@
-const { Uninitialized, gen, shouldNotRunOn } = require('test-commons')
+const { Uninitialized, gen: genCommon, shouldNotRunOn } = require('test-commons')
 const schema = require('../drivers/schema_api_rest_test_support')
 const matchers = require('../drivers/schema_api_rest_matchers')
 const { authOwner } = require('../drivers/auth_test_support')
-const gen2 = require('../gen')
+const gen = require('../gen')
 const Chance = require('chance')
 const each = require('jest-each').default
 const { initApp, teardownApp, dbTeardown, testSuits } = require('../resources/e2e_resources')
@@ -83,16 +83,16 @@ describe('Velo External DB Schema REST API',  () => {
     afterAll(async() => await teardownApp())
 
     beforeEach(async() => {
-        ctx.collectionName = gen2.randomCollectionName()
-        ctx.column = gen2.randomColumn()
-        ctx.numberColumns = gen2.randomNumberColumns()
-        ctx.item = gen.randomEntity([ctx.column.name])
-        ctx.items = Array.from({ length: 10 }, () => gen.randomEntity([ctx.column.name]))
+        ctx.collectionName = gen.randomCollectionName()
+        ctx.column = gen.randomColumn()
+        ctx.numberColumns = gen.randomNumberColumns()
+        ctx.item = genCommon.randomEntity([ctx.column.name])
+        ctx.items = Array.from({ length: 10 }, () => genCommon.randomEntity([ctx.column.name]))
         ctx.modifiedItems = ctx.items.map(i => ( { ...i, [ctx.column.name]: chance.word() } ) )
         ctx.modifiedItem = { ...ctx.item, [ctx.column.name]: chance.word() }
-        ctx.anotherItem = gen.randomEntity([ctx.column.name])
-        ctx.numberItem = gen2.randomNumberDbEntity(ctx.numberColumns)
-        ctx.anotherNumberItem = gen2.randomNumberDbEntity(ctx.numberColumns)
+        ctx.anotherItem = genCommon.randomEntity([ctx.column.name])
+        ctx.numberItem = gen.randomNumberDbEntity(ctx.numberColumns)
+        ctx.anotherNumberItem = gen.randomNumberDbEntity(ctx.numberColumns)
     })
 
 })

--- a/packages/velo-external-db/test/e2e/app_schema.e2e.spec.js
+++ b/packages/velo-external-db/test/e2e/app_schema.e2e.spec.js
@@ -2,6 +2,7 @@ const { Uninitialized, gen, shouldNotRunOn } = require('test-commons')
 const schema = require('../drivers/schema_api_rest_test_support')
 const matchers = require('../drivers/schema_api_rest_matchers')
 const { authOwner } = require('../drivers/auth_test_support')
+const gen2 = require('../gen')
 const Chance = require('chance')
 const each = require('jest-each').default
 const { initApp, teardownApp, dbTeardown, testSuits } = require('../resources/e2e_resources')
@@ -82,16 +83,16 @@ describe('Velo External DB Schema REST API',  () => {
     afterAll(async() => await teardownApp())
 
     beforeEach(async() => {
-        ctx.collectionName = gen.randomCollectionName()
-        ctx.column = gen.randomColumn()
-        ctx.numberColumns = gen.randomNumberColumns()
+        ctx.collectionName = gen2.randomCollectionName()
+        ctx.column = gen2.randomColumn()
+        ctx.numberColumns = gen2.randomNumberColumns()
         ctx.item = gen.randomEntity([ctx.column.name])
         ctx.items = Array.from({ length: 10 }, () => gen.randomEntity([ctx.column.name]))
         ctx.modifiedItems = ctx.items.map(i => ( { ...i, [ctx.column.name]: chance.word() } ) )
         ctx.modifiedItem = { ...ctx.item, [ctx.column.name]: chance.word() }
         ctx.anotherItem = gen.randomEntity([ctx.column.name])
-        ctx.numberItem = gen.randomNumberDbEntity(ctx.numberColumns)
-        ctx.anotherNumberItem = gen.randomNumberDbEntity(ctx.numberColumns)
+        ctx.numberItem = gen2.randomNumberDbEntity(ctx.numberColumns)
+        ctx.anotherNumberItem = gen2.randomNumberDbEntity(ctx.numberColumns)
     })
 
 })

--- a/packages/velo-external-db/test/gen.js
+++ b/packages/velo-external-db/test/gen.js
@@ -80,4 +80,19 @@ const systemFieldsWith = fields => {
         , systemFields)
 }
 
-module.exports = { randomDbEntities, randomDbEntity, randomNumberDbEntity, randomNumberColumns, randomColumn, randomCollectionName, systemFieldsWith }
+
+const randomKeyObject = (obj) => {
+    const objectKeys = Object.keys(obj)
+    const selectedKey = objectKeys[Math.floor(Math.random() * objectKeys.length)]
+    return selectedKey
+}
+
+const deleteRandomKeyObject = (obj) => {
+    const deletedKey = randomKeyObject(obj)
+    delete obj[deletedKey]
+    return { deletedKey, newObject: obj }
+}
+
+
+
+module.exports = { randomDbEntities, randomDbEntity, randomNumberDbEntity, randomNumberColumns, randomColumn, randomCollectionName, systemFieldsWith, deleteRandomKeyObject }

--- a/packages/velo-external-db/test/gen.js
+++ b/packages/velo-external-db/test/gen.js
@@ -1,0 +1,83 @@
+
+const { SystemFields } = require('velo-external-db-commons')
+const Chance = require('chance')
+
+
+const chance = Chance()
+
+const newDate = () => {
+    const d = new Date()
+    d.setMilliseconds(0)
+    return d
+}
+
+const randomDbEntity = (columns) => {
+    const entity = {
+        _id: chance.guid(),
+        _createdDate: newDate(),
+        _updatedDate: newDate(),
+        _owner: chance.guid(),
+    }
+
+    const _columns = columns || []
+
+    _columns.forEach(column => entity[column] = chance.word())
+
+    return entity
+}
+
+
+
+const randomDbEntities = (columns) => {
+    const num = chance.natural({ min: 2, max: 20 })
+    const arr = []
+    for (let i = 0; i < num; i++) {
+        arr.push(randomDbEntity(columns))
+    }
+    return arr
+}
+
+const randomNumberDbEntity = (columns) => {
+    const entity = {
+        _id: chance.guid(),
+        _createdDate: newDate(),
+        _updatedDate: newDate(),
+        _owner: chance.guid(),
+    }
+
+    const _columns = columns || []
+
+    _columns.forEach(column => {
+        if (column.type === 'number' && column.subtype === 'int') {
+            entity[column.name] = chance.integer({ min: 0, max: 10000 })
+        } else if (column.type === 'number' && column.subtype === 'decimal') {
+            entity[column.name] = chance.floating({ min: 0, max: 10000, fixed: 2 })
+        }
+    })
+
+    return entity
+}
+
+const randomNumberColumns = () => {
+    return [ { name: chance.word(), type: 'number', subtype: 'int', isPrimary: false },
+             { name: chance.word(), type: 'number', subtype: 'decimal', precision: '10,2', isPrimary: false } ]
+}
+
+const randomColumn = () => ( { name: chance.word(), type: 'text', subtype: 'string', precision: '256', isPrimary: false } )
+
+const randomCollectionName = () => chance.word({ length: 5 })
+
+const systemFieldsWith = fields => {
+    const systemFields = SystemFields.map(({ name, type, subtype, isPrimary }) => ({ field: name, type, subtype, isPrimary }))
+    return fields.reduce((pV, cV) =>
+        [...pV, 
+        {
+            field: cV.name,
+            type: cV.type,
+            subtype: cV.subtype,
+            isPrimary: cV.isPrimary
+        }]
+        , systemFields)
+}
+
+module.exports = { randomDbEntities, randomDbEntity, randomNumberDbEntity, randomNumberColumns, randomColumn, randomCollectionName, systemFieldsWith }

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -1,252 +1,247 @@
 const { Uninitialized, shouldNotRunOn } = require('test-commons')
-const each = require('jest-each').default
 const Chance = require('chance')
 const gen = require('../gen')
 const { env, dbTeardown, setupDb, currentDbImplementationName } = require('../resources/provider_resources')
 const { entitiesWithOwnerFieldOnly } = require ('../drivers/data_provider_matchers')
 const chance = new Chance()
 
-describe('Data API', () => {
+describe(`Data API: ${currentDbImplementationName()}`, () => {
+    beforeAll(async() => {
+        await setupDb()
+    }, 20000)
 
-    each(testSuits()).describe('%s', (name, setup) => {
-
-        beforeAll(async() => {
-            await setup()
-        }, 20000)
-
-        afterAll(async() => {
-            await dbTeardown()
-        }, 20000)
+    afterAll(async() => {
+        await dbTeardown()
+    }, 20000)
 
 
-        const givenCollectionWith = async(entities, forCollection, fields) => {
-            await env.dataProvider.insert(forCollection, entities, fields)
-        }
+    const givenCollectionWith = async(entities, forCollection, fields) => {
+        await env.dataProvider.insert(forCollection, entities, fields)
+    }
 
-        test('search with empty filter, default projection and empty order by and no data', async() => {
-            env.driver.stubEmptyFilterFor(ctx.filter)
-            env.driver.stubEmptyOrderByFor(ctx.sort)
-            env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-            await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual([])
-        })
+    test('search with empty filter, default projection and empty order by and no data', async() => {
+        env.driver.stubEmptyFilterFor(ctx.filter)
+        env.driver.stubEmptyOrderByFor(ctx.sort)
+        env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+        await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual([])
+    })
 
 
-        if (shouldNotRunOn(['DynamoDb'], name)) {
-            test('search with non empty filter, default projection will return data', async() => {
-                await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
-                env.driver.givenFilterByIdWith(ctx.entity._id, ctx.filter)
-                env.driver.stubEmptyOrderByFor(ctx.sort)
-                env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-                await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual(expect.arrayContaining([ctx.entity]))
-            })
-        
-            test('search with non empty order by, default projection will return sorted data', async() => {
-                await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
-                env.driver.stubEmptyFilterFor(ctx.filter)
-                env.driver.givenOrderByFor('_owner', ctx.sort)
-                env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-                await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual([ctx.anotherEntity, ctx.entity].sort((a, b) => (a._owner > b._owner) ? 1 : -1))
-            })
-
-            test('search with empty order, filter and default projection but with limit and skip', async() => {
-                await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
-                env.driver.stubEmptyFilterFor(ctx.filter)
-                env.driver.givenOrderByFor('_owner', ctx.sort)
-                env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-                await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, 1, 1, ctx.projection) ).resolves.toEqual([ctx.anotherEntity, ctx.entity].sort((a, b) => (a._owner < b._owner) ? 1 : -1).slice(0, 1))
-            })
-        }
-
-        if(shouldNotRunOn(['Firestore', 'Google-Sheet'], name)) {
-            test('search with projection will return the specified fields', async() => {
-                const projection = ['_owner']
-                await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
-                env.driver.stubEmptyFilterFor(ctx.filter)
-                env.driver.stubEmptyOrderByFor(ctx.sort)
-                env.driver.givenProjectionExprFor(projection)
-                await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, 0, 50, projection) ).resolves.toEqual(entitiesWithOwnerFieldOnly(ctx.entities))
-            })
-        }
-        test('count will run query', async() => {
-            await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
-            env.driver.stubEmptyFilterFor(ctx.filter)
-
-            await expect( env.dataProvider.count(ctx.collectionName, ctx.filter) ).resolves.toEqual(ctx.entities.length)
-        })
-
-        test('count will run query with filter', async() => {
+    if (shouldNotRunOn(['DynamoDb'], currentDbImplementationName())) {
+        test('search with non empty filter, default projection will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             env.driver.givenFilterByIdWith(ctx.entity._id, ctx.filter)
-
-            await expect( env.dataProvider.count(ctx.collectionName, ctx.filter) ).resolves.toEqual(1)
-        })
-
-        test('insert data into collection name and query all of it', async() => {
-            env.driver.stubEmptyFilterAndSortFor('', '')
+            env.driver.stubEmptyOrderByFor(ctx.sort)
             env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-
-            await expect( env.dataProvider.insert(ctx.collectionName, [ctx.entity], ctx.entityFields) ).resolves.toEqual(1)
-
-            await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([ctx.entity])
+            await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual(expect.arrayContaining([ctx.entity]))
         })
 
-        test('bulk insert data into collection name and query all of it', async() => {
-            env.driver.stubEmptyFilterAndSortFor('', '')
+        test('search with non empty order by, default projection will return sorted data', async() => {
+            await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
+            env.driver.stubEmptyFilterFor(ctx.filter)
+            env.driver.givenOrderByFor('_owner', ctx.sort)
             env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-
-            await expect( env.dataProvider.insert(ctx.collectionName, ctx.entities, ctx.entityFields) ).resolves.toEqual(ctx.entities.length)
-
-            await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(expect.arrayContaining(ctx.entities))
+            await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual([ctx.anotherEntity, ctx.entity].sort((a, b) => (a._owner > b._owner) ? 1 : -1))
         })
 
-        test('insert entity with number', async() => {
-            await env.schemaProvider.create(ctx.numericCollectionName, ctx.numericColumns)
-            env.driver.stubEmptyFilterAndSortFor('', '')
+        test('search with empty order, filter and default projection but with limit and skip', async() => {
+            await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
+            env.driver.stubEmptyFilterFor(ctx.filter)
+            env.driver.givenOrderByFor('_owner', ctx.sort)
             env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-
-            await expect( env.dataProvider.insert(ctx.numericCollectionName, [ctx.numberEntity], ctx.numberEntityFields)).resolves.toEqual(1)
-
-            await expect( env.dataProvider.find(ctx.numericCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([ctx.numberEntity])
-        })
-
-        if (shouldNotRunOn(['BigQuery'], name)) {
-            test('delete data from collection', async() => {
-                await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
-                env.driver.stubEmptyFilterAndSortFor('', '')
-                env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-
-                await expect( env.dataProvider.delete(ctx.collectionName, ctx.entities.map(e => e._id)) ).resolves.toEqual(ctx.entities.length)
-
-                await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([])
-            })
-        }
-
-        if (shouldNotRunOn(['BigQuery'], name)) {
-            test('allow update for single entity', async() => {
-                await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
-                env.driver.stubEmptyFilterAndSortFor('', '')
-                env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-
-                await expect( env.dataProvider.update(ctx.collectionName, [ctx.modifiedEntity]) ).resolves.toEqual(1)
-
-                await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([ctx.modifiedEntity])
+            await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, 1, 1, ctx.projection) ).resolves.toEqual([ctx.anotherEntity, ctx.entity].sort((a, b) => (a._owner < b._owner) ? 1 : -1).slice(0, 1))
         })
     }
 
-        if (shouldNotRunOn(['BigQuery'], name)) {
-            test('allow update for multiple entities', async() => {
-                await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
-                env.driver.stubEmptyFilterAndSortFor('', '')
-                env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+    if(shouldNotRunOn(['Firestore', 'Google-Sheet'], currentDbImplementationName())) {
+        test('search with projection will return the specified fields', async() => {
+            const projection = ['_owner']
+            await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
+            env.driver.stubEmptyFilterFor(ctx.filter)
+            env.driver.stubEmptyOrderByFor(ctx.sort)
+            env.driver.givenProjectionExprFor(projection)
+            await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, 0, 50, projection) ).resolves.toEqual(entitiesWithOwnerFieldOnly(ctx.entities))
+        })
+    }
+    test('count will run query', async() => {
+        await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
+        env.driver.stubEmptyFilterFor(ctx.filter)
 
-                expect( await env.dataProvider.update(ctx.collectionName, ctx.modifiedEntities) ).toEqual(ctx.modifiedEntities.length)
+        await expect( env.dataProvider.count(ctx.collectionName, ctx.filter) ).resolves.toEqual(ctx.entities.length)
+    })
 
-                expect( await env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).toEqual(expect.arrayContaining(ctx.modifiedEntities))
-            })
-        }
+    test('count will run query with filter', async() => {
+        await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
+        env.driver.givenFilterByIdWith(ctx.entity._id, ctx.filter)
 
-        // testt('if update does not have and updatable fields, do nothing', async () => {
-        //     await givenCollectionWith([ctx.entity], ctx.collectionName)
-        //     delete ctx.modifiedEntity[ctx.column.name]
-        //
-        //     expect( await env.dataProvider.update(ctx.collectionName, [ctx.modifiedEntity]) ).toEqual(0)
-        //
-        //     expect( await env.dataProvider.find(ctx.collectionName, '', '', 0, 50) ).toEqual([ctx.entity]);
-        // });
+        await expect( env.dataProvider.count(ctx.collectionName, ctx.filter) ).resolves.toEqual(1)
+    })
 
-        test('truncate will remove all data from collection', async() => {
+    test('insert data into collection name and query all of it', async() => {
+        env.driver.stubEmptyFilterAndSortFor('', '')
+        env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+
+        await expect( env.dataProvider.insert(ctx.collectionName, [ctx.entity], ctx.entityFields) ).resolves.toEqual(1)
+
+        await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([ctx.entity])
+    })
+
+    test('bulk insert data into collection name and query all of it', async() => {
+        env.driver.stubEmptyFilterAndSortFor('', '')
+        env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+
+        await expect( env.dataProvider.insert(ctx.collectionName, ctx.entities, ctx.entityFields) ).resolves.toEqual(ctx.entities.length)
+
+        await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(expect.arrayContaining(ctx.entities))
+    })
+
+    test('insert entity with number', async() => {
+        await env.schemaProvider.create(ctx.numericCollectionName, ctx.numericColumns)
+        env.driver.stubEmptyFilterAndSortFor('', '')
+        env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+
+        await expect( env.dataProvider.insert(ctx.numericCollectionName, [ctx.numberEntity], ctx.numberEntityFields)).resolves.toEqual(1)
+
+        await expect( env.dataProvider.find(ctx.numericCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([ctx.numberEntity])
+    })
+
+    if (shouldNotRunOn(['BigQuery'], currentDbImplementationName())) {
+        test('delete data from collection', async() => {
+            await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
+            env.driver.stubEmptyFilterAndSortFor('', '')
+            env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+
+            await expect( env.dataProvider.delete(ctx.collectionName, ctx.entities.map(e => e._id)) ).resolves.toEqual(ctx.entities.length)
+
+            await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([])
+        })
+    }
+
+    if (shouldNotRunOn(['BigQuery'], currentDbImplementationName())) {
+        test('allow update for single entity', async() => {
             await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
             env.driver.stubEmptyFilterAndSortFor('', '')
             env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
 
-            await env.dataProvider.truncate(ctx.collectionName)
+            await expect( env.dataProvider.update(ctx.collectionName, [ctx.modifiedEntity]) ).resolves.toEqual(1)
 
-            await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([])
+            await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([ctx.modifiedEntity])
+    })
+}
+
+    if (shouldNotRunOn(['BigQuery'], currentDbImplementationName())) {
+        test('allow update for multiple entities', async() => {
+            await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
+            env.driver.stubEmptyFilterAndSortFor('', '')
+            env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+
+            expect( await env.dataProvider.update(ctx.collectionName, ctx.modifiedEntities) ).toEqual(ctx.modifiedEntities.length)
+
+            expect( await env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).toEqual(expect.arrayContaining(ctx.modifiedEntities))
+        })
+    }
+
+    // testt('if update does not have and updatable fields, do nothing', async () => {
+    //     await givenCollectionWith([ctx.entity], ctx.collectionName)
+    //     delete ctx.modifiedEntity[ctx.column.name]
+    //
+    //     expect( await env.dataProvider.update(ctx.collectionName, [ctx.modifiedEntity]) ).toEqual(0)
+    //
+    //     expect( await env.dataProvider.find(ctx.collectionName, '', '', 0, 50) ).toEqual([ctx.entity]);
+    // });
+
+    test('truncate will remove all data from collection', async() => {
+        await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
+        env.driver.stubEmptyFilterAndSortFor('', '')
+        env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+
+        await env.dataProvider.truncate(ctx.collectionName)
+
+        await expect( env.dataProvider.find(ctx.collectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual([])
+    })
+
+    if (shouldNotRunOn(['Firestore', 'Airtable', 'DynamoDb'], currentDbImplementationName())) {
+        test('aggregate api without filter', async() => {
+            await env.schemaProvider.create(ctx.numericCollectionName, ctx.numericColumns)
+            await givenCollectionWith([ctx.numberEntity, ctx.anotherNumberEntity], ctx.numericCollectionName, ctx.numberEntityFields)
+
+            env.driver.stubEmptyFilterFor(ctx.filter)
+            env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 1)
+
+            await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual(expect.arrayContaining([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] },
+                                                          { _id: ctx.anotherNumberEntity._id, [ctx.aliasColumns[0]]: ctx.anotherNumberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.anotherNumberEntity[ctx.numericColumns[1].name] }
+            ]))
         })
 
-        if (shouldNotRunOn(['Firestore', 'Airtable', 'DynamoDb'], name)) {
-            test('aggregate api without filter', async() => {
-                await env.schemaProvider.create(ctx.numericCollectionName, ctx.numericColumns)
-                await givenCollectionWith([ctx.numberEntity, ctx.anotherNumberEntity], ctx.numericCollectionName, ctx.numberEntityFields)
-    
-                env.driver.stubEmptyFilterFor(ctx.filter)
-                env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 1)
-    
-                await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual(expect.arrayContaining([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] },
-                                                              { _id: ctx.anotherNumberEntity._id, [ctx.aliasColumns[0]]: ctx.anotherNumberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.anotherNumberEntity[ctx.numericColumns[1].name] }
-                ]))
-            })
-    
-            test('aggregate api without having', async() => {
-                await env.schemaProvider.create(ctx.numericCollectionName, ctx.numericColumns)
-                await givenCollectionWith([ctx.numberEntity, ctx.anotherNumberEntity], ctx.numericCollectionName, ctx.numberEntityFields)
-    
-                env.driver.stubEmptyFilterFor(ctx.filter)
-                env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 1)
-    
-                await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual(expect.arrayContaining([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] },
-                                                                                                                                                                { _id: ctx.anotherNumberEntity._id, [ctx.aliasColumns[0]]: ctx.anotherNumberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.anotherNumberEntity[ctx.numericColumns[1].name] }
-                ]))
-            })
-    
-            test('aggregate api with filter', async() => {
-                await env.schemaProvider.create(ctx.numericCollectionName, ctx.numericColumns)
-                await givenCollectionWith([ctx.numberEntity, ctx.anotherNumberEntity], ctx.numericCollectionName, ctx.numberEntityFields)
-    
-                env.driver.givenFilterByIdWith(ctx.numberEntity._id, ctx.filter)
-                env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 2)
-    
-                await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] }])
-            })
-        }
+        test('aggregate api without having', async() => {
+            await env.schemaProvider.create(ctx.numericCollectionName, ctx.numericColumns)
+            await givenCollectionWith([ctx.numberEntity, ctx.anotherNumberEntity], ctx.numericCollectionName, ctx.numberEntityFields)
 
-        const ctx = {
-            collectionName: Uninitialized,
-            numericCollectionName: Uninitialized,
-            filter: Uninitialized,
-            aggregation: Uninitialized,
-            sort: Uninitialized,
-            skip: Uninitialized,
-            limit: Uninitialized,
-            projection: Uninitialized,
-            column: Uninitialized,
-            numericColumns: Uninitialized,
-            aliasColumns: Uninitialized,
-            entity: Uninitialized,
-            entityFields: Uninitialized,
-            numberEntity: Uninitialized,
-            anotherNumberEntity: Uninitialized,
-            modifiedEntity: Uninitialized,
-            anotherEntity: Uninitialized,
-            entities: Uninitialized,
-            modifiedEntities: Uninitialized,
-            numberEntityFields: Uninitialized,
-        }
+            env.driver.stubEmptyFilterFor(ctx.filter)
+            env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 1)
 
-        beforeEach(async() => {
-            ctx.collectionName = gen.randomCollectionName()
-            ctx.numericCollectionName = gen.randomCollectionName()
-            ctx.column = gen.randomColumn()
-            ctx.numericColumns = gen.randomNumberColumns()
-            ctx.aliasColumns = ctx.numericColumns.map(() => chance.word())
-            ctx.filter = chance.word()
-            ctx.aggregation = { processingStep: chance.word(), postFilteringStep: chance.word() }
-            ctx.sort = chance.word()
-            ctx.skip = 0
-            ctx.limit = 10
-            ctx.projection = chance.word()
-
-            ctx.entity = gen.randomDbEntity([ctx.column.name])
-            ctx.entityFields = Object.keys(ctx.entity).map(f => ({ field: f }))
-            ctx.modifiedEntity = { ...ctx.entity, [ctx.column.name]: chance.word() }
-            ctx.anotherEntity = gen.randomDbEntity([ctx.column.name])
-            ctx.entities = gen.randomDbEntities([ctx.column.name])
-            ctx.modifiedEntities = ctx.entities.map(e => ( { ...e, [ctx.column.name]: chance.word() } ))
-            ctx.numberEntity = gen.randomNumberDbEntity(ctx.numericColumns)
-            ctx.numberEntityFields = gen.systemFieldsWith(ctx.numericColumns)
-            ctx.anotherNumberEntity = gen.randomNumberDbEntity(ctx.numericColumns)
-
-            await env.schemaProvider.create(ctx.collectionName, [ctx.column])
+            await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual(expect.arrayContaining([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] },
+                                                                                                                                                            { _id: ctx.anotherNumberEntity._id, [ctx.aliasColumns[0]]: ctx.anotherNumberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.anotherNumberEntity[ctx.numericColumns[1].name] }
+            ]))
         })
+
+        test('aggregate api with filter', async() => {
+            await env.schemaProvider.create(ctx.numericCollectionName, ctx.numericColumns)
+            await givenCollectionWith([ctx.numberEntity, ctx.anotherNumberEntity], ctx.numericCollectionName, ctx.numberEntityFields)
+
+            env.driver.givenFilterByIdWith(ctx.numberEntity._id, ctx.filter)
+            env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 2)
+
+            await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] }])
+        })
+    }
+
+    const ctx = {
+        collectionName: Uninitialized,
+        numericCollectionName: Uninitialized,
+        filter: Uninitialized,
+        aggregation: Uninitialized,
+        sort: Uninitialized,
+        skip: Uninitialized,
+        limit: Uninitialized,
+        projection: Uninitialized,
+        column: Uninitialized,
+        numericColumns: Uninitialized,
+        aliasColumns: Uninitialized,
+        entity: Uninitialized,
+        entityFields: Uninitialized,
+        numberEntity: Uninitialized,
+        anotherNumberEntity: Uninitialized,
+        modifiedEntity: Uninitialized,
+        anotherEntity: Uninitialized,
+        entities: Uninitialized,
+        modifiedEntities: Uninitialized,
+        numberEntityFields: Uninitialized,
+    }
+
+    beforeEach(async() => {
+        ctx.collectionName = gen.randomCollectionName()
+        ctx.numericCollectionName = gen.randomCollectionName()
+        ctx.column = gen.randomColumn()
+        ctx.numericColumns = gen.randomNumberColumns()
+        ctx.aliasColumns = ctx.numericColumns.map(() => chance.word())
+        ctx.filter = chance.word()
+        ctx.aggregation = { processingStep: chance.word(), postFilteringStep: chance.word() }
+        ctx.sort = chance.word()
+        ctx.skip = 0
+        ctx.limit = 10
+        ctx.projection = chance.word()
+
+        ctx.entity = gen.randomDbEntity([ctx.column.name])
+        ctx.entityFields = Object.keys(ctx.entity).map(f => ({ field: f }))
+        ctx.modifiedEntity = { ...ctx.entity, [ctx.column.name]: chance.word() }
+        ctx.anotherEntity = gen.randomDbEntity([ctx.column.name])
+        ctx.entities = gen.randomDbEntities([ctx.column.name])
+        ctx.modifiedEntities = ctx.entities.map(e => ( { ...e, [ctx.column.name]: chance.word() } ))
+        ctx.numberEntity = gen.randomNumberDbEntity(ctx.numericColumns)
+        ctx.numberEntityFields = gen.systemFieldsWith(ctx.numericColumns)
+        ctx.anotherNumberEntity = gen.randomNumberDbEntity(ctx.numericColumns)
+
+        await env.schemaProvider.create(ctx.collectionName, [ctx.column])
     })
 })

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -1,6 +1,7 @@
-const { Uninitialized, gen, shouldNotRunOn } = require('test-commons')
+const { Uninitialized, shouldNotRunOn } = require('test-commons')
 const each = require('jest-each').default
 const Chance = require('chance')
+const gen = require('../gen')
 const { env, testSuits, dbTeardown } = require('../resources/provider_resources')
 const { entitiesWithOwnerFieldOnly } = require ('../drivers/data_provider_matchers')
 const chance = new Chance()


### PR DESCRIPTION
As you know, `gen.js` become a long and cumbersome file, so we need to split it.

For the first step, I created some `gen.js` files for each module, and extracted from the original gen.js file functions that are used only by one module, to the `gen.js` of the module 