### PR TITLE
remove generate id for aggregation

### DIFF
--- a/packages/velo-external-db-core/lib/converters/data_utils.js
+++ b/packages/velo-external-db-core/lib/converters/data_utils.js
@@ -3,6 +3,8 @@ const crypto = require('crypto')
 
 const asWixData = e => generateIdsIfNeeded(packDates(e))
 
+const aggregationAsWixData = e => packDates(e)
+
 const generateIdsIfNeeded = item => {
     if ('_id' in item)
         return item
@@ -14,4 +16,4 @@ const generateIdsIfNeeded = item => {
 const packDates = item => Object.entries(item)
                                 .reduce((o, [k, v]) => ({ ...o, [k]: isDate(v) ? { $date: new Date(v).toISOString() } : v }), {})
 
-module.exports = { asWixData, generateIdsIfNeeded }
+module.exports = { asWixData, generateIdsIfNeeded, aggregationAsWixData }

--- a/packages/velo-external-db-core/lib/service/data.js
+++ b/packages/velo-external-db-core/lib/service/data.js
@@ -1,4 +1,4 @@
-const { asWixData } = require('../converters/data_utils')
+const { asWixData, aggregationAsWixData } = require('../converters/data_utils')
 const { getByIdFilterFor } = require ('../utils/data_utils')
 
 class DataService {
@@ -63,7 +63,7 @@ class DataService {
     async aggregate(collectionName, filter, aggregation) {
         return {
             items: (await this.storage.aggregate(collectionName, filter, aggregation))
-                                      .map( asWixData ),
+                                      .map( aggregationAsWixData ),
             totalCount: 0
         }
     }


### PR DESCRIPTION
Due to a problem we had in content manager, we added _id when returning a query result without _id.
This issue relevant only for find, and not for aggregate. 
for aggregate, we get misleading information - because we are generating _id even though the query result shouldn't have _id 
For example, group by 'field1' - the response should have only field1 as column, and the _id we are generating for them is not relevant.