### PR TITLE
error translator for remove column - bigquery

### DIFF
--- a/packages/external-db-bigquery/lib/bigquery_schema_provider.js
+++ b/packages/external-db-bigquery/lib/bigquery_schema_provider.js
@@ -1,5 +1,5 @@
 const { SystemFields, validateSystemFields, parseTableData, AllSchemaOperations, errors } = require('velo-external-db-commons')
-const { translateErrorCodes, createCollectionTranslateErrorCodes, addColumnTranslateErrorCodes } = require('./sql_exception_translator')
+const { translateErrorCodes, createCollectionTranslateErrorCodes, addColumnTranslateErrorCodes, removeColumnTranslateErrorCodes } = require('./sql_exception_translator')
 const { escapeIdentifier } = require('./bigquery_utils')
 const SchemaColumnTranslator = require('./sql_schema_translator')
 class SchemaProvider {
@@ -53,7 +53,7 @@ class SchemaProvider {
         await validateSystemFields(columnName)
         const fullCollectionName = `${this.projectId}.${this.databaseId}.${collectionName}`
         await this.pool.query(`CREATE OR REPLACE TABLE ${escapeIdentifier(fullCollectionName)} AS SELECT * EXCEPT (${escapeIdentifier(columnName)}) FROM ${escapeIdentifier(fullCollectionName)}`)
-                       .catch(translateErrorCodes)
+                       .catch(removeColumnTranslateErrorCodes)
     }
 
     async describeCollection(collectionName) {

--- a/packages/external-db-bigquery/lib/sql_exception_translator.js
+++ b/packages/external-db-bigquery/lib/sql_exception_translator.js
@@ -1,4 +1,4 @@
-const { CollectionDoesNotExists, FieldAlreadyExists } = require('velo-external-db-commons').errors
+const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist } = require('velo-external-db-commons').errors
 
 const notThrowingTranslateErrorCodes = err => {
     switch (err.code) {
@@ -10,6 +10,7 @@ const notThrowingTranslateErrorCodes = err => {
 }
 
 const translateErrorCodes = err => {
+    console.log(err)
     throw notThrowingTranslateErrorCodes(err)
 }
 
@@ -30,6 +31,14 @@ const addColumnTranslateErrorCodes = err => {
         throw notThrowingTranslateErrorCodes(err)
 }
 
+const removeColumnTranslateErrorCodes = err => {
+    if (err.code === 400)
+        throw new FieldDoesNotExist(err.message)
+    else
+        throw notThrowingTranslateErrorCodes(err)
+}
+
 module.exports = { notThrowingTranslateErrorCodes, translateErrorCodes,
-    createCollectionTranslateErrorCodes, addColumnTranslateErrorCodes }
+    createCollectionTranslateErrorCodes, addColumnTranslateErrorCodes,
+    removeColumnTranslateErrorCodes }
 

--- a/packages/external-db-bigquery/lib/sql_exception_translator.js
+++ b/packages/external-db-bigquery/lib/sql_exception_translator.js
@@ -10,7 +10,6 @@ const notThrowingTranslateErrorCodes = err => {
 }
 
 const translateErrorCodes = err => {
-    console.log(err)
     throw notThrowingTranslateErrorCodes(err)
 }
 


### PR DESCRIPTION
In BigQuery the error code is always the same error code (400), It is impossible to distinguish between errors when doing different actions, so there is an error translator for each function, which translates the error code to the appropriate error message. 