### PR TITLE
Fix aggregation count 

### DIFF
--- a/packages/external-db-bigquery/lib/bigquery_utils.js
+++ b/packages/external-db-bigquery/lib/bigquery_utils.js
@@ -1,6 +1,6 @@
 
 // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
-const escapeIdentifier = (str) => `\`${(str || '').replace(/"/g, '""')}\``
+const escapeIdentifier = (str) => str==='*' ? '*' : `\`${(str || '').replace(/"/g, '""')}\``
 const wildCardWith = (n, char) => Array(n).fill(char, 0, n).join(', ')
 
 const reISO = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/

--- a/packages/external-db-bigquery/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-bigquery/lib/sql_filter_transformer.spec.js
@@ -325,7 +325,7 @@ describe('Sql Parser', () => {
                     }
                     
                     expect(env.filterParser.parseAggregation(aggregation) ).toEqual({
-                        fieldsStatement: `${escapeId(ctx.fieldName)}, CAST(COUNT(${escapeId('*')}) AS FLOAT64) AS ${escapeId(ctx.moreFieldName)}`,
+                        fieldsStatement: `${escapeId(ctx.fieldName)}, CAST(COUNT(*)) AS FLOAT64) AS ${escapeId(ctx.moreFieldName)}`,
                         groupByColumns: [ctx.fieldName],
                         havingFilter: '',
                         parameters: [],

--- a/packages/external-db-mssql/lib/mssql_utils.js
+++ b/packages/external-db-mssql/lib/mssql_utils.js
@@ -13,7 +13,7 @@ const SqlServerSystemTables = ['syblicenseslog', 'sysalternates', 'sysaltusages'
 
 const isSystemTable = collectionId => SqlServerSystemTables.includes(collectionId.trim().toLowerCase())
 
-const escapeId = s => SqlString.escapeId(s)
+const escapeId = s => s === '*' ? '*' : SqlString.escapeId(s)
 const escape = s => SqlString.escape(s)
 const escapeTable = s => {
     if (s && ( s.indexOf('.') !== -1 || isSystemTable(s) )) {

--- a/packages/external-db-mssql/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mssql/lib/sql_filter_transformer.spec.js
@@ -344,7 +344,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseAggregation(aggregation) ).toEqual({
-                        fieldsStatement: `${escapeId(ctx.fieldName)}, COUNT(${escapeId('*')}) AS ${escapeId(ctx.moreFieldName)}`,
+                        fieldsStatement: `${escapeId(ctx.fieldName)}, COUNT(*) AS ${escapeId(ctx.moreFieldName)}`,
                         groupByColumns: [ctx.fieldName],
                         havingFilter: '',
                         parameters: {},

--- a/packages/external-db-mysql/lib/mysql_utils.js
+++ b/packages/external-db-mysql/lib/mysql_utils.js
@@ -10,4 +10,5 @@ const escapeTable = t => {
     return escapeId(t)
 }
 
-module.exports = { wildCardWith, escapeId, escapeTable }
+const escapeIdField = f => f === '*' ? '*' : escapeId(f)
+module.exports = { wildCardWith, escapeId: escapeIdField, escapeTable }

--- a/packages/external-db-mysql/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mysql/lib/sql_filter_transformer.spec.js
@@ -338,7 +338,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect(env.filterParser.parseAggregation(aggregation)).toEqual({
-                        fieldsStatement: `${escapeId(ctx.fieldName)}, COUNT(${escapeId('*')}) AS ${escapeId(ctx.moreFieldName)}`,
+                        fieldsStatement: `${escapeId(ctx.fieldName)}, COUNT(*) AS ${escapeId(ctx.moreFieldName)}`,
                         groupByColumns: [ctx.fieldName],
                         havingFilter: '',
                         parameters: [],

--- a/packages/external-db-postgres/lib/postgres_utils.js
+++ b/packages/external-db-postgres/lib/postgres_utils.js
@@ -1,6 +1,6 @@
 
 // Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
-const escapeIdentifier = (str) => `"${(str || '').replace(/"/g, '""')}"`
+const escapeIdentifier = (str) => str === '*' ? '*' : `"${(str || '').replace(/"/g, '""')}"`
 
 const prepareStatementVariables = (n) => {
     return Array.from({ length: n }, (_, i) => i + 1)

--- a/packages/external-db-postgres/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-postgres/lib/sql_filter_transformer.spec.js
@@ -362,7 +362,7 @@ describe('Sql Parser', () => {
                     }
                     
                     expect(env.filterParser.parseAggregation(aggregation) ).toEqual({
-                        fieldsStatement: `${escapeIdentifier(ctx.fieldName)}, COUNT(${escapeIdentifier('*')}) AS ${escapeIdentifier(ctx.moreFieldName)}`,
+                        fieldsStatement: `${escapeIdentifier(ctx.fieldName)}, COUNT(*) AS ${escapeIdentifier(ctx.moreFieldName)}`,
                         groupByColumns: [ctx.fieldName],
                         havingFilter: '',
                         parameters: [],

--- a/packages/external-db-spanner/lib/spanner_utils.js
+++ b/packages/external-db-spanner/lib/spanner_utils.js
@@ -26,7 +26,7 @@ const validateLiteral = l => {
     return `@${l}`
 }
 
-const escapeFieldId = f => escapeId(patchFieldName(f))
+const escapeFieldId = f => f=== '*' ? '*' : escapeId(patchFieldName(f))
 
 
 const patchFloat = (item, floatFields) => {

--- a/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
@@ -343,7 +343,7 @@ describe('Sql Parser', () => {
                     }
 
                     expect( env.filterParser.parseAggregation(aggregation)).toEqual({
-                        fieldsStatement: `${escapeId(ctx.fieldName)}, COUNT(${escapeId('*')}) AS ${escapeId(ctx.moreFieldName)}`,
+                        fieldsStatement: `${escapeId(ctx.fieldName)}, COUNT(*) AS ${escapeId(ctx.moreFieldName)}`,
                         groupByColumns: [ctx.fieldName],
                         havingFilter: '',
                         parameters: {},

--- a/packages/velo-external-db-core/lib/converters/query_validator.js
+++ b/packages/velo-external-db-core/lib/converters/query_validator.js
@@ -24,13 +24,12 @@ class QueryValidator {
     
     validateAggregation(fields, aggregation) {
         const fieldsWithAliases = aggregation.projection.reduce((pV, cV) => {
+            if (cV.name === '*') return pV
             if (cV.alias) return [...pV, { field: cV.alias, type: fields.find(f => f.field === cV.name).type }]
             return pV
         }, fields)
-
         const fieldNames = fieldsWithAliases.map(f => f.field)
-        const projectionFields = aggregation.projection.map(f => [f.name, f.alias]).flat().filter(f => f !== undefined)
-        
+        const projectionFields = aggregation.projection.filter(f => f.name !== '*').map(f => [f.name, f.alias]).flat().filter(f => f !== undefined)        
         this.validateFilter(fieldsWithAliases, aggregation.postFilter)
         this.validateFieldsExists(fieldNames, projectionFields)
     }


### PR DESCRIPTION
sql databases, refer `*` as column name instead the meaning of all columns, because we used `escapeId` function on `*`.