### PR TITLE
Change role names in collection level config

### DIFF
--- a/packages/external-db-config/lib/utils/config_utils.js
+++ b/packages/external-db-config/lib/utils/config_utils.js
@@ -6,7 +6,7 @@ const supportedDBs = ['postgres', 'spanner', 'firestore', 'mssql', 'mysql', 'mon
 
 const supportedVendors = ['gcp', 'aws', 'azure']
 
-const veloRoles = ['OWNER', 'BACKEND_CODE', 'VISITOR', 'MEMBER']
+const veloRoles = ['Admin', 'Member', 'Visitor']
 
 const collectionConfigPattern = {
     type: 'object',

--- a/packages/external-db-config/test/drivers/aws_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/aws_mysql_config_test_support.js
@@ -2,6 +2,7 @@ const { AwsConfigReader } = require('../../lib/readers/aws_config_reader')
 const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager')
 const mockClient = require('aws-sdk-client-mock')
 const mockedAwsSdk = mockClient.mockClient(SecretsManagerClient)
+const { validAuthorizationConfig } = require ('../test_utils')
 
 const Chance = require('chance')
 const chance = new Chance()
@@ -44,15 +45,6 @@ const validConfigWithAuthorization = () => ({
     authorization: validAuthorizationConfig.collectionLevelConfig 
 })
 
-const validAuthorizationConfig = {
-    collectionLevelConfig: [
-        {
-            id: chance.word(),
-            readPolicies: ['Admin'],
-            writePolicies: ['Admin'],
-        }
-    ]
-}
 
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),

--- a/packages/external-db-config/test/drivers/aws_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/aws_mysql_config_test_support.js
@@ -48,8 +48,8 @@ const validAuthorizationConfig = {
     collectionLevelConfig: [
         {
             id: chance.word(),
-            readPolicies: ['OWNER'],
-            writePolicies: ['BACKEND_CODE'],
+            readPolicies: ['Admin'],
+            writePolicies: ['Admin'],
         }
     ]
 }

--- a/packages/external-db-config/test/drivers/azure_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/azure_mysql_config_test_support.js
@@ -1,6 +1,7 @@
 const { AzureConfigReader } = require('../../lib/readers/azure_config_reader')
 const Chance = require('chance')
 const chance = new Chance()
+const { validAuthorizationConfig } = require ('../test_utils')
 
 const defineValidConfig = (config) => {
     if (config.host) {
@@ -44,16 +45,6 @@ const validConfigWithAuthorization = () => ({
     ...validConfig(),
     authorization: validAuthorizationConfig.collectionLevelConfig 
 })
-
-const validAuthorizationConfig = {
-    collectionLevelConfig: [
-        {
-            id: chance.word(),
-            readPolicies: ['Admin'],
-            writePolicies: ['Admin'],
-        }
-    ]
-}
 
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),

--- a/packages/external-db-config/test/drivers/azure_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/azure_mysql_config_test_support.js
@@ -49,8 +49,8 @@ const validAuthorizationConfig = {
     collectionLevelConfig: [
         {
             id: chance.word(),
-            readPolicies: ['OWNER'],
-            writePolicies: ['BACKEND_CODE'],
+            readPolicies: ['Admin'],
+            writePolicies: ['Admin'],
         }
     ]
 }

--- a/packages/external-db-config/test/drivers/gcp_firestore_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_firestore_config_test_support.js
@@ -1,6 +1,7 @@
 const { GcpFirestoreConfigReader } = require('../../lib/readers/gcp_config_reader')
 const Chance = require('chance')
 const chance = new Chance()
+const { validAuthorizationConfig } = require ('../test_utils')
 
 const defineValidConfig = (config) => {
     if (config.projectId) {
@@ -32,16 +33,6 @@ const validConfigWithAuthorization = () => ({
     ...validConfig(),
     authorization: validAuthorizationConfig.collectionLevelConfig 
 })
-
-const validAuthorizationConfig = {
-    collectionLevelConfig: [
-        {
-            id: chance.word(),
-            readPolicies: ['Admin'],
-            writePolicies: ['Admin'],
-        }
-    ]
-}
 
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),

--- a/packages/external-db-config/test/drivers/gcp_firestore_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_firestore_config_test_support.js
@@ -37,8 +37,8 @@ const validAuthorizationConfig = {
     collectionLevelConfig: [
         {
             id: chance.word(),
-            readPolicies: ['OWNER'],
-            writePolicies: ['BACKEND_CODE'],
+            readPolicies: ['Admin'],
+            writePolicies: ['Admin'],
         }
     ]
 }

--- a/packages/external-db-config/test/drivers/gcp_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_mysql_config_test_support.js
@@ -1,6 +1,7 @@
 const { GcpConfigReader } = require('../../lib/readers/gcp_config_reader')
 const Chance = require('chance')
 const chance = new Chance()
+const { validAuthorizationConfig } = require ('../test_utils')
 
 const defineValidConfig = (config) => {
     if (config.cloudSqlConnectionName) {
@@ -44,16 +45,6 @@ const validConfigWithAuthorization = () => ({
     ...validConfig(),
     authorization: validAuthorizationConfig.collectionLevelConfig 
 })
-
-const validAuthorizationConfig = {
-    collectionLevelConfig: [
-        {
-            id: chance.word(),
-            readPolicies: ['Admin'],
-            writePolicies: ['Admin'],
-        }
-    ]
-}
 
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),

--- a/packages/external-db-config/test/drivers/gcp_mysql_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_mysql_config_test_support.js
@@ -49,8 +49,8 @@ const validAuthorizationConfig = {
     collectionLevelConfig: [
         {
             id: chance.word(),
-            readPolicies: ['OWNER'],
-            writePolicies: ['BACKEND_CODE'],
+            readPolicies: ['Admin'],
+            writePolicies: ['Admin'],
         }
     ]
 }

--- a/packages/external-db-config/test/drivers/gcp_spanner_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_spanner_config_test_support.js
@@ -45,8 +45,8 @@ const validAuthorizationConfig = {
     collectionLevelConfig: [
         {
             id: chance.word(),
-            readPolicies: ['OWNER'],
-            writePolicies: ['BACKEND_CODE'],
+            readPolicies: ['Admin'],
+            writePolicies: ['Admin'],
         }
     ]
 }

--- a/packages/external-db-config/test/drivers/gcp_spanner_config_test_support.js
+++ b/packages/external-db-config/test/drivers/gcp_spanner_config_test_support.js
@@ -1,6 +1,7 @@
 const { GcpSpannerConfigReader } = require('../../lib/readers/gcp_config_reader')
 const Chance = require('chance')
 const chance = new Chance()
+const { validAuthorizationConfig } = require ('../test_utils')
 
 const defineValidConfig = (config) => {
     if (config.projectId) {
@@ -41,15 +42,6 @@ const validConfigWithAuthorization = () => ({
     authorization: validAuthorizationConfig.collectionLevelConfig 
 })
 
-const validAuthorizationConfig = {
-    collectionLevelConfig: [
-        {
-            id: chance.word(),
-            readPolicies: ['Admin'],
-            writePolicies: ['Admin'],
-        }
-    ]
-}
 const validConfigWithAuthConfig = () => ({
     ...validConfig(),
     auth: {

--- a/packages/external-db-config/test/test_utils.js
+++ b/packages/external-db-config/test/test_utils.js
@@ -1,0 +1,15 @@
+
+const Chance = require('chance')
+const chance = new Chance()
+
+const validAuthorizationConfig = {
+    collectionLevelConfig: [
+        {
+            id: chance.word(),
+            readPolicies: ['Admin'],
+            writePolicies: ['Admin'],
+        }
+    ]
+}
+
+module.exports = { validAuthorizationConfig }

--- a/packages/external-db-security/lib/services/role_authorization.js
+++ b/packages/external-db-security/lib/services/role_authorization.js
@@ -1,5 +1,5 @@
 const { UnauthorizedError } = require('velo-external-db-commons/lib/errors')
-const DefaultPolicies = ['OWNER', 'BACKEND_CODE']
+const DefaultPolicies = ['Admin']
 
 class RoleAuthorizationService {
     constructor(config) {
@@ -8,14 +8,14 @@ class RoleAuthorizationService {
 
     authorizeRead(collectionName, role) {
         const readPolicies = this.readPoliciesFor(collectionName)
-        
-        if (!readPolicies.includes(role)) throw new UnauthorizedError('You are not authorized')
+
+        if (!readPolicies.includes(this.dataToVeloRole(role))) throw new UnauthorizedError('You are not authorized')
     }
     
     authorizeWrite(collectionName, role) {
         const writePolicies = this.writePoliciesFor(collectionName)
- 
-        if (!writePolicies.includes(role)) throw new UnauthorizedError('You are not authorized')
+        
+        if (!writePolicies.includes(this.dataToVeloRole(role))) throw new UnauthorizedError('You are not authorized')
     }
 
     setConfig(config) {
@@ -33,6 +33,18 @@ class RoleAuthorizationService {
     writePoliciesFor(collectionName) {
         return this.policiesFor(collectionName)?.writePolicies || DefaultPolicies
     }
+
+    dataToVeloRole(role) { 
+        switch (role) {
+            case 'OWNER':
+            case 'BACKEND_CODE':
+                return 'Admin'
+            case 'MEMBER':
+                return 'Member'
+            case 'VISITOR':
+                return 'Visitor'
+        }
+    }     
 }
 
 module.exports = RoleAuthorizationService

--- a/packages/external-db-security/lib/services/role_authorization.js
+++ b/packages/external-db-security/lib/services/role_authorization.js
@@ -43,6 +43,8 @@ class RoleAuthorizationService {
                 return 'Member'
             case 'VISITOR':
                 return 'Visitor'
+            default:
+                return role
         }
     }     
 }

--- a/packages/external-db-security/lib/test/gen.js
+++ b/packages/external-db-security/lib/test/gen.js
@@ -2,7 +2,7 @@ const { gen }  = require('test-commons')
 const Chance = require('chance')
 const chance = Chance()
 
-const veloRoles = ['OWNER', 'BACKEND_CODE', 'MEMBER', 'VISITOR']
+const veloRoles = ['Admin', 'Member', 'Visitor']
 
 const collectionConfigEntity = () => ({
     id: chance.word(),
@@ -17,17 +17,27 @@ const collectionNameFrom = (config) => gen.randomObjectFromArray(config).id
 const readRolesFor = (collectionName, config) => config.find(c => c.id = collectionName).readPolicies
 const writeRolesFor = (collectionName, config) => config.find(c => c.id = collectionName).writePolicies
 
-const authorizedReadRoleFor = (collectionName, config) => gen.randomObjectFromArray(readRolesFor(collectionName, config))
+const authorizedReadRoleFor = (collectionName, config) => veloRoleToData(gen.randomObjectFromArray(readRolesFor(collectionName, config)))
 
-const unauthorizedReadRoleFor = (collectionName, config) => gen.randomObjectFromArray(
+const unauthorizedReadRoleFor = (collectionName, config) => veloRoleToData(gen.randomObjectFromArray(
                                                                 veloRoles.filter(x => !readRolesFor(collectionName, config).includes(x))
-                                                                )
+                                                                ))
 
-const authorizedWriteRoleFor = (collectionName, config) => gen.randomObjectFromArray(writeRolesFor(collectionName, config))
+const authorizedWriteRoleFor = (collectionName, config) => veloRoleToData(gen.randomObjectFromArray(writeRolesFor(collectionName, config)))
 
-const unauthorizedWriteRoleFor = (collectionName, config) => gen.randomObjectFromArray(
+const unauthorizedWriteRoleFor = (collectionName, config) => veloRoleToData(gen.randomObjectFromArray(
                                                                 veloRoles.filter(x => !writeRolesFor(collectionName, config).includes(x))
-                                                                )
+                                                                ))
 
+const veloRoleToData = (role) => { 
+    switch (role) {
+        case 'Admin':
+            return 'OWNER'
+        case 'Member':
+            return 'MEMBER'
+        case 'Visitor':
+            return 'VISITOR'
+    }
+}   
 
 module.exports = { authorizationConfig, collectionNameFrom, authorizedReadRoleFor, unauthorizedReadRoleFor, authorizedWriteRoleFor, unauthorizedWriteRoleFor }

--- a/packages/velo-external-db/test/drivers/authorization_test_support.js
+++ b/packages/velo-external-db/test/drivers/authorization_test_support.js
@@ -1,6 +1,6 @@
 const { dbTeardown, initApp } = require('../resources/e2e_resources')
 
-const DefaultPolicies = ['OWNER', 'BACKEND_CODE']
+const DefaultPolicies = ['Admin']
 
 const authRoleConfig = (collectionName, readPolicies, writePolicies) => {
     const config = {
@@ -17,7 +17,7 @@ const authRoleConfig = (collectionName, readPolicies, writePolicies) => {
 
 const givenCollectionWithVisitorReadPolicy = async(collectionName) => {
     await dbTeardown()
-    authRoleConfig(collectionName, ['VISITOR'], [])
+    authRoleConfig(collectionName, ['Visitor'], [])
     await initApp()
 }
 


### PR DESCRIPTION
Instead of using data roles : 
`OWNER, BACKEND_CODE, VISITOR, MEMBER`
the config will accept now Velo roles : 
`Admin, Member, Visitor` 

When we execute `authorizedRead` / `authorizeWrite` we get a data role, and we'll translate it as follows:
OWNER, BACKEND_CODE → Admin
MEMBER → Member
VISITOR → Visitor
