### PR TITLE
Test hasSome operator

### DIFF
--- a/packages/external-db-bigquery/lib/supported_operations.js
+++ b/packages/external-db-bigquery/lib/supported_operations.js
@@ -1,5 +1,5 @@
-const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, StartWithCaseSensitive, Projection, Matches, NotOperator } = require('velo-external-db-commons').SchemaOperations
+const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, StartWithCaseSensitive, Projection, Matches, NotOperator, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, StartWithCaseSensitive, Projection, Matches, NotOperator ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, StartWithCaseSensitive, Projection, Matches, NotOperator, IncludeOperator]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-bigquery/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-bigquery/tests/drivers/sql_filter_transformer_test_support.js
@@ -77,6 +77,10 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                             .join('')]
                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeIdentifier('_id')} IN (?)`, parameters: [value] })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -88,6 +92,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
 }

--- a/packages/external-db-bigquery/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-bigquery/tests/drivers/sql_filter_transformer_test_support.js
@@ -77,7 +77,7 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                             .join('')]
                                 })
 
-const givenIncludeFilterFor_idColumn = (filter, value) => 
+const givenIncludeFilterForIdColumn = (filter, value) => 
     when(filterParser.transform).calledWith(filter)
                                 .mockReturnValue({ filterExpr: `WHERE ${escapeIdentifier('_id')} IN (?)`, parameters: [value] })
 
@@ -92,6 +92,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterForIdColumn,
                    filterParser, reset
 }

--- a/packages/external-db-dynamodb/lib/sql_filter_transformer.js
+++ b/packages/external-db-dynamodb/lib/sql_filter_transformer.js
@@ -89,17 +89,13 @@ class FilterParser {
             if (value === undefined || value.length === 0)
                 throw new InvalidQuery('$hasSome cannot have an empty list of arguments')
 
-            const filterExpressionVariables = { ...value }
-
             return [{
                 filterExpr: {
-                    FilterExpression: `#${fieldName} IN (${Object.keys(filterExpressionVariables).map(f => `:${f}`).join(', ')})`,
+                    FilterExpression: `#${fieldName} IN (${value.map((_v, i) => `:${i}`).join(', ')})`,
                     ExpressionAttributeNames: {
                         [`#${fieldName}`]: fieldName
                     },
-                    ExpressionAttributeValues: {
-                        ...filterExpressionVariables
-                    }
+                    ExpressionAttributeValues: value.reduce((pV, cV, i) => ({ ...pV, [`:${i}`]: cV }), {})                 
                 }
             }] 
 

--- a/packages/external-db-dynamodb/lib/sql_filter_transformer.spec.js
+++ b/packages/external-db-dynamodb/lib/sql_filter_transformer.spec.js
@@ -91,7 +91,8 @@ describe('Sql Parser', () => {
                     filterExpr: {
                         FilterExpression: `#${ctx.fieldName} IN (:0, :1, :2, :3, :4)`,
                         ExpressionAttributeNames: { [`#${ctx.fieldName}`]: ctx.fieldName },
-                        ExpressionAttributeValues: { ...ctx.fieldListValue } 
+                        ExpressionAttributeValues: { ':0': ctx.fieldListValue[0], ':1': ctx.fieldListValue[1], ':2': ctx.fieldListValue[2],
+                                                     ':3': ctx.fieldListValue[3], ':4': ctx.fieldListValue[4] } 
                     }
                 }])
             })

--- a/packages/external-db-dynamodb/lib/supported_operations.js
+++ b/packages/external-db-dynamodb/lib/supported_operations.js
@@ -1,5 +1,5 @@
-const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject } = require('velo-external-db-commons').SchemaOperations
+const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject, IncludeOperator ]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-dynamodb/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-dynamodb/tests/drivers/sql_filter_transformer_test_support.js
@@ -101,7 +101,7 @@ const givenNotFilterQueryFor = (filter, column, value) =>
                                 }
                             })
 
