### PR TITLE
Change schema information structure

### DIFF
--- a/packages/velo-external-db-core/lib/service/schema.js
+++ b/packages/velo-external-db-core/lib/service/schema.js
@@ -20,7 +20,7 @@ class SchemaService {
     }
 
     async find(collectionNames) {
-        const dbs = await Promise.all(collectionNames.map(async collectionName => ({ id: collectionName, fields: await this.storage.describeCollection(collectionName) })))
+        const dbs = await Promise.all(collectionNames.map(async collectionName => ({ id: collectionName, fields: await this.schemaInformation.schemaFieldsFor(collectionName) })))
         const dbsWithAllowedOperations = this.appendAllowedOperationsTo(dbs)
 
         return { schemas: dbsWithAllowedOperations.map( asWixSchema ) }

--- a/packages/velo-external-db-core/lib/service/schema.spec.js
+++ b/packages/velo-external-db-core/lib/service/schema.spec.js
@@ -27,7 +27,7 @@ describe('Schema Service', () => {
 
     test('retrieve collections by ids from provider', async() => {
         driver.givenAllSchemaOperations()
-        driver.givenFindResults(ctx.dbsWithIdColumn)
+        schema.givenSchemaFieldsResultFor(ctx.dbsWithIdColumn)
 
         await expect( env.schemaService.find(ctx.dbsWithIdColumn.map(db => db.id)) ).resolves.toEqual( schemasListFor(ctx.dbsWithIdColumn, AllSchemaOperations) )
     })

--- a/packages/velo-external-db-core/lib/service/schema_information.js
+++ b/packages/velo-external-db-core/lib/service/schema_information.js
@@ -1,8 +1,6 @@
 const { CollectionDoesNotExists } = require('velo-external-db-commons').errors
 const NodeCache = require('node-cache')
 
-const CacheKey = 'schema'
-
 const FiveMinutes = 5 * 60
 
 class CacheableSchemaInformation {
@@ -16,33 +14,27 @@ class CacheableSchemaInformation {
         }
         setImmediate(refreshFunc)
     }
-
-    async schemaFor(collectionName) {
-        const schema = await this.schema()
-        if (!schema.some(s => s.id === collectionName)) {
-            throw new CollectionDoesNotExists('Collection does not exists')
-        }
-
-        return schema.find(s => s.id === collectionName)
-    }
-
+    
     async schemaFieldsFor(collectionName) {
-        const s = await this.schemaFor(collectionName)
-        return s.fields
-    }
-
-    async schema() {
-        const schema = this.cache.get(CacheKey)
-        if ( schema === undefined ) {
-            await this.refresh()
-            return this.cache.get(CacheKey) || []
+        const schema = this.cache.get(collectionName)
+        if ( !schema ) {
+            await this.update(collectionName)
+            return this.cache.get(collectionName) 
         }
         return schema
     }
 
+    async update(collectionName) {
+        const collection = await this.schemaProvider.describeCollection(collectionName)
+        if (!collection) throw new CollectionDoesNotExists('Collection does not exists')
+        this.cache.set(collectionName, collection, FiveMinutes)
+    }
+
     async refresh() {
         const schema = await this.schemaProvider.list()
-        this.cache.set(CacheKey, schema, FiveMinutes)
+        schema?.forEach(collection => {
+            this.cache.set(collection.id, collection.fields, FiveMinutes)
+        })
     }
 
     async clear() {

--- a/packages/velo-external-db-core/lib/service/schema_information.js
+++ b/packages/velo-external-db-core/lib/service/schema_information.js
@@ -14,7 +14,6 @@ class CacheableSchemaInformation {
             await this.refresh()
                       .catch( console.log )
         }
-        this.timer = setInterval(refreshFunc, FiveMinutes * 1000)
         setImmediate(refreshFunc)
     }
 
@@ -50,9 +49,6 @@ class CacheableSchemaInformation {
         this.cache.flushAll()
     }
 
-    cleanup() {
-        this.timer.unref()
-    }
 }
 
 module.exports = CacheableSchemaInformation

--- a/packages/velo-external-db-core/lib/service/schema_information.spec.js
+++ b/packages/velo-external-db-core/lib/service/schema_information.spec.js
@@ -53,10 +53,6 @@ describe('Schema Information Service', () => {
         env.schemaInformation = new SchemaInformation(driver.schemaProvider)
     })
 
-    afterAll(() => {
-        env.schemaInformation.cleanup()
-    })
-
     beforeEach(() => {
         driver.reset()
         env.schemaInformation.clear()

--- a/packages/velo-external-db-core/lib/service/schema_information.spec.js
+++ b/packages/velo-external-db-core/lib/service/schema_information.spec.js
@@ -8,24 +8,21 @@ describe('Schema Information Service', () => {
 
     test('will automatically refresh and return schema for collection when queried', async() => {
         driver.givenListResult(ctx.dbs)
+        driver.givenFindResults(ctx.dbs)
 
-        await expect( env.schemaInformation.schemaFor(ctx.dbs[0].id) ).resolves.toEqual(ctx.dbs[0])
-    })
-
-    test('retrieve collection if it does not exists, throw an exception', async() => {
-        driver.givenListResult([])
-
-        await expect( env.schemaInformation.schemaFor(ctx.collectionName) ).rejects.toThrow(CollectionDoesNotExists)
+        await expect( env.schemaInformation.schemaFieldsFor(ctx.dbs[0].id) ).resolves.toEqual(ctx.dbs[0].fields)
     })
 
     test('will automatically refresh and return schema fields for collection when queried', async() => {
         driver.givenListResult(ctx.dbs)
+        driver.givenFindResults(ctx.dbs)
 
         await expect( env.schemaInformation.schemaFieldsFor(ctx.dbs[0].id) ).resolves.toEqual(ctx.dbs[0].fields)
     })
 
     test('retrieve collection fields if it does not exists, throw an exception', async() => {
         driver.givenListResult([])
+        driver.givenFindResults([])
 
         await expect(env.schemaInformation.schemaFieldsFor(ctx.collectionName)).rejects.toThrow(CollectionDoesNotExists)
     })
@@ -37,7 +34,7 @@ describe('Schema Information Service', () => {
 
         await env.schemaInformation.refresh()
 
-        await expect( env.schemaInformation.schemaFor(ctx.dbs[0].id) ).resolves.toEqual(ctx.dbs[0])
+        await expect( env.schemaInformation.schemaFieldsFor(ctx.dbs[0].id) ).resolves.toEqual(ctx.dbs[0].fields)
     })
 
     const ctx = {

--- a/packages/velo-external-db-core/test/drivers/schema_information_test_support.js
+++ b/packages/velo-external-db-core/test/drivers/schema_information_test_support.js
@@ -14,6 +14,9 @@ const givenDefaultSchemaFor = collectionName => {
 const expectSchemaRefresh = () =>
     when(schemaInformation.refresh).mockResolvedValue()
 
+const givenSchemaFieldsResultFor = (dbs) =>
+    dbs.forEach(db => when(schemaInformation.schemaFieldsFor).calledWith(db.id).mockResolvedValue(db.fields) )
+
 
 const reset = () => {
     schemaInformation.schemaFieldsFor.mockClear()
@@ -21,6 +24,6 @@ const reset = () => {
 }
 
 module.exports = {
-    givenDefaultSchemaFor, expectSchemaRefresh,
+    givenDefaultSchemaFor, expectSchemaRefresh, givenSchemaFieldsResultFor,
     schemaInformation, reset
 }

--- a/packages/velo-external-db/lib/app.js
+++ b/packages/velo-external-db/lib/app.js
@@ -34,7 +34,6 @@ const load = async() => {
     
     _cleanup = async() => {
         await cleanup()
-        schemaInformation.cleanup()
     }
 
     _schemaProvider = schemaProvider


### PR DESCRIPTION
This PR have 2 goals: 

1. remove refresh interval every five minutes
2. change the cache structure, instead save key with all the schemas, save key for each collection. When looking for a collection, update only this key.  