### PR TITLE
Case insensitive tests

### DIFF
--- a/packages/external-db-bigquery/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-bigquery/tests/drivers/sql_filter_transformer_test_support.js
@@ -56,6 +56,9 @@ const givenProjectionExprFor = (projection) =>
     when(filterParser.selectFieldsFor).calledWith(projection)
                                       .mockReturnValue(projection.map(escapeIdentifier).join(', '))
 
+const givenStartsWithFilterFor = (filter, column, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeIdentifier(column)} LIKE ?`, parameters: [`${value}%`] })
 
 const reset = () => {
     filterParser.transform.mockClear()
@@ -67,6 +70,6 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
-                   givenAllFieldsProjectionFor, givenProjectionExprFor,
+                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
                    filterParser, reset
 }

--- a/packages/external-db-dynamodb/lib/dynamo_data_provider.js
+++ b/packages/external-db-dynamodb/lib/dynamo_data_provider.js
@@ -20,7 +20,8 @@ class DataProvider {
 
         const expressionAttributeNames = { ...filterExpr.ExpressionAttributeNames, ...projectionAttributeNames }
 
-        const filterExprWithProjection = { ...filterExpr, ProjectionExpression: projectionExpr, ExpressionAttributeNames: expressionAttributeNames }
+        const filterExprWithProjection = { ...filterExpr, ExpressionAttributeNames: expressionAttributeNames }
+        if (projectionExpr !== '') Object.assign(filterExprWithProjection, { ProjectionExpression: projectionExpr })
 
         const { Items } = await this.query(dynamoRequests.findCommand(collectionName, filterExprWithProjection, limit), queryable)
 

--- a/packages/external-db-dynamodb/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-dynamodb/tests/drivers/sql_filter_transformer_test_support.js
@@ -61,6 +61,18 @@ const givenProjectionExprFor = (projection) =>
 // eslint-disable-next-line no-unused-vars
 const givenAggregateQueryWith = (having, numericColumns, columnAliases, groupByColumns, filter) => {}
 
+const givenStartsWithFilterFor = (filter, column, value) =>
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: {
+                                    FilterExpression: `begins_with (#${column}, :${column})`,
+                                    ExpressionAttributeNames: {
+                                        [`#${column}`]: column
+                                    },
+                                    ExpressionAttributeValues: {
+                                        [`:${column}`]: value
+                                    }
+                                }
+                            })
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -71,5 +83,5 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, stubEmptyOrderByFor, stubEmptyFilterFor,
                    givenFilterByIdWith, filterParser, reset, givenAggregateQueryWith,
-                   givenAllFieldsProjectionFor, givenProjectionExprFor
+                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor
 }

--- a/packages/external-db-mongo/lib/sql_filter_transformer.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.js
@@ -67,7 +67,7 @@ class FilterParser {
         }
 
         if (this.isSingleFieldStringOperator(operator)) {
-            return [{ filterExpr: { [fieldName]: { $regex: this.valueForStringOperator(operator, value) } } }]
+            return [{ filterExpr: { [fieldName]: { $regex: this.valueForStringOperator(operator, value), $options: 'i' } } }]
         }
 
         if (operator === urlized) {
@@ -86,11 +86,11 @@ class FilterParser {
     valueForStringOperator(operator, value) {
         switch (operator) {
             case string_contains:
-                return `/${value}/i`
+                return value
             case string_begins:
-                return `/^${value}/i`
+                return `^${value}`
             case string_ends:
-                return `/${value}$/i`
+                return `${value}$`
         }
     }
 

--- a/packages/external-db-mongo/lib/sql_filter_transformer.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.js
@@ -86,11 +86,11 @@ class FilterParser {
     valueForStringOperator(operator, value) {
         switch (operator) {
             case string_contains:
-                return value
+                return `/${value}/i`
             case string_begins:
-                return `^${value}`
+                return `/^${value}/i`
             case string_ends:
-                return `${value}$`
+                return `/${value}$/i`
         }
     }
 

--- a/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
@@ -155,7 +155,7 @@ describe('Sql Parser', () => {
                         value: ctx.fieldValue
                     }
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: `/${ctx.fieldValue}/i` } }
+                        filterExpr: { [ctx.fieldName]: { $regex: `${ctx.fieldValue}`, $options: 'i' } }
                     }])
                 })
 
@@ -167,7 +167,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: `/^${ctx.fieldValue}/i` } }
+                        filterExpr: { [ctx.fieldName]: { $regex: `^${ctx.fieldValue}`, $options: 'i' } }
                     }])
                 })
 
