### PR TITLE
change Dockerfile path on build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@ node_modules
 .husky
 scripts
 tmp
-dist
 tools
 
 

--- a/apps/velo-external-db/project.json
+++ b/apps/velo-external-db/project.json
@@ -63,7 +63,7 @@
       "options": {
         "commands": [
           "nx run velo-external-db:build",
-          "docker build -f ./Dockerfile . -t velo-external-db"
+          "docker build -f ./apps/velo-external-db/Dockerfile . -t velo-external-db"
         ],
         "parallel": false
       }

--- a/apps/velo-external-db/project.json
+++ b/apps/velo-external-db/project.json
@@ -63,7 +63,7 @@
       "options": {
         "commands": [
           "nx run velo-external-db:build",
-          "docker build -f ./apps/velo-external-db/Dockerfile . -t velo-external-db"
+          "docker build -f ./Dockerfile . -t velo-external-db"
         ],
         "parallel": false
       }


### PR DESCRIPTION
This PR removes the `dist` folder from the `dockerignore` file, this will allow running the `build:full-image` command without any errors.