### PR TITLE
make find and count parallel

### DIFF
--- a/packages/velo-external-db-core/lib/service/data.js
+++ b/packages/velo-external-db-core/lib/service/data.js
@@ -7,11 +7,11 @@ class DataService {
     }
 
     async find(collectionName, _filter, sort, skip, limit, projection) {
-        const items = await this.storage.find(collectionName, _filter, sort, skip, limit, projection) //todo: change order when all implementation support projection
-        const totalCount = await this.storage.count(collectionName, _filter)
+        const items = this.storage.find(collectionName, _filter, sort, skip, limit, projection) //todo: change order when all implementation support projection
+        const totalCount = this.storage.count(collectionName, _filter)
         return {
-            items: items.map( asWixData ),
-            totalCount
+            items: (await items).map( asWixData ),
+            totalCount: await totalCount
         }
     }
 


### PR DESCRIPTION
In the previous mode, we waited for the find promise to resolve and then performed a count, The two calls are not dependent on each other, so they can be performed in parallel and shorten the operation by half (hopefully)