### PR TITLE
Fix IS NULL / IS NOT NULL bug

### DIFF
--- a/packages/external-db-bigquery/lib/sql_filter_transformer.js
+++ b/packages/external-db-bigquery/lib/sql_filter_transformer.js
@@ -1,6 +1,6 @@
 const { InvalidQuery } = require('velo-external-db-commons').errors
 const { escapeIdentifier, wildCardWith } = require('./bigquery_utils')
-const { EmptyFilter, EmptySort, isObject, isEmptyFilter, AdapterOperators, AdapterFunctions, extractGroupByNames, extractProjectionFunctionsObjects } = require('velo-external-db-commons')
+const { EmptyFilter, EmptySort, isObject, isEmptyFilter, AdapterOperators, AdapterFunctions, extractGroupByNames, extractProjectionFunctionsObjects, isNull } = require('velo-external-db-commons')
 const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_contains, and, or, not, urlized } = AdapterOperators
 const { avg, max, min, sum, count } = AdapterFunctions
 
@@ -104,7 +104,7 @@ class FilterParser {
         if (this.isSingleFieldOperator(operator)) {
             return [{
                 filterExpr: `${escapeIdentifier(fieldName)} ${this.adapterOperatorToMySqlOperator(operator, value)} ${this.valueForOperator(value, operator)}`.trim(),
-                parameters: value !== undefined ? [].concat( this.patchTrueFalseValue(value) ) : []
+                parameters: !isNull(value) ? [].concat( this.patchTrueFalseValue(value) ) : []
             }]
         }
 
@@ -146,11 +146,11 @@ class FilterParser {
 
     valueForOperator(value, operator) {
         if (operator === include) {
-            if (value === undefined || value.length === 0) {
+            if (isNull(value) || value.length === 0) {
                 throw new InvalidQuery('$hasSome cannot have an empty list of arguments')
             }
             return `(${wildCardWith(value.length, '?')})`
-        } else if (operator === eq && value === undefined) {
+        } else if ((operator === eq || operator === ne) && isNull(value)) {
             return ''
         }
 
@@ -160,12 +160,15 @@ class FilterParser {
     adapterOperatorToMySqlOperator(operator, value) {
         switch (operator) {
             case eq:
-                if (value !== undefined) {
+                if (!isNull(value)) {
                     return '='
                 }
                 return 'IS NULL'
             case ne:
-                return '<>'
+                if (!isNull(value)) {
+                    return '<>'
+                }
+                return 'IS NOT NULL'
             case lt:
                 return '<'
             case lte:

--- a/packages/external-db-bigquery/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-bigquery/lib/sql_filter_transformer.spec.js
@@ -115,15 +115,33 @@ describe('Sql Parser', () => {
                 expect( () => env.filterParser.parseFilter(filter) ).toThrow(InvalidQuery)
             })
 
-            test('correctly transform operator [eq] with null value', () => {
+            each([
+                undefined, null
+            ]).test('correctly transform operator [eq] with null value [%s]', (value) => {
                 const filter = {
                     operator: eq,
                     fieldName: ctx.fieldName,
-                    value: undefined                    
+                    value
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
                     filterExpr: `${escapeId(ctx.fieldName)} IS NULL`,
+                    parameters: []
+                }])
+
+            })
+
+            each([
+                undefined, null
+            ]).test('correctly transform operator [ne] with null value [%s]', (value) => {
+                const filter = {
+                    operator: ne,
+                    fieldName: ctx.fieldName,
+                    value
+                }
+
+                expect( env.filterParser.parseFilter(filter) ).toEqual([{
+                    filterExpr: `${escapeId(ctx.fieldName)} IS NOT NULL`,
                     parameters: []
                 }])
 
@@ -325,7 +343,7 @@ describe('Sql Parser', () => {
                     }
                     
                     expect(env.filterParser.parseAggregation(aggregation) ).toEqual({
-                        fieldsStatement: `${escapeId(ctx.fieldName)}, CAST(COUNT(*)) AS FLOAT64) AS ${escapeId(ctx.moreFieldName)}`,
+                        fieldsStatement: `${escapeId(ctx.fieldName)}, CAST(COUNT(*) AS FLOAT64) AS ${escapeId(ctx.moreFieldName)}`,
                         groupByColumns: [ctx.fieldName],
                         havingFilter: '',
                         parameters: [],

--- a/packages/external-db-mssql/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mssql/lib/sql_filter_transformer.spec.js
@@ -136,15 +136,32 @@ describe('Sql Parser', () => {
                 expect( () => env.filterParser.parseFilter(filter) ).toThrow(InvalidQuery)
             })
 
-            test('correctly transform operator [$eq] with null value', () => {
+            each([
+                undefined, null
+            ]).test('correctly transform operator [$eq] with null value [%s]', (value) => {
                 const filter = {
                     operator: eq,
                     fieldName: ctx.fieldName,
-                    value: undefined                    
+                    value
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
                     filterExpr: `${escapeId(ctx.fieldName)} IS NULL`,
+                    parameters: { }
+                }])
+            })
+
+            each([
+                undefined, null
+            ]).test('correctly transform operator [$ne] with null value [%s]', (value) => {
+                const filter = {
+                    operator: ne,
+                    fieldName: ctx.fieldName,
+                    value
+                }
+
+                expect( env.filterParser.parseFilter(filter) ).toEqual([{
+                    filterExpr: `${escapeId(ctx.fieldName)} IS NOT NULL`,
                     parameters: { }
                 }])
             })

--- a/packages/external-db-mysql/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-mysql/lib/sql_filter_transformer.spec.js
@@ -127,15 +127,33 @@ describe('Sql Parser', () => {
                 expect( () => env.filterParser.parseFilter(filter) ).toThrow(InvalidQuery)
             })
 
-            test('correctly transform operator [eq] with null value', () => {
+            each([
+                undefined, null
+            ]).test('correctly transform operator [eq] with null value [%s]', (value) => {
                 const filter = {
                     operator: eq,
                     fieldName: ctx.fieldName,
-                    value: undefined                    
+                    value                    
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
                     filterExpr: `${escapeId(ctx.fieldName)} IS NULL`,
+                    parameters: []
+                }])
+
+            })
+            
+            each([
+                undefined, null
+            ]).test('correctly transform operator [ne] with null value [%s]', (value) => {
+                const filter = {
+                    operator: ne,
+                    fieldName: ctx.fieldName,
+                    value                    
+                }
+
+                expect( env.filterParser.parseFilter(filter) ).toEqual([{
+                    filterExpr: `${escapeId(ctx.fieldName)} IS NOT NULL`,
                     parameters: []
                 }])
 

--- a/packages/external-db-postgres/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-postgres/lib/sql_filter_transformer.spec.js
@@ -135,11 +135,13 @@ describe('Sql Parser', () => {
                 expect( () => env.filterParser.parseFilter(filter, ctx.offset) ).toThrow(InvalidQuery)
             })
 
-            test('correctly transform operator [eq] with null value', () => {
+            each([
+                undefined, null
+            ]).test('correctly transform operator [eq] with null value [%s]', (value) => {
                 const filter = {
                     operator: eq,
                     fieldName: ctx.fieldName,
-                    value: undefined                    
+                    value
                 }
 
                 expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
@@ -149,7 +151,24 @@ describe('Sql Parser', () => {
                     parameters: []
                 }])
             })
+            
+            each([
+                undefined, null
+            ]).test('correctly transform operator [ne] with null value [%s]', (value) => {
+                const filter = {
+                    operator: ne,
+                    fieldName: ctx.fieldName,
+                    value
+                }
 
+                expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
+                    filterExpr: `${escapeIdentifier(ctx.fieldName)} IS NOT NULL`,
+                    filterColumns: [],
+                    offset: ctx.offset,
+                    parameters: []
+                }])
+            })
+            
             test('correctly transform operator [eq] with boolean value', () => {
                 const value = chance.bool()
                 const filter = {

--- a/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
@@ -135,15 +135,32 @@ describe('Sql Parser', () => {
                 expect( () => env.filterParser.parseFilter(filter) ).toThrow(InvalidQuery)
             })
 
-            test('correctly transform operator [eq] with null value', () => {
+            each([
+                undefined, null
+            ]).test('correctly transform operator [eq] with null value [%s]', (value) => {
                 const filter = {
                     operator: eq,
                     fieldName: ctx.fieldName,
-                    value: undefined                    
+                    value
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
                     filterExpr: `${escapeId(ctx.fieldName)} IS NULL`,
+                    parameters: { }
+                }])
+            })
+            
+            each([
+                undefined, null
+            ]).test('correctly transform operator [ne] with null value [%s]', (value) => {
+                const filter = {
+                    operator: ne,
+                    fieldName: ctx.fieldName,
+                    value
+                }
+
+                expect( env.filterParser.parseFilter(filter) ).toEqual([{
+                    filterExpr: `${escapeId(ctx.fieldName)} IS NOT NULL`,
                     parameters: { }
                 }])
             })

--- a/packages/velo-external-db-commons/lib/data_commons.js
+++ b/packages/velo-external-db-commons/lib/data_commons.js
@@ -74,6 +74,8 @@ const extractGroupByNames = (projection) =>  projection.filter(f => !f.function)
 
 const extractProjectionFunctionsObjects = (projection) => projection.filter(f => f.function)
 
+const isNull = (value) => (value === null || value === undefined)
+
 module.exports = { EmptyFilter, EmptySort, patchDateTime, asParamArrays, isObject, isDate,
                      updateFieldsFor, isEmptyFilter, AdapterOperators, AdapterFunctions,
-                     extractGroupByNames, extractProjectionFunctionsObjects }
+                     extractGroupByNames, extractProjectionFunctionsObjects, isNull }


### PR DESCRIPTION
As you probably know, **It is not possible to test for NULL values with comparison operators**

On SQL databases, when we preformed this kind of query : 
`wixData.query("sql/collection").ne("field", null).find()`
we should create this query : 
`select ... from collection where field is not null`
 and currently we are creating this query : 
`select ... from collection where field <> null ` 

same for equal operator