### PR TITLE
Change aws config reader

### DIFF
--- a/packages/external-db-config/lib/readers/aws_config_reader.js
+++ b/packages/external-db-config/lib/readers/aws_config_reader.js
@@ -42,7 +42,9 @@ class AwsDynamoConfigReader {
 
     async readConfig() {
       const { config } = await this.getExternalAndLocalEnvs()
-  
+      if (process.env.NODE_ENV === 'test') {
+        return { region: this.region, secretKey: config.SECRET_KEY, endpoint: process.env.ENDPOINT_URL }
+      }
       return { region: this.region, secretKey: config.SECRET_KEY }
     }
     

--- a/packages/external-db-config/lib/readers/aws_config_reader.js
+++ b/packages/external-db-config/lib/readers/aws_config_reader.js
@@ -1,8 +1,7 @@
 const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager')
 const { checkRequiredKeys } = require('../utils/config_utils')
 
-const EmptyAWSConfig = { host: '', username: '', password: '', DB: '', SECRET_KEY: '', error: true }
-const EmptyConfig = { error: true }
+const emptyConfig = (err) => ({ secretMangerError: err.message })
 
 class AwsConfigReader {
   constructor(secretId, region) {
@@ -11,9 +10,8 @@ class AwsConfigReader {
   }
 
   async readConfig() {
-    const cfg = await this.readExternalConfig()
-                          .catch(() => EmptyAWSConfig)
-    const { host, username, password, DB, SECRET_KEY } = cfg
+    const { config } = await this.getExternalAndLocalEnvs()
+    const { host, username, password, DB, SECRET_KEY } = config
     return { host: host, user: username, password: password, db: DB, secretKey: SECRET_KEY }
   }
 
@@ -23,77 +21,83 @@ class AwsConfigReader {
     return JSON.parse(data.SecretString)
   }
 
+  async getExternalAndLocalEnvs() { 
+    const externalConfig = await this.readExternalConfig().catch(emptyConfig)
+    const { host, username, password, DB, SECRET_KEY, HOST, PASSWORD, USER } = { ...process.env, ...externalConfig }
+    const config = {  host: host || HOST, username: username || USER, password: password || PASSWORD, DB, SECRET_KEY }
+    return { config, secretMangerError: externalConfig.secretMangerError }
+  }
+
   async validate() {
-    try {
-      const cfg = await this.readExternalConfig()
-      return { missingRequiredSecretsKeys: checkRequiredKeys(cfg, ['host', 'username', 'password', 'DB', 'SECRET_KEY']) }
-    } catch (err) {
-      return { configReadError: err.message, missingRequiredSecretsKeys: [] }
-    }
+      const { config, secretMangerError } = await this.getExternalAndLocalEnvs()
+      return { missingRequiredSecretsKeys: checkRequiredKeys(config, ['host', 'username', 'password', 'DB', 'SECRET_KEY']), secretMangerError }
   }
 }
 
-  class AwsDynamoConfigReader {
-    constructor(region, secretId) {
-      this.region = region
-      this.secretId = secretId
-     }
-
-     async readExternalConfig() {
-      const client = new SecretsManagerClient({ region: this.region })
-      const data = await client.send(new GetSecretValueCommand({ SecretId: this.secretId }))
-      return JSON.parse(data.SecretString)
+class AwsDynamoConfigReader {
+  constructor(region, secretId) {
+    this.region = region
+    this.secretId = secretId
     }
 
     async readConfig() {
-      if (process.env.NODE_ENV === 'test') {
-        return { region: this.region, secretKey: process.env.SECRET_KEY, endpoint: process.env.ENDPOINT_URL }
-      }
-      const cfg = await this.readExternalConfig()
-                            .catch(() => (EmptyConfig))
+      const { config } = await this.getExternalAndLocalEnvs()
   
-      return { region: this.region, secretKey: cfg.SECRET_KEY }
+      return { region: this.region, secretKey: config.SECRET_KEY }
+    }
+    
+    async getExternalAndLocalEnvs() { 
+      const externalConfig = await this.readExternalConfig().catch(emptyConfig)
+      const { SECRET_KEY } = { ...process.env, ...externalConfig }
+      const config = { SECRET_KEY }
+
+      return { config, secretMangerError: externalConfig.secretMangerError }
     }
 
-    async validate() {
-      try {
-        const cfg = process.env.NODE_ENV !== 'test' ? await this.readExternalConfig() : process.env
-        return { missingRequiredSecretsKeys: checkRequiredKeys(cfg, ['SECRET_KEY']) }
-        
-      } catch (err) {
-        return { configReadError: err.message, missingRequiredSecretsKeys: ['SECRET_KEY'] }
-      }
-    }
+    async readExternalConfig() {
+    const client = new SecretsManagerClient({ region: this.region })
+    const data = await client.send(new GetSecretValueCommand({ SecretId: this.secretId }))
+    return JSON.parse(data.SecretString)
   }
 
-  class AwsMongoConfigReader {
-    constructor(region, secretId) {
-      this.region = region
-      this.secretId = secretId
-     }
-
-     async readExternalConfig() {
-      const client = new SecretsManagerClient({ region: this.region })
-      const data = await client.send(new GetSecretValueCommand({ SecretId: this.secretId }))
-      return JSON.parse(data.SecretString)
-    }
-
-    async readConfig() {
-      const cfg = await this.readExternalConfig()
-                            .catch(() => (EmptyConfig))
-
-      const { SECRET_KEY, URI } = cfg
-      return { region: this.region, secretKey: SECRET_KEY, connectionUri: URI }
-    }
-
-    async validate() {
-      try {
-        const cfg = await this.readExternalConfig()
-        return { missingRequiredSecretsKeys: checkRequiredKeys(cfg, ['URI', 'SECRET_KEY']) }
-      } catch (err) {
-        return { configReadError: err.message, missingRequiredSecretsKeys: [] }
-      }
-    }
+  async validate() {
+    const { config, secretMangerError } = await this.getExternalAndLocalEnvs()
+    return { missingRequiredSecretsKeys: checkRequiredKeys(config, ['SECRET_KEY']), secretMangerError }
   }
+}
+
+class AwsMongoConfigReader {
+  constructor(region, secretId) {
+    this.region = region
+    this.secretId = secretId
+    }
+
+    async readExternalConfig() {
+    const client = new SecretsManagerClient({ region: this.region })
+    const data = await client.send(new GetSecretValueCommand({ SecretId: this.secretId }))
+    return JSON.parse(data.SecretString)
+  }
+
+  async getExternalAndLocalEnvs() { 
+    const externalConfig = await this.readExternalConfig().catch(emptyConfig)
+    const { SECRET_KEY, URI } = { ...process.env, ...externalConfig }
+    const config = { SECRET_KEY, URI }
+
+    return { config, secretMangerError: externalConfig.secretMangerError }
+  }
+
+  async readConfig() {
+    const { config } = await this.getExternalAndLocalEnvs()
+
+    const { SECRET_KEY, URI } = config
+
+    return { secretKey: SECRET_KEY, connectionUri: URI }
+  }
+
+  async validate() {
+      const { config, secretMangerError } = await this.getExternalAndLocalEnvs()
+      return { missingRequiredSecretsKeys: checkRequiredKeys(config, ['URI', 'SECRET_KEY']), secretMangerError }
+  }
+}
 
 module.exports = { AwsConfigReader, AwsDynamoConfigReader, AwsMongoConfigReader }

--- a/packages/external-db-config/test/drivers/aws_mongo_config_test_support.js
+++ b/packages/external-db-config/test/drivers/aws_mongo_config_test_support.js
@@ -1,0 +1,61 @@
+const { AwsMongoConfigReader } = require('../../lib/readers/aws_config_reader')
+const { SecretsManagerClient, GetSecretValueCommand } = require('@aws-sdk/client-secrets-manager')
+const mockClient = require('aws-sdk-client-mock')
+let mockedAwsSdk
+const { validAuthorizationConfig } = require ('../test_utils')
+
+const Chance = require('chance')
+const chance = new Chance()
+
+const init = () => mockedAwsSdk = mockClient.mockClient(SecretsManagerClient)
+
+const defineValidConfig = (config) => {
+    const awsConfig = { }
+    if (config.connectionUri) {
+        awsConfig.URI = config.connectionUri
+    }
+    if (config.secretKey) {
+        awsConfig.SECRET_KEY = config.secretKey
+    }
+    if (config.authorization) {
+        awsConfig.ROLE_CONFIG = JSON.stringify({ collectionLevelConfig: config.authorization })
+    }
+    mockedAwsSdk.on(GetSecretValueCommand).resolves({ SecretString: JSON.stringify(awsConfig) })
+}
+
+const defineInvalidConfig = () => defineValidConfig({})
+
+const validConfig = () => ({
+    connectionUri: chance.word(),
+    secretKey: chance.word()
+})
+
+const validConfigWithAuthorization = () => ({
+    ...validConfig(),
+    authorization: validAuthorizationConfig.collectionLevelConfig 
+})
+
+const ExpectedProperties = ['URI', 'SECRET_KEY', 'ROLE_CONFIG']
+const RequiredProperties = ['URI', 'SECRET_KEY']
+
+const reset = () => { 
+    mockedAwsSdk.reset()
+    ExpectedProperties.forEach(p => delete process.env[p])
+}
+
+const defineErroneousConfig = (msg) => mockedAwsSdk.on(GetSecretValueCommand).rejects(new Error(msg || chance.word()))
+
+module.exports = {
+    init,
+    defineValidConfig,
+    validConfigWithAuthorization,
+    defineInvalidConfig,
+    defineErroneousConfig,
+    validConfig,
+    reset,
+    hasReadErrors: true,
+    ExpectedProperties,
+    RequiredProperties,
+    configReaderProvider: new AwsMongoConfigReader()
+}
+

--- a/packages/external-db-config/test/drivers/external_config_reader_e2e_test_support.js
+++ b/packages/external-db-config/test/drivers/external_config_reader_e2e_test_support.js
@@ -1,6 +1,7 @@
 const { Uninitialized } = require('test-commons')
 const { create } = require('../../lib/factory')
 const awsMySql = require('./aws_mysql_config_test_support')
+const awsMongo = require('./aws_mongo_config_test_support')
 const azureMySql = require('./azure_mysql_config_test_support')
 const gcpMySql = require('./gcp_mysql_config_test_support')
 const gcpSpanner = require('./gcp_spanner_config_test_support')
@@ -13,6 +14,13 @@ const env = {
 const initDriver = (vendor, engine) => {
     switch (vendor.toLowerCase()) {
         case 'aws':
+            switch(engine) {
+                case 'mysql':
+                case 'postgres':
+                    return awsMySql
+                case 'mongo':
+                    return awsMongo
+            }
             return awsMySql
         case 'azure':
             return azureMySql

--- a/packages/external-db-config/test/drivers/external_config_reader_e2e_test_support.js
+++ b/packages/external-db-config/test/drivers/external_config_reader_e2e_test_support.js
@@ -35,6 +35,7 @@ const initEnv = (vendor, engine) => {
 
     env.configReader = create()
     env.driver = initDriver(vendor, engine)
+    env.driver.init?.()
 }
 
 const ExpectedProperties = ['CLOUD_VENDOR', 'TYPE']

--- a/packages/external-db-config/test/e2e/external_db_config_client.e2e.spec.js
+++ b/packages/external-db-config/test/e2e/external_db_config_client.e2e.spec.js
@@ -6,7 +6,7 @@ const { invalidConfigStatusResponse } = require('./external_db_config_client_mat
 each(
 [
        ['AZURE', ['mysql', 'postgres']],
-       ['AWS', ['mysql', 'postgres']],
+       ['AWS', ['mysql', 'postgres', 'mongo']],
        ['GCP', ['mysql', 'postgres', 'spanner', 'firestore']]
       ]
 ).describe('Config Reader for %s', (vendor, engines) => {

--- a/packages/external-db-config/test/provider/config_reader_service.spec.js
+++ b/packages/external-db-config/test/provider/config_reader_service.spec.js
@@ -7,6 +7,7 @@ const gcpSpannerDriver = require('../drivers/gcp_spanner_config_test_support')
 const gcpFirestoreDriver = require('../drivers/gcp_firestore_config_test_support')
 const azureDriver = require('../drivers/gcp_mysql_config_test_support')
 const awsDriver = require('../drivers/aws_mysql_config_test_support')
+const awsMongoDriver = require('../drivers/aws_mongo_config_test_support')
 const commonDriver = require('../drivers/common_config_test_support')
 
 describe('External DB config client', () => {
@@ -16,6 +17,7 @@ describe('External DB config client', () => {
     ['Vendor: GCP, DB: Firestore', gcpFirestoreDriver],
     ['Vendor: Azure, DB: MySql/Postgres', azureDriver],
     ['Vendor: AWS, DB: MySql/Postgres', awsDriver],
+    ['Vendor: AWS, DB: Mongo', awsMongoDriver],
     ['Vendor: All, Common Config Reader', commonDriver],
   ]).describe('%s', (name, driver) => {
 

--- a/packages/external-db-config/test/provider/config_reader_service.spec.js
+++ b/packages/external-db-config/test/provider/config_reader_service.spec.js
@@ -68,6 +68,14 @@ describe('External DB config client', () => {
 
           expect(expected).toEqual({ secretMangerError: ctx.error, missingRequiredSecretsKeys: driver.RequiredProperties })
       })
+
+      test('read config when part of the config from secret manager and other part from process.env', async() => {
+        driver.defineSplittedConfig(ctx.config)
+
+        const expected = await env.configReaderProvider.readConfig()
+
+        expect(expected).toEqual(ctx.config)
+      })
     }
 
     const ctx = {

--- a/packages/external-db-config/test/test_utils.js
+++ b/packages/external-db-config/test/test_utils.js
@@ -1,7 +1,7 @@
 
 const Chance = require('chance')
 const chance = new Chance()
-
+const { randomElementsFromArray } = require ('test-commons').gen
 const validAuthorizationConfig = {
     collectionLevelConfig: [
         {
@@ -12,4 +12,11 @@ const validAuthorizationConfig = {
     ]
 }
 
-module.exports = { validAuthorizationConfig }
+const splitConfig = (config) => {
+    const firstPart = randomElementsFromArray(Object.keys(config)).reduce((pV, cV) => ({ ...pV, [cV]: config[cV] }), {})
+    
+    const secondPart = Object.keys(config).filter(k => firstPart[k] === undefined)
+                                          .reduce((pV, cV) => ({ ...pV, [cV]: config[cV] }), {})
+    return { firstPart, secondPart }
+}
+module.exports = { validAuthorizationConfig, splitConfig }


### PR DESCRIPTION
fix #226 
Add the ability to read hybrid configuration in AWS - part of it from environment variables, and part of it from the secret manager.