### PR TITLE
Projection

### DIFF
--- a/apps/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/apps/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -1,5 +1,5 @@
 const { Uninitialized, gen: genCommon } = require('@wix-velo/test-commons')
-const { UpdateImmediately, DeleteImmediately, Truncate, Aggregate, FindWithSort } = require('@wix-velo/velo-external-db-commons').SchemaOperations
+const { UpdateImmediately, DeleteImmediately, Truncate, Aggregate, FindWithSort, Projection } = require('@wix-velo/velo-external-db-commons').SchemaOperations
 const { testIfSupportedOperationsIncludes } = require('@wix-velo/test-commons')
 const gen = require('../gen')
 const schema = require('../drivers/schema_api_rest_test_support')
@@ -37,7 +37,17 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
                     totalCount: 2
                 } }))
     })
-
+    
+    testIfSupportedOperationsIncludes(supportedOperations, [ Projection ])('find api with projection', async() => {
+        await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
+        await data.givenItems([ctx.item ], ctx.collectionName, authAdmin)
+        await expect( axios.post('/data/find', { collectionName: ctx.collectionName, filter: '', skip: 0, limit: 25, projection: [ctx.column.name] }, authOwner) ).resolves.toEqual(
+            expect.objectContaining({ data: {
+                    items: [ ctx.item ].map(item => ({ [ctx.column.name]: item[ctx.column.name] })),
+                    totalCount: 1
+                } }))
+    })
+    
     //todo: create another test without sort for these implementations
 
     test('insert api', async() => {

--- a/apps/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/apps/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -120,6 +120,16 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
         await expect( axios.post('/data/get', { collectionName: ctx.collectionName, itemId: ctx.item._id }, authAdmin) ).resolves.toEqual(matchers.responseWith({ item: ctx.item }))
     })
 
