### PR TITLE
randomBodyWith to core, fix imports

### DIFF
--- a/packages/velo-external-db-core/lib/data_hooks_utils.spec.js
+++ b/packages/velo-external-db-core/lib/data_hooks_utils.spec.js
@@ -2,7 +2,7 @@ const each = require('jest-each').default
 const Chance = require('chance')
 const chance = Chance()
 const { Uninitialized } = require('test-commons')
-const { givenBodyWith } = require('../../velo-external-db/test/drivers/hooks_test_support')
+const { randomBodyWith } = require ('../test/gen')
 const { HooksForAction, Operations, payloadFor, Actions } = require('./data_hooks_utils')
 
 describe('Hooks Utils', () => {
@@ -35,7 +35,7 @@ describe('Hooks Utils', () => {
 
     describe('Payload For', () => {
         test('Payload for Find should return query object', () => {
-            expect(payloadFor(Operations.Find, givenBodyWith({ filter: ctx.filter, skip: ctx.skip, limit: ctx.limit, sort: ctx.sort }))).toEqual({
+            expect(payloadFor(Operations.Find, randomBodyWith({ filter: ctx.filter, skip: ctx.skip, limit: ctx.limit, sort: ctx.sort }))).toEqual({
                 filter: ctx.filter,
                 skip: ctx.skip,
                 limit: ctx.limit,
@@ -43,31 +43,31 @@ describe('Hooks Utils', () => {
             })
         })
         test('Payload for Insert should return item', () => {
-            expect(payloadFor(Operations.Insert, givenBodyWith({ item: ctx.item }))).toEqual({ item: ctx.item })
+            expect(payloadFor(Operations.Insert, randomBodyWith({ item: ctx.item }))).toEqual({ item: ctx.item })
         })
         test('Payload for BulkInsert should return items', () => {
-            expect(payloadFor(Operations.BulkInsert, givenBodyWith({ items: ctx.items }))).toEqual({ items: ctx.items })
+            expect(payloadFor(Operations.BulkInsert, randomBodyWith({ items: ctx.items }))).toEqual({ items: ctx.items })
         })
         test('Payload for Update should return item', () => {
-            expect(payloadFor(Operations.Update, givenBodyWith({ item: ctx.item }))).toEqual({ item: ctx.item })
+            expect(payloadFor(Operations.Update, randomBodyWith({ item: ctx.item }))).toEqual({ item: ctx.item })
         })
         test('Payload for BulkUpdate should return items', () => {
-            expect(payloadFor(Operations.BulkUpdate, givenBodyWith({ items: ctx.items }))).toEqual({ items: ctx.items })
+            expect(payloadFor(Operations.BulkUpdate, randomBodyWith({ items: ctx.items }))).toEqual({ items: ctx.items })
         })
         test('Payload for Remove should return item id', () => {
-            expect(payloadFor(Operations.Remove, givenBodyWith({ itemId: ctx.itemId }))).toEqual({ itemId: ctx.itemId })
+            expect(payloadFor(Operations.Remove, randomBodyWith({ itemId: ctx.itemId }))).toEqual({ itemId: ctx.itemId })
         })
         test('Payload for BulkRemove should return item ids', () => {
-            expect(payloadFor(Operations.BulkRemove, givenBodyWith({ itemIds: ctx.itemIds }))).toEqual({ itemIds: ctx.itemIds })
+            expect(payloadFor(Operations.BulkRemove, randomBodyWith({ itemIds: ctx.itemIds }))).toEqual({ itemIds: ctx.itemIds })
         })
         test('Payload for Count should return filter', () => {
-            expect(payloadFor(Operations.Count, givenBodyWith({ filter: ctx.filter }))).toEqual({ filter: ctx.filter })
+            expect(payloadFor(Operations.Count, randomBodyWith({ filter: ctx.filter }))).toEqual({ filter: ctx.filter })
         })
         test('Payload for Get should return item id', () => {
-            expect(payloadFor(Operations.Get, givenBodyWith({ itemId: ctx.itemId }))).toEqual({ itemId: ctx.itemId })
+            expect(payloadFor(Operations.Get, randomBodyWith({ itemId: ctx.itemId }))).toEqual({ itemId: ctx.itemId })
         })
         test('Payload for Aggregate should return Aggregation query', () => {
-            expect(payloadFor(Operations.Aggregate, givenBodyWith({ filter: ctx.filter, processingStep: ctx.processingStep, postFilteringStep: ctx.postFilteringStep })))
+            expect(payloadFor(Operations.Aggregate, randomBodyWith({ filter: ctx.filter, processingStep: ctx.processingStep, postFilteringStep: ctx.postFilteringStep })))
                 .toEqual(
                     {
                         filter: ctx.filter,

--- a/packages/velo-external-db-core/lib/schema_hooks_utils.spec.js
+++ b/packages/velo-external-db-core/lib/schema_hooks_utils.spec.js
@@ -2,7 +2,7 @@ const each = require('jest-each').default
 const Chance = require('chance')
 const chance = Chance()
 const { Uninitialized } = require('test-commons')
-const { givenBodyWith } = require('../../velo-external-db/test/drivers/hooks_test_support')
+const { randomBodyWith } = require ('../test/gen')
 const { HooksForAction, Operations, payloadFor, Actions } = require('./schema_hooks_utils')
 
 describe('Hooks Utils', () => {
@@ -36,19 +36,19 @@ describe('Hooks Utils', () => {
     describe('Payload For', () => {
         each([Operations.List, Operations.ListHeaders])
             .test('Payload for %s should return null', (operation) => {
-                expect(payloadFor(operation, givenBodyWith({}))).toEqual({})
+                expect(payloadFor(operation, randomBodyWith({}))).toEqual({})
             })
         test('Payload for Find should return schemaIds', () => {
-            expect(payloadFor(Operations.Find, givenBodyWith({ schemaIds: ctx.schemaIds }))).toEqual({ schemaIds: ctx.schemaIds })
+            expect(payloadFor(Operations.Find, randomBodyWith({ schemaIds: ctx.schemaIds }))).toEqual({ schemaIds: ctx.schemaIds })
         })
         test('Payload for Create should return collectionName', () => {
-            expect(payloadFor(Operations.Create, givenBodyWith({ collectionName: ctx.collectionName }))).toEqual({ collectionName: ctx.collectionName })
+            expect(payloadFor(Operations.Create, randomBodyWith({ collectionName: ctx.collectionName }))).toEqual({ collectionName: ctx.collectionName })
         })
         test('Payload for ColumnAdd should return column', () => {
-            expect(payloadFor(Operations.ColumnAdd, givenBodyWith({ column: ctx.column }))).toEqual({ column: ctx.column })
+            expect(payloadFor(Operations.ColumnAdd, randomBodyWith({ column: ctx.column }))).toEqual({ column: ctx.column })
         })
         test('Payload for ColumnRemove should return columnName', () => {
-            expect(payloadFor(Operations.ColumnRemove, givenBodyWith({ columnName: ctx.columnName }))).toEqual({ columnName: ctx.columnName })
+            expect(payloadFor(Operations.ColumnRemove, randomBodyWith({ columnName: ctx.columnName }))).toEqual({ columnName: ctx.columnName })
         })
     })
 

--- a/packages/velo-external-db-core/test/gen.js
+++ b/packages/velo-external-db-core/test/gen.js
@@ -1,6 +1,6 @@
 const Chance = require('chance')
 const { AdapterOperators } = require('velo-external-db-commons')
-
+const { gen: genCommon } = require('test-commons')
 const chance = Chance()
 
 const invalidOperatorForType = (validOperators) => randomObjectFromArray (
@@ -65,4 +65,12 @@ const deleteRandomKeyObject = (obj) => {
     return { deletedKey, newObject: obj }
 }
 
-module.exports = { randomOperator, randomFilter, randomWixType, invalidOperatorForType, randomObjectFromArray, randomColumn, randomDb, randomDbsWithIdColumn, randomCollections, randomDbs, randomCollectionName, truthyValue, falsyValue, deleteRandomKeyObject }
+const randomBodyWith = (obj) => ({
+    ...genCommon.randomObject(),
+    ...obj
+})
+
+module.exports = {
+    randomOperator, randomFilter, randomWixType, invalidOperatorForType, randomObjectFromArray, randomColumn, randomDb, randomDbsWithIdColumn, randomCollections,
+    randomDbs, randomCollectionName, truthyValue, falsyValue, deleteRandomKeyObject, randomBodyWith
+}

--- a/packages/velo-external-db/test/drivers/hooks_test_support.js
+++ b/packages/velo-external-db/test/drivers/hooks_test_support.js
@@ -1,5 +1,4 @@
 const { Aggregate } = require('velo-external-db-commons').SchemaOperations
-const { gen: genCommon } = require('test-commons')
 
 const resetHooks = (externalDbRouter) => externalDbRouter.reloadHooks()
 
@@ -27,10 +26,6 @@ const skipAggregationIfNotSupported = (hookName, supportedOperations) => {
     return (hookName.includes('Aggregate') && !supportedOperations.includes(Aggregate))
 }
 
-const givenBodyWith = (obj) => ({
-    ...genCommon.randomObject(),
-    ...obj
-})
 
 const writeSchemaRequestBodyWith = (collectionName, columnToRemove, columnToCreate) => ({
     collectionName, column: columnToCreate, columnName: columnToRemove.name
@@ -41,6 +36,6 @@ const readSchemaRequestBodyWith = (collectionName) => ({
 })
 
 module.exports = {
-    writeRequestBodyWith, readRequestBodyWith, resetHooks, findRequestBodyWith, givenBodyWith, getRequestBodyWith, aggregateRequestBodyWith,
+    writeRequestBodyWith, readRequestBodyWith, resetHooks, findRequestBodyWith, getRequestBodyWith, aggregateRequestBodyWith,
     skipAggregationIfNotSupported, writeSchemaRequestBodyWith, readSchemaRequestBodyWith
 }


### PR DESCRIPTION
In #276 I mistakenly  imported `givenBodyWith` in core from _velo-external-db_ instead from the same package. 
(@MXPOL, thanks for paying attention,  https://github.com/wix/velo-external-db/pull/276#discussion_r880628944)