### PR TITLE
Skip tests when not the operation is not supported 

### DIFF
--- a/packages/test-commons/lib/test-commons.js
+++ b/packages/test-commons/lib/test-commons.js
@@ -13,7 +13,17 @@ const removeColumnNotIn = (supportedOperations) => !supportedOperations.includes
 
 const addColumnNotIn = (supportedOperations) => !supportedOperations.includes(AddColumn)
 
-const passTest = () =>  expect(true).toBe(true)
+const testIfSchemaSupportsAddColumn = async({ schemaOperations }, f) => {
+    if (!addColumnNotIn(schemaOperations)) {
+        return await f()
+    }
+}
+
+const testIfSchemaSupportsRemoveColumn = async({ schemaOperations }, f) => {
+    if (!removeColumnNotIn(schemaOperations)) {
+        return await f()
+    }
+}
 
 module.exports = { shouldNotRunOn, shouldRunOnlyOn, sleep, Uninitialized, 
-    removeColumnNotIn, addColumnNotIn, passTest }
+    testIfSchemaSupportsAddColumn, testIfSchemaSupportsRemoveColumn }

--- a/packages/velo-external-db/test/storage/schema_provider.spec.js
+++ b/packages/velo-external-db/test/storage/schema_provider.spec.js
@@ -1,5 +1,5 @@
 const { CollectionDoesNotExists, FieldAlreadyExists, CannotModifySystemField, FieldDoesNotExist } = require('velo-external-db-commons').errors
-const { Uninitialized, gen, removeColumnNotIn, addColumnNotIn, passTest } = require('test-commons')
+const { Uninitialized, gen, testIfSchemaSupportsAddColumn, testIfSchemaSupportsRemoveColumn } = require('test-commons')
 const each = require('jest-each').default
 const Chance = require('chance')
 const { env, testSuits, dbTeardown } = require('../resources/provider_resources')
@@ -87,15 +87,11 @@ describe('Schema API', () => {
         })
 
 
-        test('add column on a an existing collection', async() => {
-
-            if (addColumnNotIn(env.schemaOperations))
-                return passTest()
-            
+        test('add column on a an existing collection', async() => testIfSchemaSupportsAddColumn(env, async() => {          
             await env.schemaProvider.create(ctx.collectionName, [])
             await env.schemaProvider.addColumn(ctx.collectionName, { name: ctx.columnName, type: 'datetime', subtype: 'timestamp' })
             await expect( env.schemaProvider.describeCollection(ctx.collectionName) ).resolves.toEqual( hasSameSchemaFieldsLike([{ field: ctx.columnName  }]))
-        })
+        }))
         
         test('add duplicate column will fail', async() => {
             await env.schemaProvider.create(ctx.collectionName, [])
@@ -114,37 +110,26 @@ describe('Schema API', () => {
                 })
         })
 
-        test('drop column on a an existing collection', async() => {
-            
-            if (removeColumnNotIn(env.schemaOperations))
-                return passTest()
-
+        test('drop column on a an existing collection', async() => testIfSchemaSupportsRemoveColumn(env, async() => {  
             await env.schemaProvider.create(ctx.collectionName, [])
             await env.schemaProvider.addColumn(ctx.collectionName, { name: ctx.columnName, type: 'datetime', subtype: 'timestamp' })
             await env.schemaProvider.removeColumn(ctx.collectionName, ctx.columnName)
             await expect(env.schemaProvider.describeCollection(ctx.collectionName)).resolves.not.toEqual(hasSameSchemaFieldsLike([{ field: ctx.columnName, type: 'datetime' }]))
-        })
+        }))
 
-        test('drop column on a a non existing collection', async() => {
-            
-            if (removeColumnNotIn(env.schemaOperations))
-                return passTest()
 
+        test('drop column on a a non existing collection', async() => testIfSchemaSupportsRemoveColumn(env, async() => {
             await env.schemaProvider.create(ctx.collectionName, [])
             await expect(env.schemaProvider.removeColumn(ctx.collectionName, ctx.columnName)).rejects.toThrow(FieldDoesNotExist)
-        })
+        }))
 
-        test('drop system column will fail', async() => {
-            
-            if (removeColumnNotIn(env.schemaOperations))
-                return passTest()
-
+        test('drop system column will fail', async() => testIfSchemaSupportsRemoveColumn(env, async() => {
             await env.schemaProvider.create(ctx.collectionName, [])
             SystemFields.map(f => f.name)
                 .forEach(async f => {
                     await expect(env.schemaProvider.removeColumn(ctx.collectionName, f)).rejects.toThrow(CannotModifySystemField)
             })
-        })
+        }))
         
         const ctx = {
             collectionName: Uninitialized,


### PR DESCRIPTION
Removed `ShouldNotRun` from schema tests and now if the test using operation that not supported by the engine, it will pass the test without failing it. (maybe in the future we will skip these tests)