### PR TITLE
Fix and-or filter transformer

### DIFF
--- a/libs/external-db-bigquery/src/sql_filter_transformer.js
+++ b/libs/external-db-bigquery/src/sql_filter_transformer.js
@@ -90,7 +90,7 @@ class FilterParser {
                 const res = value.map( this.parseFilter.bind(this) )
                 const op = operator === and ? ' AND ' : ' OR '
                 return [{
-                    filterExpr: res.map(r => r[0].filterExpr).join( op ),
+                    filterExpr: `(${res.map(r => r[0].filterExpr).join( op )})`,
                     parameters: res.map( s => s[0].parameters ).flat()
                 }]
             case not:

--- a/libs/external-db-bigquery/src/sql_filter_transformer.spec.js
+++ b/libs/external-db-bigquery/src/sql_filter_transformer.spec.js
@@ -266,7 +266,7 @@ describe('Sql Parser', () => {
                 const op = o === and ? 'AND' : 'OR'
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                    filterExpr: `${env.filterParser.parseFilter(ctx.filter)[0].filterExpr} ${op} ${env.filterParser.parseFilter(ctx.anotherFilter)[0].filterExpr}`,
+                    filterExpr: `(${env.filterParser.parseFilter(ctx.filter)[0].filterExpr} ${op} ${env.filterParser.parseFilter(ctx.anotherFilter)[0].filterExpr})`,
                     parameters: [].concat(env.filterParser.parseFilter(ctx.filter)[0].parameters)
                                   .concat(env.filterParser.parseFilter(ctx.anotherFilter)[0].parameters)
                 }])

--- a/libs/external-db-mysql/src/sql_filter_transformer.js
+++ b/libs/external-db-mysql/src/sql_filter_transformer.js
@@ -32,7 +32,7 @@ class FilterParser {
                 const res = value.map( this.parseFilter.bind(this) )
                 const op = operator === AdapterOperators.and ? ' AND ' : ' OR '
                 return [{
-                    filterExpr: res.map(r => r[0].filterExpr).join( op ),
+                    filterExpr: `(${res.map(r => r[0].filterExpr).join( op )})`,
                     parameters: res.map( s => s[0].parameters ).flat()
                 }]
             case not:

--- a/libs/external-db-mysql/src/sql_filter_transformer.spec.js
+++ b/libs/external-db-mysql/src/sql_filter_transformer.spec.js
@@ -281,7 +281,7 @@ describe('Sql Parser', () => {
                 const op = o === and ? 'AND' : 'OR'
 
                 expect( env.filterParser.parseFilter(filter) ).toEqual([{
-                    filterExpr: `${env.filterParser.parseFilter(ctx.filter)[0].filterExpr} ${op} ${env.filterParser.parseFilter(ctx.anotherFilter)[0].filterExpr}`,
+                    filterExpr: `(${env.filterParser.parseFilter(ctx.filter)[0].filterExpr} ${op} ${env.filterParser.parseFilter(ctx.anotherFilter)[0].filterExpr})`,
                     parameters: [].concat(env.filterParser.parseFilter(ctx.filter)[0].parameters)
                                   .concat(env.filterParser.parseFilter(ctx.anotherFilter)[0].parameters)
                 }])

--- a/libs/external-db-postgres/src/sql_filter_transformer.js
+++ b/libs/external-db-postgres/src/sql_filter_transformer.js
@@ -99,7 +99,7 @@ class FilterParser {
 
                 const op = operator === and ? ' AND ' : ' OR '
                 return [{
-                    filterExpr: res.filter.map(r => r.filterExpr).join( op ),
+                    filterExpr: `(${res.filter.map(r => r.filterExpr).join( op )})`,
                     filterColumns: [],
                     offset: res.offset,
                     parameters: res.filter.map( s => s.parameters ).flat()

--- a/libs/external-db-postgres/src/sql_filter_transformer.spec.js
+++ b/libs/external-db-postgres/src/sql_filter_transformer.spec.js
@@ -290,7 +290,7 @@ describe('Sql Parser', () => {
                 const filter1 = env.filterParser.parseFilter(ctx.filter, ctx.offset)[0]
                 const filter2 = env.filterParser.parseFilter(ctx.anotherFilter, filter1.offset)[0]
                 expect( env.filterParser.parseFilter(filter, ctx.offset) ).toEqual([{
-                    filterExpr: `${filter1.filterExpr} ${op} ${filter2.filterExpr}`,
+                    filterExpr: `(${filter1.filterExpr} ${op} ${filter2.filterExpr})`,
                     filterColumns: [],
                     offset: filter2.offset,
                     parameters: [].concat(filter1.parameters)


### PR DESCRIPTION
Make sure each operator - (or, and) is enclosed in parentheses to maintain the intended logical sequence
fixed for mysql, bigquery, postgres 