### PR TITLE
fix authorization config reader

### DIFF
--- a/packages/external-db-config/lib/readers/authorization_config_reader.js
+++ b/packages/external-db-config/lib/readers/authorization_config_reader.js
@@ -1,4 +1,4 @@
-const { checkRequiredKeys, isJson, EmptyRoleConfig, configPattern, collectionConfigPattern } = require('../utils/config_utils')
+const { checkRequiredKeys, isJson, jsonParser, EmptyRoleConfig, configPattern, collectionConfigPattern } = require('../utils/config_utils')
 const Avj = require('ajv')
 const ajv = new Avj({ strict: false })
 
@@ -10,10 +10,8 @@ class AuthorizationConfigReader {
 
   async readConfig() {
     const { ROLE_CONFIG: roleConfig } = process.env
-    console.log(roleConfig)
-    isJson(roleConfig) ? console.log(JSON.parse(roleConfig)) : ''
 
-    const { collectionLevelConfig } = (isJson(roleConfig) && Array.isArray( (JSON.parse(roleConfig)).collectionLevelConfig ) ) ? JSON.parse(roleConfig) : EmptyRoleConfig
+    const { collectionLevelConfig } = (isJson(roleConfig) && Array.isArray( (jsonParser(roleConfig)).collectionLevelConfig ) ) ? jsonParser(roleConfig) : EmptyRoleConfig
 
     return collectionLevelConfig.filter(collection => this.collectionValidator(collection))
   }
@@ -21,7 +19,7 @@ class AuthorizationConfigReader {
   validate() {
     const { ROLE_CONFIG: roleConfig } = process.env
     
-    const valid = isJson(roleConfig) && this.configValidator(JSON.parse(roleConfig))
+    const valid = isJson(roleConfig) && this.configValidator(jsonParser(roleConfig))
     let message 
     
 

--- a/packages/external-db-config/lib/utils/config_utils.js
+++ b/packages/external-db-config/lib/utils/config_utils.js
@@ -28,8 +28,14 @@ const configPattern = {
 
 const isJson = (str) => { try { JSON.parse(str); return true } catch (e) { return false } }
 
+const jsonParser = (str) => {
+    let parsed = JSON.parse(str)
+    if (typeof parsed === 'string') parsed = jsonParser(parsed)
+    return parsed
+ }
+
 const EmptyRoleConfig = {
     collectionLevelConfig: []
 }
 
-module.exports = { checkRequiredKeys, supportedDBs, supportedVendors, isJson, EmptyRoleConfig, configPattern, collectionConfigPattern }
+module.exports = { checkRequiredKeys, supportedDBs, supportedVendors, isJson, jsonParser, EmptyRoleConfig, configPattern, collectionConfigPattern }

--- a/packages/external-db-config/lib/utils/config_utils.spec.js
+++ b/packages/external-db-config/lib/utils/config_utils.spec.js
@@ -1,6 +1,6 @@
 const Chance = require('chance')
 const chance = Chance()
-const { checkRequiredKeys } = require('../utils/config_utils')
+const { checkRequiredKeys, jsonParser } = require('../utils/config_utils')
 const { gen } = require('test-commons')
 
 
@@ -35,4 +35,13 @@ describe('Check Required Keys Function', () => {
     test('property detect non empty string prop', () => {
         expect(checkRequiredKeys({ prop: chance.word() }, ['prop'])).toEqual([])
     })
+
+    test('jsonParser should return json object on quoted string', () => {
+        expect(jsonParser('{}')).toEqual({})
+    })
+
+    test('jsonParser should return json object on double quoted string', () => {
+        expect(jsonParser('"{}"')).toEqual({})
+    })
+
 })


### PR DESCRIPTION
Getting the JSON double or more quoted was the issue, but that's only happened in some environments, so I've added a function to make it parse it as long as necessary.