### PR TITLE
Dynamo filter transformer fixes

### DIFF
--- a/libs/external-db-dynamodb/src/dynamo_utils.ts
+++ b/libs/external-db-dynamodb/src/dynamo_utils.ts
@@ -1,5 +1,6 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
 import { InputField, ResponseField } from '@wix-velo/velo-external-db-types'
+import { Counter } from './sql_filter_transformer'
 const { InvalidQuery } = errors
 
 export const SystemTable = '_descriptor'
@@ -45,3 +46,6 @@ export const canQuery = (filterExpr: { ExpressionAttributeNames: { [s: string]: 
 }
 
 export const isEmptyObject = (obj: {}) => Object.keys(obj).length === 0
+
+export const fieldNameWithCounter = (fieldName: string, counter: Counter) => `#${fieldName}${counter.nameCounter++}`
+export const attributeValueNameWithCounter = (fieldName: any, counter: Counter) => `:${fieldName}${counter.valueCounter++}`

--- a/libs/external-db-dynamodb/tests/gen.ts
+++ b/libs/external-db-dynamodb/tests/gen.ts
@@ -6,12 +6,13 @@ const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_co
 
 const chance = Chance()
 
+const operatorsWithoutEqual = [lt, lte, gt, gte, include, string_contains, string_begins, string_ends]
+const randomOperatorWithoutEqual = () => ( chance.pickone(operatorsWithoutEqual) )
+const randomAdapterOperator = () => ( chance.pickone([...operatorsWithoutEqual, eq]) )
 
-const randomAdapterOperator = () => ( chance.pickone([ne, lt, lte, gt, gte, include, eq, string_contains, string_begins, string_ends]) )
 
-
-export const idFilter = () => {
-    const operator = randomAdapterOperator()
+export const idFilter = ({withoutEqual}: {withoutEqual: boolean} = {withoutEqual: false}) => {
+    const operator = withoutEqual ? randomOperatorWithoutEqual() : randomAdapterOperator() 
     const value = operator === '$hasSome' ? [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()] : chance.word()
     return {
         fieldName: '_id',


### PR DESCRIPTION
This PR resolves 3 problems: 

- Allow the same field to appear multiple times in the same query
- Fix And/Or operators bug (order of operations)
- Query on a key with `KeyConditionExpression` allowed only with equal operator, enforce it.