-const givenIncludeFilterFor_idColumn = (filter, value) =>
+const givenIncludeFilterForIdColumn = (filter, value) =>
     when(filterParser.transform).calledWith(filter)
                                 .mockReturnValue({ filterExpr: {
                                     FilterExpression: '#_id IN (:0)',
@@ -125,5 +125,5 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, stubEmptyOrderByFor, stubEmptyFilterFor,
                    givenFilterByIdWith, filterParser, reset, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenIncludeFilterFor_idColumn
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenIncludeFilterForIdColumn
 }

--- a/packages/external-db-dynamodb/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-dynamodb/tests/drivers/sql_filter_transformer_test_support.js
@@ -101,6 +101,19 @@ const givenNotFilterQueryFor = (filter, column, value) =>
                                 }
                             })
 
+const givenIncludeFilterFor_idColumn = (filter, value) =>
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: {
+                                    FilterExpression: '#_id IN (:0)',
+                                    ExpressionAttributeNames: {
+                                        ['#_id']: '_id'
+                                    },
+                                    ExpressionAttributeValues: {
+                                        [':0']: value
+                                    }
+                                }
+                            })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -112,5 +125,5 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, stubEmptyOrderByFor, stubEmptyFilterFor,
                    givenFilterByIdWith, filterParser, reset, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenIncludeFilterFor_idColumn
 }

--- a/packages/external-db-firestore/lib/supported_operations.js
+++ b/packages/external-db-firestore/lib/supported_operations.js
@@ -1,5 +1,5 @@
-const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, StartWithCaseSensitive, FindObject } = require('velo-external-db-commons').SchemaOperations
+const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, StartWithCaseSensitive, FindObject, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, StartWithCaseSensitive, FindObject ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, StartWithCaseSensitive, FindObject, IncludeOperator ]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-firestore/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-firestore/tests/drivers/sql_filter_transformer_test_support.js
@@ -85,7 +85,7 @@ const givenGreaterThenFilterFor = (filter, column, value) =>
                                     value,
                                 }])
 
-const givenIncludeFilterFor_idColumn = (filter, value) => 
+const givenIncludeFilterForIdColumn = (filter, value) => 
     when(filterParser.transform).calledWith(filter)
                                 .mockReturnValue([{
                                     fieldName: '_id',
@@ -103,6 +103,6 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
-                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor, givenIncludeFilterFor_idColumn,
+                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor, givenIncludeFilterForIdColumn,
                    filterParser, reset
                 }

--- a/packages/external-db-firestore/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-firestore/tests/drivers/sql_filter_transformer_test_support.js
@@ -85,6 +85,14 @@ const givenGreaterThenFilterFor = (filter, column, value) =>
                                     value,
                                 }])
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue([{
+                                    fieldName: '_id',
+                                    opStr: 'in',
+                                    value: [value],
+                                }])
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -95,6 +103,6 @@ const reset = () => {
 
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
-                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor,
+                   givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
                 }

--- a/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
@@ -89,7 +89,7 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     }
                                 })
 
-const givenIncludeFilterFor_idColumn = (filter, value) => 
+const givenIncludeFilterForIdColumn = (filter, value) => 
     when(filterParser.transform).calledWith(filter)
                                 .mockReturnValue({ filterExpr: { _id: { $in: [value] } } })
 
@@ -104,6 +104,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterForIdColumn,
                    filterParser, reset
 }

--- a/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.js
@@ -89,6 +89,10 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     }
                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: { _id: { $in: [value] } } })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -100,6 +104,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
 }

--- a/packages/external-db-mssql/lib/supported_operations.js
+++ b/packages/external-db-mssql/lib/supported_operations.js
@@ -1,6 +1,6 @@
 const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, 
-        Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection } = require('velo-external-db-commons').SchemaOperations
+        Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, NotOperator, Matches, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
-const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection ]
+const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, FindWithSort, Aggregate, BulkDelete, Truncate, UpdateImmediately, DeleteImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, NotOperator, Matches, IncludeOperator ]
 
 module.exports = { supportedOperations }

--- a/packages/external-db-mssql/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mssql/tests/drivers/sql_filter_transformer_test_support.js
@@ -79,7 +79,7 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                                     } 
                                                 })
 
-const givenIncludeFilterFor_idColumn = (filter, value) => 
+const givenIncludeFilterForIdColumn = (filter, value) => 
     when(filterParser.transform).calledWith(filter)
                                 .mockReturnValue({ filterExpr: `WHERE ${escapeId('_id')} IN (${validateLiteral('_id')})`, parameters: { [patchFieldName('_id')]: value } })
 
