### PR TITLE
Test hasSome operator

### DIFF
--- a/packages/external-db-bigquery/lib/supported_operations.js
+++ b/packages/external-db-bigquery/lib/supported_operations.js
@@ -1,5 +1,5 @@
-const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, StartWithCaseSensitive, Projection, Matches, NotOperator } = require('velo-external-db-commons').SchemaOperations
+const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, StartWithCaseSensitive, Projection, Matches, NotOperator, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, StartWithCaseSensitive, Projection, Matches, NotOperator ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, StartWithCaseSensitive, Projection, Matches, NotOperator, IncludeOperator ]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-bigquery/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-bigquery/tests/drivers/sql_filter_transformer_test_support.js
@@ -77,6 +77,10 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                             .join('')]
                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeIdentifier('_id')} IN (?)`, parameters: [value] })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -88,6 +92,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
 }

--- a/packages/external-db-dynamodb/lib/sql_filter_transformer.js
+++ b/packages/external-db-dynamodb/lib/sql_filter_transformer.js
@@ -89,17 +89,13 @@ class FilterParser {
             if (value === undefined || value.length === 0)
                 throw new InvalidQuery('$hasSome cannot have an empty list of arguments')
 
-            const filterExpressionVariables = { ...value }
-
             return [{
                 filterExpr: {
-                    FilterExpression: `#${fieldName} IN (${Object.keys(filterExpressionVariables).map(f => `:${f}`).join(', ')})`,
+                    FilterExpression: `#${fieldName} IN (${value.map((_v, i) => `:${i}`).join(', ')})`,
                     ExpressionAttributeNames: {
                         [`#${fieldName}`]: fieldName
                     },
-                    ExpressionAttributeValues: {
-                        ...filterExpressionVariables
-                    }
+                    ExpressionAttributeValues: value.reduce((pV, cV, i) => ({ ...pV, [`:${i}`]: cV }), {})                 
                 }
             }] 
 

--- a/packages/external-db-dynamodb/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-dynamodb/lib/sql_filter_transformer.spec.js
@@ -91,7 +91,8 @@ describe('Sql Parser', () => {
                     filterExpr: {
                         FilterExpression: `#${ctx.fieldName} IN (:0, :1, :2, :3, :4)`,
                         ExpressionAttributeNames: { [`#${ctx.fieldName}`]: ctx.fieldName },
-                        ExpressionAttributeValues: { ...ctx.fieldListValue } 
+                        ExpressionAttributeValues: { ':0': ctx.fieldListValue[0], ':1': ctx.fieldListValue[1], ':2': ctx.fieldListValue[2],
+                                                     ':3': ctx.fieldListValue[3], ':4': ctx.fieldListValue[4] } 
                     }
                 }])
             })

--- a/packages/external-db-dynamodb/lib/supported_operations.js
+++ b/packages/external-db-dynamodb/lib/supported_operations.js
@@ -1,5 +1,5 @@
-const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject } = require('velo-external-db-commons').SchemaOperations
+const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject, IncludeOperator ]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-dynamodb/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-dynamodb/tests/drivers/sql_filter_transformer_test_support.js
@@ -101,6 +101,19 @@ const givenNotFilterQueryFor = (filter, column, value) =>
                                 }
                             })
 
+const givenIncludeFilterFor_idColumn = (filter, value) =>
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: {
+                                    FilterExpression: '#_id IN (:0)',
+                                    ExpressionAttributeNames: {
+                                        ['#_id']: '_id'
+                                    },
+                                    ExpressionAttributeValues: {
+                                        [':0']: value
+                                    }
+                                }
+                            })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -112,5 +125,5 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, stubEmptyOrderByFor, stubEmptyFilterFor,
                    givenFilterByIdWith, filterParser, reset, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenIncludeFilterFor_idColumn
 }

--- a/packages/external-db-firestore/lib/supported_operations.js
+++ b/packages/external-db-firestore/lib/supported_operations.js
@@ -1,5 +1,5 @@
-const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, StartWithCaseSensitive, FindObject } = require('velo-external-db-commons').SchemaOperations
+const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, StartWithCaseSensitive, FindObject, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, StartWithCaseSensitive, FindObject ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, StartWithCaseSensitive, FindObject, IncludeOperator ]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-firestore/package.json
+++ b/packages/external-db-firestore/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/wix-private/noam-external-db-poc.git"
   },
   "scripts": {
-    "test": ""
+    "test": "jest"
   },
   "bugs": {
     "url": "https://github.com/wix-private/noam-external-db-poc/issues"
@@ -32,6 +32,7 @@
   "devDependencies": {
     "jest": "^27.5.1",
     "jest-when": "^3.5.1",
-    "test-commons": "^0.0.0"
+    "test-commons": "^0.0.0",
+    "chance": "^1.1.8"
   }
 }

