### PR TITLE
Docker image for each db type

### DIFF
--- a/.github/workflows/publish-slim-version.yaml
+++ b/.github/workflows/publish-slim-version.yaml
@@ -1,0 +1,105 @@
+name: Publish Slim Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      gcp:
+        type: boolean
+        description: GCP container registry
+        default: true
+
+      aws:
+        type: boolean
+        description: AWS ECR container registry
+        default: true
+
+      dockerHub:
+        type: boolean
+        description: Docker container registry
+        default: true
+
+jobs:
+  Build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+      
+        database: ["postgres", "spanner", "mysql", "mssql", "mongo", "firestore", "airtable", "dynamodb", "google-sheets"]
+  
+    env:
+      ECR_REPOSITORY: ${{ secrets.AWS_REPO_NAME }}
+      PUBLIC_ECR_URL: ${{ secrets.AWS_REPO_URL }}
+      DOCKERHUB_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      CONTAINER_REGISTRY_FOLDER: ${{ secrets.GCP_CONTAINER_REGISTRY_FOLDER }}
+      IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
+      IMAGE_TAG: ${{ matrix.database }}
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      # Build docker image
+      - name: Build Docker image
+        id: build-image
+        run: docker build --build-arg TYPE=${{ matrix.database }} --progress=plain -t $IMAGE_NAME .
+
+      # Login to Public ECR
+      - name: Login to Public ECR
+        if: github.event.inputs.aws == 'true'
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+      - name: Tag and push the image to Amazon ECR
+        if: github.event.inputs.aws == 'true'
+        id: aws-push-image
+        run: |
+          docker tag $IMAGE_NAME:$IMAGE_TAG $PUBLIC_ECR_URL/$IMAGE_NAME:$IMAGE_TAG
+          echo "Pushing image to ECR..."
+          docker push $PUBLIC_ECR_URL/$IMAGE_NAME:$IMAGE_TAG
+          echo "::set-output name=image::$PUBLIC_ECR_URL/$IMAGE_NAME:$IMAGE_TAG"
+
+      - name: Login to Docker Hub
+        if: github.event.inputs.dockerHub == 'true'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
+      - name: Tag and push the image to Docker Hub
+        if: github.event.inputs.dockerHub == 'true'
+        id: dockerhub-push-image
+        run: |
+          docker tag $IMAGE_NAME $DOCKERHUB_REPOSITORY/$IMAGE_NAME:$IMAGE_TAG
+          echo "Pushing image to Docker Hub..."
+          docker push $DOCKERHUB_REPOSITORY/$IMAGE_NAME:$IMAGE_TAG
+          echo "::set-output name=image::$DOCKERHUB_REPOSITORY/$IMAGE_NAME:$IMAGE_TAG"
+
+      #  Authenticate to Google Cloud
+      - id: auth
+        name: Authenticate to Google Cloud
+        if: github.event.inputs.gcp == 'true'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      # Set up Cloud SDK
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        if: github.event.inputs.gcp == 'true'
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      # Push image to Google Container Registry
+      - name: Tag and push image to GCP container registry
+        if: github.event.inputs.gcp == 'true'
+        run: |
+          gcloud auth configure-docker -q
+          docker tag $IMAGE_NAME:$IMAGE_TAG gcr.io/$GCP_PROJECT_ID/$CONTAINER_REGISTRY_FOLDER
+          docker push gcr.io/$GCP_PROJECT_ID/$CONTAINER_REGISTRY_FOLDER:$IMAGE_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,29 @@
-# Use the official lightweight Node.js image.
-FROM node:lts-slim
-
-# Create and change to the app directory.
+FROM node:lts-slim as full_version
 WORKDIR /usr/lib/app
 
-# Copy application dependency manifests to the container image.
 COPY package.json .
 
-# Installing lerna to install the homemade packages.
 RUN npm install -g lerna
 
-# Copy the local packages.
 COPY packages ./packages/
-
-# Copy lernas configurations.
 COPY lerna.json .
 
-# Install production dependencies of the homemade packages.
-RUN lerna bootstrap -- --production  --hoist
+RUN lerna bootstrap -- --production
 
-# Run velo-external-db service on container startup.
-CMD [  "npm", "--prefix", "packages/velo-external-db", "start" ]
+CMD [ "npm", "--prefix", "packages/velo-external-db", "start" ]
+
+FROM node:lts-slim
+ARG TYPE
+WORKDIR /usr/lib/app
+
+COPY --from=full_version /usr/lib/app/packages/external-db-config/ ./packages/external-db-config/
+COPY --from=full_version /usr/lib/app/packages/velo-external-db/ ./packages/velo-external-db/
+COPY --from=full_version /usr/lib/app/packages/velo-external-db-core/ ./packages/velo-external-db-core/
+COPY --from=full_version /usr/lib/app/packages/external-db-security/ ./packages/external-db-security/
+COPY --from=full_version /usr/lib/app/packages/velo-external-db-commons/ ./packages/velo-external-db-commons/
+
+COPY --from=full_version /usr/lib/app/packages/external-db-${TYPE}/ ./packages/external-db-${TYPE}/
+
+ENV TYPE=${TYPE}
+
+CMD [ "npm", "--prefix", "packages/velo-external-db", "start" ]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "start": "lerna exec --scope velo-external-db \"npm run start\"",
     "build:dev": "lerna bootstrap --hoist",
+    "build:full-image": "docker build --target full_version -t velo-external-db .",
     "lint": "eslint --cache ./",
     "lint:fix": "eslint --cache --fix ./",
     "test": "npm run test:core; npm run test:postgres; npm run test:spanner; npm run test:mysql; npm run test:mssql; npm run test:firestore; npm run test:mongo; npm run test:airtable; npm run test:dynamodb; npm run test:bigquery",


### PR DESCRIPTION
This PR lets create a docker image for each db type, with the environment variable corresponding to the selected database type.

For example, if the user wants to run a cloud run instance with a Postgres database, he will use the next image link in the creation process of the cloud run instance: `gcr.io/wix-velo-api/velo-external-db:postgres`
**without the need to insert an environment variable that specifies the db type**

In addition, this pr has a special GitHub workflow that will create for each supported db an image and will push it to GCP, AWS and docker hub. 

 Interesting fact: In this way, the image size is reduced to ~200 MB compared to 570 MB in the full version