### PR TITLE
Firestore config validator fix

### DIFF
--- a/libs/external-db-firestore/src/firestore_config_validator.ts
+++ b/libs/external-db-firestore/src/firestore_config_validator.ts
@@ -6,7 +6,7 @@ export class ConfigValidator implements IConfigValidator {
     config: any
     
     constructor(config: any) {
-        this.requiredKeys = ['projectId', 'instanceId', 'databaseId'] 
+        this.requiredKeys = ['projectId'] 
         this.config = config
     }
 


### PR DESCRIPTION
This PR defines the correct required keys list for Firestore db engine.