--- a/packages/external-db-firestore/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-firestore/tests/drivers/sql_filter_transformer_test_support.js
@@ -85,6 +85,14 @@ const givenGreaterThenFilterFor = (filter, column, value) =>
                                     value,
                                 }])
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue([{
+                                    fieldName: '_id',
+                                    opStr: 'in',
+                                    value: [value],
+                                }])
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -95,6 +103,6 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
-                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor,
+                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
                 }

--- a/packages/external-db-firestore/tests/gen.js
+++ b/packages/external-db-firestore/tests/gen.js
@@ -1,0 +1,20 @@
+const Chance = require('chance')
+const chance = Chance()
+const { AdapterOperators } = require('velo-external-db-commons')
+const { eq, gt, gte, include, lt, lte, ne } = AdapterOperators
+
+
+const randomSupportedFilter = () => {
+    const operator = chance.pickone([ne, lt, lte, gt, gte, include, eq])
+    const fieldName = chance.word()
+    const value = operator === include ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
+    return {
+        fieldName,
+        operator,
+        value
+    }
+}
+
+
+
+module.exports = { randomSupportedFilter }

--- a/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
@@ -89,6 +89,10 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     }
                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: { _id: { $in: [value] } } })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -100,6 +104,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
 }

--- a/packages/external-db-mssql/lib/supported_operations.js
+++ b/packages/external-db-mssql/lib/supported_operations.js
@@ -1,6 +1,6 @@
 const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, 
-        Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, NotOperator, Matches } = require('velo-external-db-commons').SchemaOperations
+        Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, NotOperator, Matches, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, NotOperator, Matches ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, NotOperator, Matches, IncludeOperator ]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-mssql/lib/supported_operations.js
+++ b/packages/external-db-mssql/lib/supported_operations.js
@@ -1,6 +1,6 @@
 const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, 
-        Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection } = require('velo-external-db-commons').SchemaOperations
+        Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, NotOperator, Matches } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, NotOperator, Matches ]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-mssql/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mssql/tests/drivers/sql_filter_transformer_test_support.js
@@ -79,6 +79,10 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                                     } 
                                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeId('_id')} IN (${validateLiteral('_id')})`, parameters: { [patchFieldName('_id')]: value } })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -90,6 +94,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
 }

--- a/packages/external-db-mysql/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mysql/tests/drivers/sql_filter_transformer_test_support.js
@@ -78,6 +78,10 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                         .join('')
                                 ] })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeId('_id')} IN (?)`, parameters: [value] })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -89,6 +93,6 @@ module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByF
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor,
                    givenStartsWithFilterFor, givenGreaterThenFilterFor,
-                   givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset 
 }