@@ -94,6 +94,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterForIdColumn,
                    filterParser, reset
 }

--- a/packages/external-db-mssql/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mssql/tests/drivers/sql_filter_transformer_test_support.js
@@ -79,6 +79,10 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                                     } 
                                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeId('_id')} IN (${validateLiteral('_id')})`, parameters: { [patchFieldName('_id')]: value } })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -90,6 +94,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
 }

--- a/packages/external-db-mysql/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mysql/tests/drivers/sql_filter_transformer_test_support.js
@@ -78,7 +78,7 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                         .join('')
                                 ] })
 
-const givenIncludeFilterFor_idColumn = (filter, value) => 
+const givenIncludeFilterForIdColumn = (filter, value) => 
     when(filterParser.transform).calledWith(filter)
                                 .mockReturnValue({ filterExpr: `WHERE ${escapeId('_id')} IN (?)`, parameters: [value] })
 
@@ -93,6 +93,6 @@ module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByF
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor,
                    givenStartsWithFilterFor, givenGreaterThenFilterFor,
-                   givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
+                   givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterForIdColumn,
                    filterParser, reset 
 }

--- a/packages/external-db-mysql/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-mysql/tests/drivers/sql_filter_transformer_test_support.js
@@ -78,6 +78,10 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                         .join('')
                                 ] })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeId('_id')} IN (?)`, parameters: [value] })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -89,6 +93,6 @@ module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByF
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                    givenAllFieldsProjectionFor, givenProjectionExprFor,
                    givenStartsWithFilterFor, givenGreaterThenFilterFor,
-                   givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset 
 }

--- a/packages/external-db-postgres/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-postgres/tests/drivers/sql_filter_transformer_test_support.js
@@ -79,7 +79,7 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     offset: 2
                                 })
 
-const givenIncludeFilterFor_idColumn = (filter, value) => 
+const givenIncludeFilterForIdColumn = (filter, value) => 
     when(filterParser.transform).calledWith(filter)
                                 .mockReturnValue({ filterExpr: `WHERE ${escapeIdentifier('_id')} IN ($1)`, parameters: [value], offset: 2 })
 
@@ -95,6 +95,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor, stubEmptyFilterFor, 
                    givenFilterByIdWith, givenAggregateQueryWith, givenAllFieldsProjectionFor,
                    givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor,
-                   givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
+                   givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterForIdColumn,
                    filterParser, reset
 }