@@ -179,7 +179,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: `/${ctx.fieldValue}$/i` } }
+                        filterExpr: { [ctx.fieldName]: { $regex: `${ctx.fieldValue}$`, $options: 'i' } }
                     }])
                 })
 

--- a/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.spec.js
@@ -155,7 +155,7 @@ describe('Sql Parser', () => {
                         value: ctx.fieldValue
                     }
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: ctx.fieldValue } }
+                        filterExpr: { [ctx.fieldName]: { $regex: `/${ctx.fieldValue}/i` } }
                     }])
                 })
 
@@ -167,7 +167,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: `^${ctx.fieldValue}` } }
+                        filterExpr: { [ctx.fieldName]: { $regex: `/^${ctx.fieldValue}/i` } }
                     }])
                 })
 
@@ -179,7 +179,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect(env.filterParser.parseFilter(filter)).toEqual([{
-                        filterExpr: { [ctx.fieldName]: { $regex: `${ctx.fieldValue}$` } }
+                        filterExpr: { [ctx.fieldName]: { $regex: `/${ctx.fieldValue}$/i` } }
                     }])
                 })
 

--- a/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
@@ -62,6 +62,9 @@ const givenProjectionExprFor = (projection) =>
                                     { ...pV, [cV]: 1 }
                                 ), { _id: 0 }))
 
+const givenStartsWithFilterFor = (filter, column, value) =>
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: { [column]: { $regex: `/^${value}/i` } } })
 
 const reset = () => {
     filterParser.transform.mockClear()
@@ -73,6 +76,6 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
-                   givenAllFieldsProjectionFor, givenProjectionExprFor,
+                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
                    filterParser, reset
 }

--- a/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
@@ -64,7 +64,7 @@ const givenProjectionExprFor = (projection) =>
 
 const givenStartsWithFilterFor = (filter, column, value) =>
     when(filterParser.transform).calledWith(filter)
-                                .mockReturnValue({ filterExpr: { [column]: { $regex: `/^${value}/i` } } })
+                                .mockReturnValue({ filterExpr: { [column]: { $regex: `^${value}`, $options: 'i' } } })
 
 const reset = () => {
     filterParser.transform.mockClear()

--- a/packages/external-db-mssql/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mssql/tests/drivers/sql_filter_transformer_test_support.js
@@ -55,6 +55,9 @@ const givenProjectionExprFor = (projection) =>
     when(filterParser.selectFieldsFor).calledWith(projection)
                                       .mockReturnValue(projection.map(escapeId).join(', '))
 
+const givenStartsWithFilterFor = (filter, column, value) =>
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeId(column)} LIKE ${validateLiteral(column)}`, parameters: { [patchFieldName(column)]: `${value}%` } })
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -65,6 +68,6 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
-                   givenAllFieldsProjectionFor, givenProjectionExprFor,
+                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
                    filterParser, reset
 }

--- a/packages/external-db-mysql/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mysql/tests/drivers/sql_filter_transformer_test_support.js
@@ -55,6 +55,9 @@ const givenProjectionExprFor = (projection) =>
     when(filterParser.selectFieldsFor).calledWith(projection)
                                       .mockReturnValue(projection.map(escapeId).join(', '))
 
+const givenStartsWithFilterFor = (filter, column, value) =>
+    when(filterParser.transform).calledWith(filter)
+                                  .mockReturnValue({ filterExpr: `WHERE ${escapeId(column)} LIKE ?`, parameters: [`${value}%`] })
 
 const reset = () => {
     filterParser.transform.mockClear()
@@ -65,5 +68,5 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
-                   givenAllFieldsProjectionFor, givenProjectionExprFor, filterParser, reset 
+                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor, filterParser, reset 
 }

--- a/packages/external-db-postgres/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-postgres/tests/drivers/sql_filter_transformer_test_support.js
@@ -55,6 +55,10 @@ const givenProjectionExprFor = (projection) =>
     when(filterParser.selectFieldsFor).calledWith(projection)
                                  .mockReturnValue(projection.map(escapeIdentifier).join(', '))
 
+const givenStartsWithFilterFor = (filter, column, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeIdentifier(column)} ILIKE $1`, parameters: [`${value}%`], offset: 2 })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -64,6 +68,6 @@ const reset = () => {
 }
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor, stubEmptyFilterFor, 
-                   givenFilterByIdWith, givenAggregateQueryWith, givenAllFieldsProjectionFor, givenProjectionExprFor,
+                   givenFilterByIdWith, givenAggregateQueryWith, givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
                    filterParser, reset
 }

--- a/packages/external-db-spanner/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-spanner/tests/drivers/sql_filter_transformer_test_support.js
@@ -1,6 +1,6 @@
 const { EmptySort } = require('velo-external-db-commons')
 const { when } = require('jest-when')