--- a/packages/external-db-postgres/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-postgres/tests/drivers/sql_filter_transformer_test_support.js
@@ -79,6 +79,11 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     offset: 2
                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeIdentifier('_id')} IN ($1)`, parameters: [value], offset: 2 })
+
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -90,6 +95,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor, stubEmptyFilterFor, 
                    givenFilterByIdWith, givenAggregateQueryWith, givenAllFieldsProjectionFor,
                    givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor,
-                   givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
 }

--- a/packages/external-db-spanner/lib/sql_filter_transformer.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.js
@@ -171,7 +171,7 @@ class FilterParser {
 
     prepareStatementVariables(n, fieldName) {
 
-        return Array.from({ length: n }, (_, i) => validateLiteral(`${patchFieldName(fieldName)}${i + 1}`) )
+        return Array.from({ length: n }, (_, i) => validateLiteral(`${(fieldName)}${i + 1}`) )
                     .join(', ')
     }
 

--- a/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-spanner/lib/sql_filter_transformer.spec.js
@@ -1,6 +1,6 @@
 const FilterParser = require('./sql_filter_transformer')
 const { EmptySort, AdapterOperators, AdapterFunctions } = require('velo-external-db-commons')
-const { escapeId } = require('./spanner_utils')
+const { escapeId, escapeFieldId } = require('./spanner_utils')
 const { Uninitialized, gen } = require('test-commons')
 const { InvalidQuery } = require('velo-external-db-commons').errors
 const each = require('jest-each').default
@@ -114,13 +114,32 @@ describe('Sql Parser', () => {
                 }
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                    filterExpr: `${escapeId(ctx.fieldName)} IN (@${ctx.fieldName}1, @${ctx.fieldName}2, @${ctx.fieldName}3, @${ctx.fieldName}4, @${ctx.fieldName}5)`,
+                    filterExpr: `${escapeFieldId(ctx.fieldName)} IN (@${ctx.fieldName}1, @${ctx.fieldName}2, @${ctx.fieldName}3, @${ctx.fieldName}4, @${ctx.fieldName}5)`,
                     parameters: {
                         [`${ctx.fieldName}1`]: ctx.fieldListValue[0],
                         [`${ctx.fieldName}2`]: ctx.fieldListValue[1],
                         [`${ctx.fieldName}3`]: ctx.fieldListValue[2],
                         [`${ctx.fieldName}4`]: ctx.fieldListValue[3],
                         [`${ctx.fieldName}5`]: ctx.fieldListValue[4],
+                    }
+                }])
+            })
+
+            test('correctly transform operator [include] with _id field', () => {
+                const filter = {
+                    operator: include,
+                    fieldName: '_id',
+                    value: ctx.fieldListValue
+                }
+
+                expect( env.filterParser.parseFilter(filter) ).toEqual([{
+                    filterExpr: `${escapeFieldId(filter.fieldName)} IN (@${filter.fieldName}1, @${filter.fieldName}2, @${filter.fieldName}3, @${filter.fieldName}4, @${filter.fieldName}5)`,
+                    parameters: {
+                        [`${filter.fieldName}1`]: ctx.fieldListValue[0],
+                        [`${filter.fieldName}2`]: ctx.fieldListValue[1],
+                        [`${filter.fieldName}3`]: ctx.fieldListValue[2],
+                        [`${filter.fieldName}4`]: ctx.fieldListValue[3],
+                        [`${filter.fieldName}5`]: ctx.fieldListValue[4],
                     }
                 }])
             })

--- a/packages/external-db-spanner/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-spanner/tests/drivers/sql_filter_transformer_test_support.js
@@ -86,6 +86,12 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     }
                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, id) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeFieldId('_id')} IN (${validateLiteral('_id')})`, parameters: {
+                                    _id: id
+                                } })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -97,6 +103,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                     givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                    givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor,
+                    givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                     filterParser, reset
 }

--- a/packages/velo-external-db-commons/lib/schema_commons.js
+++ b/packages/velo-external-db-commons/lib/schema_commons.js
@@ -56,6 +56,7 @@ const SchemaOperations = Object.freeze({
     FindObject: 'findObject',
     Matches: 'matches',
     NotOperator: 'not',
+    IncludeOperator: 'include',
 })
 
 const AllSchemaOperations = Object.values(SchemaOperations)