--- a/packages/external-db-postgres/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-postgres/tests/drivers/sql_filter_transformer_test_support.js
@@ -79,6 +79,11 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     offset: 2
                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, value) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeIdentifier('_id')} IN ($1)`, parameters: [value], offset: 2 })
+
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -90,6 +95,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor, stubEmptyFilterFor, 
                    givenFilterByIdWith, givenAggregateQueryWith, givenAllFieldsProjectionFor,
                    givenProjectionExprFor, givenStartsWithFilterFor, givenGreaterThenFilterFor,
-                   givenNotFilterQueryFor, givenMatchesFilterFor,
+                   givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                    filterParser, reset
 }

--- a/packages/external-db-spanner/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-spanner/tests/drivers/sql_filter_transformer_test_support.js
@@ -86,7 +86,7 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     }
                                 })
 
-const givenIncludeFilterFor_idColumn = (filter, id) => 
+const givenIncludeFilterForIdColumn = (filter, id) => 
     when(filterParser.transform).calledWith(filter)
                                 .mockReturnValue({ filterExpr: `WHERE ${escapeFieldId('_id')} IN (${validateLiteral('_id')})`, parameters: {
                                     _id: id
@@ -103,6 +103,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                     givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                    givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
+                    givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterForIdColumn,
                     filterParser, reset
 }

--- a/packages/external-db-spanner/tests/drivers/sql_filter_transformer_test_support.js
+++ b/packages/external-db-spanner/tests/drivers/sql_filter_transformer_test_support.js
@@ -86,6 +86,12 @@ const givenMatchesFilterFor = (filter, column, value) =>
                                     }
                                 })
 
+const givenIncludeFilterFor_idColumn = (filter, id) => 
+    when(filterParser.transform).calledWith(filter)
+                                .mockReturnValue({ filterExpr: `WHERE ${escapeFieldId('_id')} IN (${validateLiteral('_id')})`, parameters: {
+                                    _id: id
+                                } })
+
 const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
@@ -97,6 +103,6 @@ const reset = () => {
 module.exports = { stubEmptyFilterAndSortFor, givenOrderByFor, stubEmptyOrderByFor,
                    stubEmptyFilterFor, givenFilterByIdWith, givenAggregateQueryWith,
                     givenAllFieldsProjectionFor, givenProjectionExprFor, givenStartsWithFilterFor,
-                    givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor,
+                    givenGreaterThenFilterFor, givenNotFilterQueryFor, givenMatchesFilterFor, givenIncludeFilterFor_idColumn,
                     filterParser, reset
 }

--- a/packages/velo-external-db-commons/lib/schema_commons.js
+++ b/packages/velo-external-db-commons/lib/schema_commons.js
@@ -56,6 +56,7 @@ const SchemaOperations = Object.freeze({
     FindObject: 'findObject',
     Matches: 'matches',
     NotOperator: 'not',
+    IncludeOperator: 'include',
 })
 
 const AllSchemaOperations = Object.values(SchemaOperations)

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -157,7 +157,7 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
 
     testIfSupportedOperationsIncludes(supportedOperations, [ IncludeOperator ])('include operator on _id field', async() => {
         await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
-        env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)
+        env.driver.givenIncludeFilterForIdColumn(ctx.filter, ctx.entity._id)
         env.driver.stubEmptyOrderByFor(ctx.sort)
         env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
 

--- a/packages/velo-external-db/test/storage/data_provider.spec.js
+++ b/packages/velo-external-db/test/storage/data_provider.spec.js
@@ -1,5 +1,5 @@
 const { Uninitialized, testIfSupportedOperationsIncludes, shouldNotRunOn } = require('test-commons')
-const { FindWithSort, DeleteImmediately, Aggregate, UpdateImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, Matches, NotOperator, FindObject } = require('velo-external-db-commons').SchemaOperations
+const { FindWithSort, DeleteImmediately, Aggregate, UpdateImmediately, StartWithCaseSensitive, StartWithCaseInsensitive, Projection, Matches, NotOperator, FindObject, IncludeOperator } = require('velo-external-db-commons').SchemaOperations
 
 const Chance = require('chance')
 const gen = require('../gen')
@@ -155,7 +155,15 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
         await expect( env.dataProvider.find(ctx.objectCollectionName, '', '', 0, 50, ctx.projection) ).resolves.toEqual(entityWithObjectField(ctx.objectEntity, ctx.objectEntityFields))
     })
 
+    testIfSupportedOperationsIncludes(supportedOperations, [ IncludeOperator ])('include operator on _id field', async() => {
+        await givenCollectionWith([ctx.entity], ctx.collectionName, ctx.entityFields)
+        env.driver.givenIncludeFilterFor_idColumn(ctx.filter, ctx.entity._id)
+        env.driver.stubEmptyOrderByFor(ctx.sort)
+        env.driver.givenAllFieldsProjectionFor?.(ctx.projection)
 
+        await expect( env.dataProvider.find(ctx.collectionName, ctx.filter, ctx.sort, 0, 50, ctx.projection) ).resolves.toEqual([ctx.entity])
+    })
+    
     testIfSupportedOperationsIncludes(supportedOperations, [ DeleteImmediately ])('delete data from collection', async() => {
         await givenCollectionWith(ctx.entities, ctx.collectionName, ctx.entityFields)
         env.driver.stubEmptyFilterAndSortFor('', '')


### PR DESCRIPTION
Content manager made a change, before each insert/update they perform data/find with _hasSome_ operator AKA _includes_ with _id value. 

The test is testing the flow of - data/find on single _id value.
 
- [x] MySQL
- [x] Spanner
- [x] Postgres
- [x] MSSQL
- [x] BigQuery
- [x] Dynmodb
- [x] Firestore
- [x] MongoDB
- [x] Google-Sheets - not implemented
- [x] AirTable - mock doesn't support include