+    testIfSupportedOperationsIncludes(supportedOperations, [ Projection ])('get by id api with projection', async() => {
+        await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
+        await data.givenItems([ctx.item], ctx.collectionName, authAdmin)
+
+        await expect(axios.post('/data/get', { collectionName: ctx.collectionName, itemId: ctx.item._id, projection: [ctx.column.name] }, authAdmin)).resolves.toEqual(
+            matchers.responseWith({
+                item: { [ctx.column.name]: ctx.item[ctx.column.name] }
+            }))
+    })
+
     testIfSupportedOperationsIncludes(supportedOperations, [ UpdateImmediately ])('update api', async() => {
         await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
         await data.givenItems([ctx.item], ctx.collectionName, authAdmin)

--- a/apps/velo-external-db/test/e2e/app_data_hooks.e2e.spec.js
+++ b/apps/velo-external-db/test/e2e/app_data_hooks.e2e.spec.js
@@ -222,6 +222,22 @@ describe(`Velo External DB Data Hooks: ${currentDbImplementationName()}`, () => 
                     expect(response.data.items).toEqual([ctx.item])
                 })
 
+            test('beforeFind should be able to change projection payload /data/find', async() => {
+                await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
+                await data.givenItems([ctx.item], ctx.collectionName, authOwner)
+
+                env.externalDbRouter.reloadHooks({
+                    dataHooks: {
+                        beforeFind: (payload, _requestContext, _serviceContext) => {
+                            return { ...payload, projection: ['_id'] }
+                        }
+                    }
+                })
+
+            const response = await axios.post('/data/find', hooks.findRequestBodyWith(ctx.collectionName, { _id: { $eq: ctx.item._id } }), authOwner)
+                expect(response.data.items).toEqual([{ _id: ctx.item._id }])
+
+            })
             each(['beforeAll', 'beforeRead', 'beforeGetById'])
                 .test('%s should able to change payload /data/get', async(hookName) => {
                     await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)

--- a/libs/velo-external-db-core/package.json
+++ b/libs/velo-external-db-core/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@wix-velo/velo-external-db-core",
-  "version": "1.0.7",
+  "version": "1.1.0",
 	"type": "commonjs"
 }

--- a/libs/velo-external-db-core/src/converters/data_utils.js
+++ b/libs/velo-external-db-core/src/converters/data_utils.js
@@ -1,10 +1,13 @@
 const { isDate } = require('@wix-velo/velo-external-db-commons')
 const crypto = require('crypto')
 
-const asWixData = e => generateIdsIfNeeded(packDates(e))
+const asWixData = (item, projection) => { 
+    const projectionNotIncludesId = Array.isArray(projection) && !projection.includes('_id')
+    return generateIdsIfNeeded(packDates(item), projectionNotIncludesId)
+}
 
-const generateIdsIfNeeded = item => {
-    if ('_id' in item)
+const generateIdsIfNeeded = (item, projectionWithOutId) => {
+    if ('_id' in item || projectionWithOutId )
         return item
     const sha = crypto.createHash('sha1')
     const fieldsConcat = Object.values(item).join('')

--- a/libs/velo-external-db-core/src/converters/data_utils.spec.js
+++ b/libs/velo-external-db-core/src/converters/data_utils.spec.js
@@ -33,6 +33,10 @@ describe('Converters', () => {
         expect(generateIdsIfNeeded(ctx.obj)._id).not.toEqual(generateIdsIfNeeded(ctx.anotherObj)._id)
     })
 
+    test('call asWixData with projection that doesn\'t includes id will not generate id', () => {
+        expect(asWixData(ctx.obj, [ctx.property])).not.toHaveProperty('_id')
+    })
+
     const ctx = {
         obj: Uninitialized,
         anotherObj: Uninitialized,

--- a/libs/velo-external-db-core/src/converters/query_validator.js
+++ b/libs/velo-external-db-core/src/converters/query_validator.js
@@ -35,11 +35,16 @@ class QueryValidator {
     }
 
     validateFieldsExists(allFields, queryFields) { 
+        console.log(queryFields)
         const nonExistentFields = queryFields.filter(field => !allFields.includes(field)) 
 
         if (nonExistentFields.length) {
-            throw new InvalidQuery(`fields ${nonExistentFields.map(f => f.name).join(', ')} don't exist`)
+            throw new InvalidQuery(`fields ${nonExistentFields.join(', ')} don't exist`)
         }
+    }
+
+    validateProjection(fields, projection) {
+        this.validateFieldsExists(fields.map(f => f.field), projection)
     }
 
     validateOperators(fields, filterObj) {

--- a/libs/velo-external-db-core/src/converters/query_validator.js
+++ b/libs/velo-external-db-core/src/converters/query_validator.js
@@ -35,15 +35,15 @@ class QueryValidator {
     }
 
     validateFieldsExists(allFields, queryFields) { 
-        console.log(queryFields)
         const nonExistentFields = queryFields.filter(field => !allFields.includes(field)) 
-
         if (nonExistentFields.length) {
             throw new InvalidQuery(`fields ${nonExistentFields.join(', ')} don't exist`)
         }
     }
 
     validateProjection(fields, projection) {
+        if (!Array.isArray(projection))
+            throw new Error(`Projection must be an array, but was ${typeof projection}`) 
         this.validateFieldsExists(fields.map(f => f.field), projection)
     }
 

--- a/libs/velo-external-db-core/src/converters/query_validator.spec.js
+++ b/libs/velo-external-db-core/src/converters/query_validator.spec.js
@@ -132,8 +132,19 @@ describe('Query Validator', () => {
             }
             expect ( () => env.queryValidator.validateAggregation([{ field: ctx.fieldName, type: ctx.type }], aggregation)).toThrow(InvalidQuery)
         })
-
         
+    })
+
+    describe('validateProjection', () => {
+        test('will not throw if projection fields exist', () => {
+            const projection = [ctx.fieldName]
+            expect ( () => env.queryValidator.validateProjection([{ field: ctx.fieldName, type: ctx.type }], projection)).not.toThrow()
+        })
+
+        test('will throw Invalid Query if projection fields doesn\'t exist', () => {
+            const projection = ['wrong']
+            expect ( () => env.queryValidator.validateProjection([{ field: ctx.fieldName, type: ctx.type }], projection)).toThrow(InvalidQuery)
+        })
     })
 
     const env = {

--- a/libs/velo-external-db-core/src/data_hooks_utils.js
+++ b/libs/velo-external-db-core/src/data_hooks_utils.js
@@ -72,7 +72,8 @@ const payloadFor = (operation, body) => {
                 filter: body.filter,
                 limit: body.limit,
                 skip: body.skip,
-                sort: body.sort
+                sort: body.sort,
+                projection: body.projection
             }
         case Operations.Insert:
         case Operations.Update:
@@ -81,6 +82,10 @@ const payloadFor = (operation, body) => {
         case Operations.BulkUpdate:
             return { items: body.items }
         case Operations.Get:
+            return {
+                itemId: body.itemId,
+                projection: body.projection
+            }
         case Operations.Remove:
             return { itemId: body.itemId }
         case Operations.BulkRemove:
@@ -98,9 +103,9 @@ const payloadFor = (operation, body) => {
     }
 }
 
-const requestContextFor = (operation, body) => ({ 
-    operation, 
-    collectionName: body.collectionName, 
+const requestContextFor = (operation, body) => ({
+    operation,
+    collectionName: body.collectionName,
     instanceId: body.requestContext.instanceId,
     memberId: body.requestContext.memberId,
     role: body.requestContext.role,

--- a/libs/velo-external-db-core/src/data_hooks_utils.spec.js
+++ b/libs/velo-external-db-core/src/data_hooks_utils.spec.js
@@ -2,7 +2,7 @@ const each = require('jest-each').default
 const Chance = require('chance')
 const chance = Chance()
 const { Uninitialized } = require('@wix-velo/test-commons')
-const { randomBodyWith } = require ('../test/gen')
+const { randomBodyWith } = require('../test/gen')
 const { HooksForAction, Operations, payloadFor, Actions } = require('./data_hooks_utils')
 
 describe('Hooks Utils', () => {
@@ -35,11 +35,12 @@ describe('Hooks Utils', () => {
 
     describe('Payload For', () => {
         test('Payload for Find should return query object', () => {
-            expect(payloadFor(Operations.Find, randomBodyWith({ filter: ctx.filter, skip: ctx.skip, limit: ctx.limit, sort: ctx.sort }))).toEqual({
+            expect(payloadFor(Operations.Find, randomBodyWith({ filter: ctx.filter, skip: ctx.skip, limit: ctx.limit, sort: ctx.sort, projection: ctx.projection }))).toEqual({
                 filter: ctx.filter,
                 skip: ctx.skip,
                 limit: ctx.limit,
-                sort: ctx.sort
+                sort: ctx.sort,
+                projection: ctx.projection
             })
         })
         test('Payload for Insert should return item', () => {
@@ -63,8 +64,8 @@ describe('Hooks Utils', () => {
         test('Payload for Count should return filter', () => {
             expect(payloadFor(Operations.Count, randomBodyWith({ filter: ctx.filter }))).toEqual({ filter: ctx.filter })
         })
-        test('Payload for Get should return item id', () => {
-            expect(payloadFor(Operations.Get, randomBodyWith({ itemId: ctx.itemId }))).toEqual({ itemId: ctx.itemId })
+        test('Payload for Get should return item id and projection', () => {
+            expect(payloadFor(Operations.Get, randomBodyWith({ itemId: ctx.itemId, projection: ctx.projection }))).toEqual({ itemId: ctx.itemId, projection: ctx.projection })
         })
         test('Payload for Aggregate should return Aggregation query', () => {
             expect(payloadFor(Operations.Aggregate, randomBodyWith({ filter: ctx.filter, processingStep: ctx.processingStep, postFilteringStep: ctx.postFilteringStep })))
@@ -84,6 +85,7 @@ describe('Hooks Utils', () => {
         limit: Uninitialized,
         skip: Uninitialized,
         sort: Uninitialized,
+        projection: Uninitialized,
         item: Uninitialized,
         items: Uninitialized,
         itemId: Uninitialized,
@@ -95,6 +97,7 @@ describe('Hooks Utils', () => {
         ctx.limit = chance.word()
         ctx.skip = chance.word()
         ctx.sort = chance.word()
+        ctx.projection = chance.word()
         ctx.item = chance.word()
         ctx.items = chance.word()
         ctx.itemId = chance.word()

--- a/libs/velo-external-db-core/src/router.js
+++ b/libs/velo-external-db-core/src/router.js
@@ -89,10 +89,10 @@ const createRouter = () => {
         try {
             const { collectionName } = req.body
 
-            const { filter, sort, skip, limit } = await executeDataHooksFor(DataActions.BeforeFind, dataPayloadFor(FIND, req.body), requestContextFor(FIND, req.body))
+            const { filter, sort, skip, limit, projection } = await executeDataHooksFor(DataActions.BeforeFind, dataPayloadFor(FIND, req.body), requestContextFor(FIND, req.body))
 
             await roleAuthorizationService.authorizeRead(collectionName, extractRole(req.body))
-            const data = await schemaAwareDataService.find(collectionName, filterTransformer.transform(filter), sort, skip, limit)
+            const data = await schemaAwareDataService.find(collectionName, filterTransformer.transform(filter), sort, skip, limit, projection)
 
             const dataAfterAction = await executeDataHooksFor(DataActions.AfterFind, data, requestContextFor(FIND, req.body))
             res.json(dataAfterAction)
@@ -148,9 +148,9 @@ const createRouter = () => {
         try {
             const { collectionName } = req.body
 
-            const { itemId } = await executeDataHooksFor(DataActions.BeforeGetById, dataPayloadFor(GET, req.body), requestContextFor(GET, req.body))
+            const { itemId, projection } = await executeDataHooksFor(DataActions.BeforeGetById, dataPayloadFor(GET, req.body), requestContextFor(GET, req.body))
             await roleAuthorizationService.authorizeRead(collectionName, extractRole(req.body))
-            const data = await schemaAwareDataService.getById(collectionName, itemId, '', 0, 1)
+            const data = await schemaAwareDataService.getById(collectionName, itemId, projection)
 
             const dataAfterAction = await executeDataHooksFor(DataActions.AfterGetById, data, requestContextFor(GET, req.body))
             if (!dataAfterAction.item) {

--- a/libs/velo-external-db-core/src/service/data.js
+++ b/libs/velo-external-db-core/src/service/data.js
@@ -10,15 +10,14 @@ class DataService {
         const items = this.storage.find(collectionName, _filter, sort, skip, limit, projection) //todo: change order when all implementation support projection
         const totalCount = this.storage.count(collectionName, _filter)
         return {
-            items: (await items).map( asWixData ),
+            items: (await items).map(item => asWixData(item, projection)),
             totalCount: await totalCount
         }
     }
 
     async getById(collectionName, itemId, projection) {
         const item = await this.storage.find(collectionName, getByIdFilterFor(itemId), '', 0, 1, projection)
-        
-        return { item: asWixData(item[0]) }
+        return { item: asWixData(item[0], projection) }
     }
 
     async count(collectionName, filter) {

--- a/libs/velo-external-db-core/src/service/schema_aware_data.spec.js
+++ b/libs/velo-external-db-core/src/service/schema_aware_data.spec.js
@@ -13,6 +13,7 @@ describe ('Schema Aware Data Service', () => {
     test('find validate filter and call data service with projection fields', async() => {
         schema.givenDefaultSchemaFor(ctx.collectionName)
         queryValidator.givenValidFilterForDefaultFieldsOf(ctx.transformedFilter) 
+        queryValidator.givenValidProjectionForDefaultFieldsOf(SystemFields)
         data.givenListResult(ctx.entities, ctx.totalCount, ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.defaultFields)  
         patcher.givenPatchedBooleanFieldsWith(ctx.patchedEntities, ctx.entities)
 
@@ -117,6 +118,7 @@ describe ('Schema Aware Data Service', () => {
         sort: Uninitialized,
         limit: Uninitialized,
         skip: Uninitialized,
+        projection: Uninitialized,
         defaultFields: Uninitialized
     }
 
@@ -156,7 +158,7 @@ describe ('Schema Aware Data Service', () => {
         ctx.sort = chance.word()
         ctx.skip = chance.integer()
         ctx.limit = chance.integer()
-
+        ctx.projection = [chance.word()]
         ctx.defaultFields = SystemFields.map(f => f.name)
     })
 })

--- a/libs/velo-external-db-core/test/drivers/query_validator_test_support.js
+++ b/libs/velo-external-db-core/test/drivers/query_validator_test_support.js
@@ -6,7 +6,8 @@ const systemFields = SystemFields.map(({ name, type, subtype }) => ({ field: nam
 const queryValidator = {
     validateFilter: jest.fn(),
     validateAggregation: jest.fn(),
-    validateGetById: jest.fn()
+    validateGetById: jest.fn(),
+    validateProjection: jest.fn(),
 }
 
 const givenValidFilterForDefaultFieldsOf = (filter) => 
@@ -22,6 +23,10 @@ const givenValidGetByIdForDefaultFieldsFor = (itemId) =>
     when(queryValidator.validateGetById).calledWith(systemFields, itemId)
                                        .mockReturnValue()
 
+const givenValidProjectionForDefaultFieldsOf = (projection) =>
+    when(queryValidator.validateProjection).calledWith(systemFields, projection)
+                                             .mockReturnValue()
+                                       
 const reset = () => {
     queryValidator.validateFilter.mockClear()
     queryValidator.validateAggregation.mockClear()
@@ -30,5 +35,5 @@ const reset = () => {
 
 module.exports = {
     queryValidator, givenValidFilterForDefaultFieldsOf, reset, validateFilter: queryValidator.validateFilter,
-     givenValidAggregationForDefaultFieldsOf, givenValidGetByIdForDefaultFieldsFor
+     givenValidAggregationForDefaultFieldsOf, givenValidGetByIdForDefaultFieldsFor, givenValidProjectionForDefaultFieldsOf
 }


### PR DESCRIPTION
This PR adds the ability to configure the projection fields for data/find, data/get queries.

Besides the basic request body, there is now a `projection` property, which contains an array of fields.

Example for request with projection: 
```
{
    "collectionName": "faveo",
    "filter": {},
    "limit": 50,
    "skip": 0,
    "sort": ""
    "projection": ["someColumnName"]
}
```

You can see, on the tests [here](https://github.com/wix/velo-external-db/blob/5f7da44e31c2689080768165a534417f07e97bab/apps/velo-external-db/test/e2e/app_data_hooks.e2e.spec.js#L225-L235), another example for configuring the projection through hook.