-const { escapeId, escapeFieldId } = require('../../lib/spanner_utils')
+const { escapeId, escapeFieldId, validateLiteral } = require('../../lib/spanner_utils')
 
 const filterParser = {
     transform: jest.fn(),
@@ -63,6 +63,10 @@ const givenProjectionExprFor = (projection) =>
     when(filterParser.selectFieldsFor).calledWith(projection)
                                       .mockReturnValue(projection.map(escapeFieldId).join(', '))
 
+const givenStartsWithFilterFor = (filter, column, value) =>
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE LOWER(${escapeFieldId(column)}) LIKE LOWER(${validateLiteral(column)})`, parameters: { [column]: `${value}%` } })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -73,6 +77,6 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
-                    givenAllFieldsProjectionFor, givenProjectionExprFor,
+                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
                    filterParser, reset
 }

--- a/packages/velo-external-db/test/drivers/data_provider_matchers.js
+++ b/packages/velo-external-db/test/drivers/data_provider_matchers.js
@@ -1,7 +1,3 @@
 const entitiesWithOwnerFieldOnly = (entities) => expect.arrayContaining(entities.map(e => ({ _owner: e._owner })))
 
-
-const toggleCase = (str) => str.split('').map(c => c === c.toUpperCase() ? c.toLowerCase() : c.toUpperCase()).join('')
-
-module.exports = { entitiesWithOwnerFieldOnly, toggleCase }
-
+module.exports = { entitiesWithOwnerFieldOnly }

--- a/packages/velo-external-db/test/drivers/data_provider_matchers.js
+++ b/packages/velo-external-db/test/drivers/data_provider_matchers.js
@@ -1,4 +1,7 @@
 const entitiesWithOwnerFieldOnly = (entities) => expect.arrayContaining(entities.map(e => ({ _owner: e._owner })))
 
-module.exports = { entitiesWithOwnerFieldOnly }
+
+const toggleCase = (str) => str.split('').map(c => c === c.toUpperCase() ? c.toLowerCase() : c.toUpperCase()).join('')
+
+module.exports = { entitiesWithOwnerFieldOnly, toggleCase }
 

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -53,11 +53,11 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         })
     }
 
-    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner', 'Sql Server'], currentDbImplementationName())) {
         test('search with startsWith operator will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)
-            
+
             env.driver.givenStartsWithFilterFor(ctx.filter, ctx.column.name, firstHalfOfValue)
             env.driver.stubEmptyOrderByFor(ctx.sort)
             env.driver.givenAllFieldsProjectionFor?.(ctx.projection)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -53,7 +53,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         })
     }
 
-    if (shouldRunOnlyOn(['Postgres'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['Postgres', 'MySql'], currentDbImplementationName())) {
         test('startsWith operator will return data and be case-insensitive', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             env.driver.givenStartsWithFilterFor(ctx.filter, ctx.column.name, toggleCase(ctx.entity[ctx.column.name][0]))

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -1,4 +1,4 @@
-const { Uninitialized, shouldNotRunOn, shouldRunOnlyOn } = require('test-commons')
+const { Uninitialized, shouldNotRunOn } = require('test-commons')
 const Chance = require('chance')
 const gen = require('../gen')
 const { env, dbTeardown, setupDb, currentDbImplementationName } = require('../resources/provider_resources')
@@ -53,7 +53,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         })
     }
 
-    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner', 'Sql Server', 'BigQuery', 'Mongo', 'DynamoDb'], currentDbImplementationName())) {
+    if (shouldNotRunOn(['Firestore', 'Google-Sheet'], currentDbImplementationName())) {
         test('search with startsWith operator will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -53,7 +53,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         })
     }
 
-    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner', 'Sql Server', 'BigQuery', 'Mongo'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner', 'Sql Server', 'BigQuery', 'Mongo', 'DynamoDb'], currentDbImplementationName())) {
         test('search with startsWith operator will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)
@@ -64,16 +64,18 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
             await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual(expect.arrayContaining([ctx.entity]))
         })
 
-        test('search with startsWith operator will return data and be case-insensitive', async() => {
-            await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
-            const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)
-            const firstHalfOfValueToggled = firstHalfOfValue.toUpperCase() === firstHalfOfValue ? firstHalfOfValue.toLowerCase() : firstHalfOfValue.toUpperCase()
+        if (shouldNotRunOn(['DynamoDb'], currentDbImplementationName())) {
+            test('search with startsWith operator will return data and be case-insensitive', async() => {
+                await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
+                const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)
+                const firstHalfOfValueToggled = firstHalfOfValue.toUpperCase() === firstHalfOfValue ? firstHalfOfValue.toLowerCase() : firstHalfOfValue.toUpperCase()
 
-            env.driver.givenStartsWithFilterFor(ctx.filter, ctx.column.name, firstHalfOfValueToggled)
-            env.driver.stubEmptyOrderByFor(ctx.sort)
-            env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
-            await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual(expect.arrayContaining([ctx.entity]))
-        })
+                env.driver.givenStartsWithFilterFor(ctx.filter, ctx.column.name, firstHalfOfValueToggled)
+                env.driver.stubEmptyOrderByFor(ctx.sort)
+                env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+                await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual(expect.arrayContaining([ctx.entity]))
+            })
+        }
     }
 
     if(shouldNotRunOn(['Firestore', 'Google-Sheet'], currentDbImplementationName())) {

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -53,8 +53,8 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         })
     }
 
-    if (shouldRunOnlyOn(['Postgres', 'MySql'], currentDbImplementationName())) {
-        test('search with  startsWith operator will return data', async() => {
+    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner'], currentDbImplementationName())) {
+        test('search with startsWith operator will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)
             

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -78,7 +78,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         }
     }
 
-    if(shouldNotRunOn(['Firestore', 'Google-Sheet'], currentDbImplementationName())) {
+    if(shouldNotRunOn(['Firestore', 'Google-Sheet', 'Airtable'], currentDbImplementationName())) {
         test('search with projection will return the specified fields', async() => {
             const projection = ['_owner']
             await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -53,7 +53,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         })
     }
 
-    if (shouldNotRunOn(['Firestore', 'Google-Sheet'], currentDbImplementationName())) {
+    if (shouldNotRunOn(['Firestore', 'Google-Sheet', 'Airtable'], currentDbImplementationName())) {
         test('search with startsWith operator will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -56,7 +56,9 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
     if (shouldRunOnlyOn(['Postgres', 'MySql'], currentDbImplementationName())) {
         test('search with  startsWith operator will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
-            env.driver.givenStartsWithFilterFor(ctx.filter, ctx.column.name, ctx.entity[ctx.column.name][0])
+            const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)
+            
+            env.driver.givenStartsWithFilterFor(ctx.filter, ctx.column.name, firstHalfOfValue)
             env.driver.stubEmptyOrderByFor(ctx.sort)
             env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
             await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual(expect.arrayContaining([ctx.entity]))
@@ -64,10 +66,10 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
 
         test('search with startsWith operator will return data and be case-insensitive', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
-            const firstChar = ctx.entity[ctx.column.name][0]
-            const firstCharToggledCase = firstChar.toUpperCase() === firstChar ? firstChar.toLowerCase() : firstChar.toUpperCase()
+            const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)
+            const firstHalfOfValueToggled = firstHalfOfValue.toUpperCase() === firstHalfOfValue ? firstHalfOfValue.toLowerCase() : firstHalfOfValue.toUpperCase()
 
-            env.driver.givenStartsWithFilterFor(ctx.filter, ctx.column.name, firstCharToggledCase)
+            env.driver.givenStartsWithFilterFor(ctx.filter, ctx.column.name, firstHalfOfValueToggled)
             env.driver.stubEmptyOrderByFor(ctx.sort)
             env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
             await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.projection) ).resolves.toEqual(expect.arrayContaining([ctx.entity]))

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -53,7 +53,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         })
     }
 
-    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner', 'Sql Server'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner', 'Sql Server', 'BigQuery'], currentDbImplementationName())) {
         test('search with startsWith operator will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -53,7 +53,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         })
     }
 
-    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner', 'Sql Server', 'BigQuery'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['Postgres', 'MySql', 'Spanner', 'Sql Server', 'BigQuery', 'Mongo'], currentDbImplementationName())) {
         test('search with startsWith operator will return data', async() => {
             await givenCollectionWith([ctx.entity, ctx.anotherEntity], ctx.collectionName, ctx.entityFields)
             const firstHalfOfValue = ctx.entity[ctx.column.name].substring(0, ctx.column.name.length / 2)


### PR DESCRIPTION
Change the `startsWith`/ `endsWith`/ `contains` to be case-insensitive 
 I changed it for all implementations except the following:
**Firestore**, **Google-Sheets**: @MXPOL needs to implement, and he will do this in another PR.
**Airtable**:  I'll do it in another PR, I'm facing some problems there.
**DynamoDB** - don't support case-insensitive, you can see in this [thread](https://forums.aws.amazon.com/thread.jspa?threadID=92159), so for now I disabled the case-insensitive test for it.