### PR TITLE
remove  from mongo filter transformer

### DIFF
--- a/packages/external-db-mongo/lib/sql_filter_transformer.js
+++ b/packages/external-db-mongo/lib/sql_filter_transformer.js
@@ -113,12 +113,7 @@ class FilterParser {
     }
 
     adapterOperatorToMongoOperator(operator) {
-        switch (operator) {
-            case '$hasSome':
-                return '$in'
-            default:
-                return `$${operator}`
-        }
+        return `$${operator}`
     }
 
     orderBy(sort) {


### PR DESCRIPTION
Probably we forgot to delete this code when we moved to the new filter format.