### PR TITLE
enable app info without require ejs or perform enableAppInfo

### DIFF
--- a/packages/velo-external-db-core/lib/index.js
+++ b/packages/velo-external-db-core/lib/index.js
@@ -9,7 +9,7 @@ const AggregationTransformer = require ('./converters/aggregation_transformer')
 const QueryValidator = require ('./converters/query_validator')
 const SchemaAwareDataService = require ('./service/schema_aware_data')
 const ItemTransformer = require('./converters/item_transformer')
-const { initServices, createRouter, enableAppInfo } = require('./router')
+const { initServices, createRouter } = require('./router')
 const { RoleAuthorizationService } = require ('@wix-velo/external-db-security')
 const { ConfigValidator, AuthorizationConfigValidator, CommonConfigValidator } = require ('@wix-velo/external-db-config')
 
@@ -39,12 +39,6 @@ class ExternalDbRouter {
 
     reloadHooks(hooks) {
         initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...this.config, type: this.connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks)
-    }
-
-    enableAppInfo(app) {
-        app.set('views', `${__dirname}/views`)
-        app.set('view engine', 'ejs')
-        enableAppInfo()
     }
 
     isInitialized(connector) {

--- a/packages/velo-external-db-core/lib/router.js
+++ b/packages/velo-external-db-core/lib/router.js
@@ -19,13 +19,13 @@ const { Find: FIND, Insert: INSERT, BulkInsert: BULK_INSERT, Update: UPDATE, Bul
 
 let schemaService, operationService, externalDbConfigClient, schemaAwareDataService, cfg, filterTransformer, aggregationTransformer, roleAuthorizationService, dataHooks, schemaHooks
 
-let AppInfoTemplate
+let appInfoTemplate
 
 const getAppInfoTemplate = async() => {
-    if (!AppInfoTemplate) {
-        AppInfoTemplate = await fs.readFile(path.join(__dirname, 'views', 'index.ejs'), 'utf8')
+    if (!appInfoTemplate) {
+        appInfoTemplate = await fs.readFile(path.join(__dirname, 'views', 'index.ejs'), 'utf8')
     }
-    return AppInfoTemplate
+    return appInfoTemplate
 }
 
 const initServices = (_schemaAwareDataService, _schemaService, _operationService, _externalDbConfigClient, _cfg, _filterTransformer, _aggregationTransformer, _roleAuthorizationService, _hooks) => {

--- a/packages/velo-external-db-core/lib/utils/router_utils.js
+++ b/packages/velo-external-db-core/lib/utils/router_utils.js
@@ -1,0 +1,17 @@
+const path = require('path')
+const ejs = require('ejs')
+const fs = require('fs').promises
+
+const getAppInfoTemplate = async() => {
+    return await fs.readFile(path.join( __dirname, '..', 'views', 'index.ejs'), 'utf8')
+}
+
+const getAppInfoPage = async(appInfo) => {
+    const appInfoTemplate = await getAppInfoTemplate()
+    const appInfoPage = ejs.render(appInfoTemplate, appInfo)
+    return appInfoPage
+}
+
+module.exports = { getAppInfoPage }
+
+

--- a/packages/velo-external-db-core/lib/views/index.ejs
+++ b/packages/velo-external-db-core/lib/views/index.ejs
@@ -26,7 +26,132 @@ const img =  dbConnectionStatus === 'Connected to database successfully' ? '/ass
 				</picture>
 			</div>
 		</div>
-		<%- include("partials/details.ejs") %>
+		<style>
+			.list-group {
+				width: auto;
+				max-width: 650px;
+				margin: 3rem auto;
+			}
+		</style>
+		
+		
+		<%
+		const connectionColor =  dbConnectionStatus === 'Connected to database successfully' ? 'success': 'danger' 
+		const configStatusColor = configReaderStatus === 'External DB Config read successfully' ? 'success' : 'danger'
+		let authorizationStatusColor
+		if (authorizationConfigStatus === 'Permissions config read successfully') {
+			authorizationStatusColor = 'success'
+		} else if (authorizationConfigStatus === 'Permissions config not defined, using default') {
+			authorizationStatusColor = 'warning'
+		} else {
+			authorizationStatusColor = 'danger'
+		}
+		%>
+		<script>
+			function toggleConfigDisplay() {
+			  let config = document.getElementById("config");
+			  config.style.display === "none" ? config.style.display = "block " : config.style.display = "none";
+			}
+			function toggleAuthorizationDisplay() {
+			  let authorization = document.getElementById("roleConfig");
+			  authorization.style.display === "none" ? authorization.style.display = "block " : authorization.style.display = "none";
+			}
+		</script>
+		
+		<div class="list-group">
+			<button onclick="toggleConfigDisplay()" href="#" class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=configStatusColor%> py-3" aria-current="true">
+				<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
+					<path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+				  </svg>
+				<div class="d-flex gap-2 w-100 justify-content-between">
+					<div>
+						<h6 class="mb-0">DB Config Status</h6>
+						<p class="mb-0 opacity-75">
+							<%= configReaderStatus %>
+						</p>
+					</div>
+				</div>
+			</button>
+			<div class="card card-body" id="config" aria-current="true" style="display:none; border:0; padding: 0;">
+				<ul class="list-group" style="margin:0;">
+				<li class="list-group-item">Host : <%= config.host || config.cloudSqlConnectionName || config.instanceId %></li>
+				<li class="list-group-item">User: <%= config.user  %></li>
+				<li class="list-group-item">Password: <%= config.password %></li>
+				<li class="list-group-item">DB name: <%= config.db || config.databaseId  %></li>
+				<li class="list-group-item">Secret Key: <%= config.secretKey %></li>
+			</ul>
+			</div>
+		
+			<button onclick="toggleAuthorizationDisplay()" href="#" class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=authorizationStatusColor%> py-3" aria-current="true">
+				<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
+					<path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+				  </svg>
+				<div class="d-flex gap-2 w-100 justify-content-between">
+					<div>
+						<h6 class="mb-0">Permissions Config Status</h6>
+						<p class="mb-0 opacity-75">
+							<%= authorizationConfigStatus %>
+						</p>
+					</div>
+				</div>
+			</button>
+		
+			<div id="roleConfig" style="display: none;" >
+				Config part that read successfully:
+				<pre style = "background-color:#d9cdcd1f;" aria-current="true" style="display:none; border:0; padding: 0;"><%= JSON.stringify(config.authorization, null, 2) %></pre>
+			</div>
+			<div class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=connectionColor%> py-3" aria-current="true"> 
+				<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-hdd-stack"
+					viewBox="0 0 16 16">
+					<path
+						d="M14 10a1 1 0 0 1 1 1v1a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-1a1 1 0 0 1 1-1h12zM2 9a2 2 0 0 0-2 2v1a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-1a2 2 0 0 0-2-2H2z" />
+					<path
+						d="M5 11.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zm-2 0a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zM14 3a1 1 0 0 1 1 1v1a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h12zM2 2a2 2 0 0 0-2 2v1a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H2z" />
+					<path d="M5 4.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zm-2 0a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0z" />
+				</svg>
+				<div class="d-flex gap-2 w-100 justify-content-between">
+					<div>
+						<h6 class="mb-0">Connection Status</h6>
+						<p class="mb-0 opacity-75">
+							<%= dbConnectionStatus %>
+						</p>
+					</div>
+				</div>
+			</div>
+		
+		
+		
+			<div class="clipboard-example align-items-center w-100 py-2">
+				<div class="input-group mb-3">
+					<span class="input-group-text">Configuration</span>
+					<input id="in01"
+						   type="text"
+						   class="form-control"
+						   placeholder="BTC Address..."
+						   aria-label="BTC Address"
+						   aria-describedby="btn01"
+						   value='{"secretKey": "<your-secret-key>"}'
+		
+					>
+					<button id="btn01"
+							data-clipboard-target="#in01"
+							class="btn btn-secondary"
+							type="button"
+							data-clipboard-demo=""
+							data-clipboard-target="#in01"
+							data-bs-toggle="tooltip"
+							data-bs-placement="bottom"
+							title="Copy to Clipboard"
+					>Copy</button>
+					
+				</div>
+			</div>
+			<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
+			<script>
+				let btn = document.getElementById('btn01');
+				let clipboard = new ClipboardJS(btn);
+			</script>
+		</div>		
 	</div>
 </body>
 

--- a/packages/velo-external-db-core/package.json
+++ b/packages/velo-external-db-core/package.json
@@ -33,6 +33,7 @@
     "ajv": "^8.11.0",
     "bluebird": "^3.7.2",
     "compression": "^1.7.4",
+    "ejs": "^3.1.8",
     "express": "^4.17.3",
     "nested-property": "^4.0.0",
     "node-cache": "^5.1.2",

--- a/packages/velo-external-db/lib/app.js
+++ b/packages/velo-external-db/lib/app.js
@@ -37,7 +37,6 @@ const initConnector = async(hooks) => {
 initConnector().then(({ externalDbRouter }) => {
     const app = express()
     app.use(externalDbRouter.router)
-    externalDbRouter.enableAppInfo(app)
 
     server = app.listen(8080, () => console.log('Connector listening on port 8080'))
 


### PR DESCRIPTION
Until now, if a user requires the two packages (core, some-enginge-connector), he must also install `ejs` and run the command `externalDbRouter.enableAppInfo(app)` in order to render the app-info page.

Using this PR, we render the `ejs` file in the router and send the page as HTML, so the user would not be required to install `ejs` or do anything else.

Please ignore the `index.ejs` changes for now.
Let me know if you have more elegant way to read the file once ([getAppInfoTemplate](https://github.com/wix/velo-external-db/blob/3344df4f7c363d26180fb93df3637b3cbc76d0f1/packages/velo-external-db-core/lib/router.js#L22-L29))

