### PR TITLE
String operators to case-insensitive

### DIFF
--- a/packages/external-db-bigquery/lib/sql_filter_transformer.js
+++ b/packages/external-db-bigquery/lib/sql_filter_transformer.js
@@ -110,7 +110,7 @@ class FilterParser {
 
         if (this.isSingleFieldStringOperator(operator)) {
             return [{
-                filterExpr: `${escapeIdentifier(fieldName)} LIKE ?`,
+                filterExpr: `LOWER(${escapeIdentifier(fieldName)}) LIKE LOWER(?)`,
                 parameters: [this.valueForStringOperator(operator, value)]
             }]
         }

--- a/packages/external-db-bigquery/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-bigquery/lib/sql_filter_transformer.spec.js
@@ -152,7 +152,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                        filterExpr: `${escapeId(ctx.fieldName)} LIKE ?`,
+                        filterExpr: `LOWER(${escapeId(ctx.fieldName)}) LIKE LOWER(?)`,
                         parameters: [`%${ctx.fieldValue}%`]
                     }])
                 })
@@ -165,7 +165,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                        filterExpr: `${escapeId(ctx.fieldName)} LIKE ?`,
+                        filterExpr: `LOWER(${escapeId(ctx.fieldName)}) LIKE LOWER(?)`,
                         parameters: [`${ctx.fieldValue}%`]
                     }])
                 })
@@ -178,7 +178,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                        filterExpr: `${escapeId(ctx.fieldName)} LIKE ?`,
+                        filterExpr: `LOWER(${escapeId(ctx.fieldName)}) LIKE LOWER(?)`,
                         parameters: [`%${ctx.fieldValue}`]
                     }])
                 })

--- a/packages/external-db-postgres/lib/sql_filter_transformer.js
+++ b/packages/external-db-postgres/lib/sql_filter_transformer.js
@@ -128,7 +128,7 @@ class FilterParser {
 
         if (this.isSingleFieldStringOperator(operator)) {
             return [{
-                filterExpr: `${this.inlineVariableIfNeeded(fieldName, inlineFields)} LIKE $${offset}`,
+                filterExpr: `${this.inlineVariableIfNeeded(fieldName, inlineFields)} ILIKE $${offset}`,
                 filterColumns: [],
                 offset: offset + 1,
                 parameters: [this.valueForStringOperator(operator, value)]

--- a/packages/external-db-postgres/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-postgres/lib/sql_filter_transformer.spec.js
@@ -175,7 +175,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
-                        filterExpr: `${escapeIdentifier(ctx.fieldName)} LIKE $${ctx.offset}`,
+                        filterExpr: `${escapeIdentifier(ctx.fieldName)} ILIKE $${ctx.offset}`,
                         filterColumns: [],
                         offset: ctx.offset + 1,
                         parameters: [`%${ctx.fieldValue}%`]
@@ -190,7 +190,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
-                        filterExpr: `${escapeIdentifier(ctx.fieldName)} LIKE $${ctx.offset}`,
+                        filterExpr: `${escapeIdentifier(ctx.fieldName)} ILIKE $${ctx.offset}`,
                         filterColumns: [],
                         offset: ctx.offset + 1,
                         parameters: [`${ctx.fieldValue}%`]
@@ -205,7 +205,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
-                        filterExpr: `${escapeIdentifier(ctx.fieldName)} LIKE $${ctx.offset}`,
+                        filterExpr: `${escapeIdentifier(ctx.fieldName)} ILIKE $${ctx.offset}`,
                         filterColumns: [],
                         offset: ctx.offset + 1,
                         parameters: [`%${ctx.fieldValue}`]

--- a/packages/external-db-spanner/lib/sql_filter_transformer.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.js
@@ -116,7 +116,7 @@ class FilterParser {
 
         if (this.isSingleFieldStringOperator(operator)) {
             return [{
-                filterExpr: `${this.inlineVariableIfNeeded(fieldName, inlineFields)} LIKE ${validateLiteral(fieldName)}`,
+                filterExpr: `LOWER(${this.inlineVariableIfNeeded(fieldName, inlineFields)}) LIKE LOWER(${validateLiteral(fieldName)})`,
                 parameters: { [fieldName]: this.valueForStringOperator(operator, value) }
             }]
         }

--- a/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
@@ -171,7 +171,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                        filterExpr: `${escapeId(ctx.fieldName)} LIKE @${ctx.fieldName}`,
+                        filterExpr: `LOWER(${escapeId(ctx.fieldName)}) LIKE LOWER(@${ctx.fieldName})`,
                         parameters: { [ctx.fieldName]: `%${ctx.fieldValue}%` }
                     }])
                 })
@@ -184,7 +184,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                        filterExpr: `${escapeId(ctx.fieldName)} LIKE @${ctx.fieldName}`,
+                        filterExpr: `LOWER(${escapeId(ctx.fieldName)}) LIKE LOWER(@${ctx.fieldName})`,
                         parameters: { [ctx.fieldName]: `${ctx.fieldValue}%` }
                     }])
                 })
@@ -197,7 +197,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                        filterExpr: `${escapeId(ctx.fieldName)} LIKE @${ctx.fieldName}`,
+                        filterExpr: `LOWER(${escapeId(ctx.fieldName)}) LIKE LOWER(@${ctx.fieldName})`,
                         parameters: { [ctx.fieldName]: `%${ctx.fieldValue}` }
                     }])
                 })


### PR DESCRIPTION
Part of #209 
change the operators `startsWith`, `endsWith`, `contains` to be case-insensitive. 

Postgres: 
change the LIKE operator to ILIKE 

MySQL, MSSQL: 
LIKE operator is already case-insensitive

Spanner, BigQuery: 
replace   `fieldName LIKE 'something` to  - `LOWER(fieldName) LIKE LOWER('something')`