### PR TITLE
resolving get by id bug

### DIFF
--- a/apps/velo-external-db/test/e2e/app_data.e2e.spec.js
+++ b/apps/velo-external-db/test/e2e/app_data.e2e.spec.js
@@ -120,6 +120,13 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
         await expect( axios.post('/data/get', { collectionName: ctx.collectionName, itemId: ctx.item._id }, authAdmin) ).resolves.toEqual(matchers.responseWith({ item: ctx.item }))
     })
 
+    test('get by id api should throw 404 if not found', async() => {
+        await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
+        await data.givenItems([ctx.item], ctx.collectionName, authAdmin)
+
+        await expect( axios.post('/data/get', { collectionName: ctx.collectionName, itemId: 'wrong' }, authAdmin) ).rejects.toThrow('404')
+    })
+
     testIfSupportedOperationsIncludes(supportedOperations, [ Projection ])('get by id api with projection', async() => {
         await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
         await data.givenItems([ctx.item], ctx.collectionName, authAdmin)

--- a/libs/velo-external-db-core/src/service/data.js
+++ b/libs/velo-external-db-core/src/service/data.js
@@ -17,7 +17,7 @@ class DataService {
 
     async getById(collectionName, itemId, projection) {
         const item = await this.storage.find(collectionName, getByIdFilterFor(itemId), '', 0, 1, projection)
-        return { item: asWixData(item[0], projection) }
+        return { item: item[0] ? asWixData(item[0], projection) : null }
     }
 
     async count(collectionName, filter) {

--- a/libs/velo-external-db-core/src/service/data.spec.js
+++ b/libs/velo-external-db-core/src/service/data.spec.js
@@ -32,6 +32,14 @@ describe('Data Service', () => {
         return expect(env.dataService.getById(ctx.collectionName, ctx.itemId, ctx.defaultProjection)).resolves.toEqual({ item: ctx.entity })
     })
 
+    test('get by id without item as a result will return item: null', async() => {
+        const idFilter = getByIdFilterFor(ctx.itemId)
+        driver.givenListResult([], ctx.collectionName,
+                        idFilter, '', 0, 1, ctx.defaultProjection)
+
+        return expect(env.dataService.getById(ctx.collectionName, ctx.itemId, ctx.defaultProjection)).resolves.toEqual({ item: null })
+    })
+
     test('insert will insert data into db', async() => {
         driver.expectInsertFor([ctx.entity], ctx.collectionName)
 


### PR DESCRIPTION
As you can see [here](https://github.com/wix/velo-external-db/blob/master/libs/velo-external-db-core/src/service/data.js#L20) -  `return { item: asWixData(item[0], projection) }` - The function `packDates` treats the item as an object and collapses it if there are no items found.

I fixed it and added 2 more tests - e2e, data service test.