--- a/packages/velo-external-db/test/drivers/data_provider_matchers.js
+++ b/packages/velo-external-db/test/drivers/data_provider_matchers.js
@@ -1,3 +1,6 @@
+const matchers = require ('jest-extended')
+expect.extend(matchers)
+
 const entitiesWithOwnerFieldOnly = (entities) => expect.arrayContaining(entities.map(e => ({ _owner: e._owner })))
 
 const entityWithObjectField = (entity, entityFields) => {

--- a/packages/velo-external-db/test/drivers/data_provider_matchers.js
+++ b/packages/velo-external-db/test/drivers/data_provider_matchers.js
@@ -1,5 +1,3 @@
-const matchers = require ('jest-extended')
-expect.extend(matchers)
 
 const entitiesWithOwnerFieldOnly = (entities) => expect.arrayContaining(entities.map(e => ({ _owner: e._owner })))
 

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -155,7 +155,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
-    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres', 'Sql Server'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres', 'Sql Server', 'BigQuery'], currentDbImplementationName())) {
         test('include operator on _id field', async() => { 
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
         env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -155,7 +155,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
-    if (shouldRunOnlyOn(['MySql', 'Spanner'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres'], currentDbImplementationName())) {
         test('include operator on _id field', async() => { 
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
         env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -155,7 +155,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
-    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres', 'Sql Server', 'BigQuery'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres', 'Sql Server', 'BigQuery', 'DynamoDb'], currentDbImplementationName())) {
         test('include operator on _id field', async() => { 
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
         env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -155,7 +155,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
-    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres', 'Sql Server', 'BigQuery', 'DynamoDb'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres', 'Sql Server', 'BigQuery', 'DynamoDb', 'Firestore'], currentDbImplementationName())) {
         test('include operator on _id field', async() => { 
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
         env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -155,7 +155,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
-    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres', 'Sql Server'], currentDbImplementationName())) {
         test('include operator on _id field', async() => { 
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
         env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -1,4 +1,4 @@
-const { Uninitialized, testIfSupportedOperationsIncludes, shouldNotRunOn, shouldRunOnlyOn } = require('test-commons')
+const { Uninitialized, testIfSupportedOperationsIncludes, shouldNotRunOn } = require('test-commons')
 const { FindWithSort, DeleteImmediately, Aggregate, UpdateImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, Matches, NotOperator, FindObject } = require('velo-external-db-commons').SchemaOperations
 
 const Chance = require('chance')
@@ -155,7 +155,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
-    if (shouldRunOnlyOn(['MySql', 'Spanner', 'Postgres', 'Sql Server', 'BigQuery', 'DynamoDb', 'Firestore'], currentDbImplementationName())) {
+    if (shouldNotRunOn(['Google-Sheet', 'Airtable'], currentDbImplementationName())) {
         test('include operator on _id field', async() => { 
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
         env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -155,6 +155,16 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
+    if (shouldNotRunOn(['Google-Sheet'], currentDbImplementationName())) {
+        test('include operator on _id field', async() => { 
+        await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
+        env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)
+        env.driver.stubEmptyOrderByFor(ctx.sort)
+        env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
+
+        await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, 0, 50, ctx.projection) ).resolves.toEqual([ctx.entity])
+    })
+    }
 
     testIfSupportedOperationsIncludes(supportedOperations, [ DeleteImmediately ])('delete data from collection', async() => {
         await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -1,5 +1,5 @@
 const { Uninitialized, testIfSupportedOperationsIncludes, shouldNotRunOn } = require('test-commons')
-const { FindWithSort, DeleteImmediately, Aggregate, UpdateImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, Matches, NotOperator, FindObject } = require('velo-external-db-commons').SchemaOperations
+const { FindWithSort, DeleteImmediately, Aggregate, UpdateImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, Matches, NotOperator, FindObject, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
 const Chance = require('chance')
 const gen = require('../gen')
@@ -155,8 +155,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
-    if (shouldNotRunOn(['Google-Sheet', 'Airtable'], currentDbImplementationName())) {
-        test('include operator on _id field', async() => { 
+    testIfSupportedOperationsIncludes(supportedOperations, [ IncludeOperator ])('include operator on _id field', async() => {
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
         env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)
         env.driver.stubEmptyOrderByFor(ctx.sort)
@@ -164,7 +163,6 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
 
         await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, 0, 50, ctx.projection) ).resolves.toEqual([ctx.entity])
     })
-    }
 
     testIfSupportedOperationsIncludes(supportedOperations, [ DeleteImmediately ])('delete data from collection', async() => {
         await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -1,4 +1,4 @@
-const { Uninitialized, testIfSupportedOperationsIncludes, shouldNotRunOn } = require('test-commons')
+const { Uninitialized, testIfSupportedOperationsIncludes, shouldNotRunOn, shouldRunOnlyOn } = require('test-commons')
 const { FindWithSort, DeleteImmediately, Aggregate, UpdateImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, Matches, NotOperator, FindObject } = require('velo-external-db-commons').SchemaOperations
 
 const Chance = require('chance')
@@ -155,7 +155,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
-    if (shouldNotRunOn(['Google-Sheet'], currentDbImplementationName())) {
+    if (shouldRunOnlyOn(['MySql', 'Spanner'], currentDbImplementationName())) {
         test('include operator on _id field', async() => { 
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
         env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)


### PR DESCRIPTION
Content manager made a change, before each insert/update they perform data/find with _hasSome_ operator AKA _includes_ with _id value. 

The test is testing the flow of - data/find on single _id value.
 
- [x] MySQL
- [x] Spanner
- [x] Postgres
- [x] MSSQL
- [x] BigQuery
- [x] Dynmodb
- [x] Firestore
- [x] MongoDB
- [x] Google-Sheets - not implemented
- [x] AirTable - mock doesn't support include
