### PR TITLE
add next to errorMiddleware function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,7 +79,10 @@
         ],
         "no-unused-vars": [
             "error",
-            { "ignoreRestSiblings": true }
+            { 
+              "ignoreRestSiblings": true,
+              "argsIgnorePattern": "^_" 
+            }
         ]
         }
 }

--- a/packages/velo-external-db/lib/web/error-middleware.js
+++ b/packages/velo-external-db/lib/web/error-middleware.js
@@ -1,4 +1,4 @@
-const errorMiddleware = (err, req, res) => {
+const errorMiddleware = (err, req, res, _next) => {
   if (process.env.NODE_ENV !== 'test') {
     console.error(err)
   }


### PR DESCRIPTION
The error middleware did not have next in the parameters, so it was unable to access it, leading to the following errors: 
![image](https://user-images.githubusercontent.com/82806105/160345535-cc539df0-f562-4f25-bdf4-75fcb3dc48f7.png)
instead of : 
![image](https://user-images.githubusercontent.com/82806105/160345571-15db6b2e-2381-45bd-88b2-760fd4178c88.png)
