### PR TITLE
Aggregation transformer v2

### DIFF
--- a/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
@@ -85,8 +85,10 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
         await data.givenItems([ctx.item, ctx.anotherItem], ctx.collectionName, authAdmin)
         await authorization.givenCollectionWithVisitorReadPolicy(ctx.collectionName)
 
-        await expect(queryCollectionAsArray(ctx.collectionName, [{ fieldName: ctx.column.name }], undefined)).resolves.toEqual(
-            expect.arrayContaining([{item: ctx.item} as QueryResponsePart, {item: ctx.anotherItem} as QueryResponsePart, pagingMetadata(2)])
+        const itemsByOrder = [ctx.item, ctx.anotherItem].sort((a,b) => (a[ctx.column.name] > b[ctx.column.name]) ? 1 : -1).map(item => ({item}))
+        
+        await expect(queryCollectionAsArray(ctx.collectionName, [{ fieldName: ctx.column.name, order: 'ASC' }], undefined)).resolves.toEqual(
+            ([...itemsByOrder, pagingMetadata(2)])
         )
     })
     

--- a/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
@@ -10,7 +10,7 @@ import { authAdmin, authOwner, authVisitor } from '@wix-velo/external-db-testkit
 import * as authorization from '../drivers/authorization_test_support'
 import Chance = require('chance')
 import { initApp, teardownApp, dbTeardown, setupDb, currentDbImplementationName, supportedOperations } from '../resources/e2e_resources'
-import { Options, QueryRequest, QueryV2, CountRequest, QueryResponsePart, UpdateRequest, TruncateRequest, RemoveRequest, RemoveResponsePart } from 'libs/velo-external-db-core/src/spi-model/data_source'
+import { Options, QueryRequest, QueryV2, CountRequest, QueryResponsePart, UpdateRequest, TruncateRequest, RemoveRequest, RemoveResponsePart, Group } from 'libs/velo-external-db-core/src/spi-model/data_source'
 import axios from 'axios'
 import { streamToArray } from '@wix-velo/test-commons'
 
@@ -68,7 +68,7 @@ const updateRequest = (collectionName, items) => ({
     } as Options,
 }) as UpdateRequest
 
-const pagingMetadata = (total) => ({pagingMetadata: {count: 25, offset:0, total: total, tooManyToCount: false}} as QueryResponsePart)
+const pagingMetadata = (total, count?) => ({pagingMetadata: {count: count || total , offset:0, total: total, tooManyToCount: false}} as QueryResponsePart)
 
 describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  () => {
     beforeAll(async() => {
@@ -122,31 +122,40 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
     testIfSupportedOperationsIncludes(supportedOperations, [ Aggregate ])('aggregate api', async() => {
         await schema.givenCollection(ctx.collectionName, ctx.numberColumns, authOwner)
         await data.givenItems([ctx.numberItem, ctx.anotherNumberItem], ctx.collectionName, authAdmin)
-
-        await expect( axiosInstance.post('/data/aggregate',
-            {
-                collectionName: ctx.collectionName,
-                filter: { _id: { $eq: ctx.numberItem._id } },
-                processingStep: {
-                    _id: {
-                        field1: '$_id',
-                        field2: '$_owner',
+        
+        const response = await axiosInstance.post('/data/aggregate',
+        {
+            collectionId: ctx.collectionName,
+            initialFilter: { _id: { $eq: ctx.numberItem._id } },
+            group: {
+                by: ['_id', '_owner'], aggregation: [
+                    {
+                        name: 'myAvg',
+                        avg: ctx.numberColumns[0].name
                     },
-                    myAvg: {
-                        $avg: `$${ctx.numberColumns[0].name}`
-                    },
-                    mySum: {
-                        $sum: `$${ctx.numberColumns[1].name}`
+                    {
+                        name: 'mySum',
+                        sum: ctx.numberColumns[1].name
                     }
-                },
-                postFilteringStep: {
-                    $and: [
-                        { myAvg: { $gt: 0 } },
-                        { mySum: { $gt: 0 } }
-                    ],
-                },
-            }, authAdmin) ).resolves.toEqual(matchers.responseWith({ items: [ { _id: ctx.numberItem._id, _owner: ctx.numberItem._owner, myAvg: ctx.numberItem[ctx.numberColumns[0].name], mySum: ctx.numberItem[ctx.numberColumns[1].name] } ],
-            totalCount: 0 }))
+                ]
+            } as Group,
+            finalFilter: {
+                $and: [
+                    { myAvg: { $gt: 0 } },
+                    { mySum: { $gt: 0 } }
+                ],
+            },
+        }, { responseType: 'stream', ...authAdmin })
+        
+        await expect(streamToArray(response.data)).resolves.toEqual(
+            expect.arrayContaining([{item: { 
+                _id: ctx.numberItem._id,
+                _owner: ctx.numberItem._owner,
+                myAvg: ctx.numberItem[ctx.numberColumns[0].name],
+                mySum: ctx.numberItem[ctx.numberColumns[1].name]
+                }},
+                pagingMetadata(1)
+        ]))
     })
 
     testIfSupportedOperationsIncludes(supportedOperations, [ DeleteImmediately ])('bulk delete api', async() => {

--- a/apps/velo-external-db/test/resources/e2e_resources.ts
+++ b/apps/velo-external-db/test/resources/e2e_resources.ts
@@ -57,7 +57,7 @@ export const testedSuit = () => testSuits[process.env.TEST_ENGINE]
 export const supportedOperations = testedSuit().supportedOperations
 
 export const setupDb = () => testedSuit().setUpDb()
-export const currentDbImplementationName = () => testedSuit().name
+export const currentDbImplementationName = () => testedSuit().currentDbImplementationName
 export const initApp = async() => {
     env = await testedSuit().initApp()
 }

--- a/apps/velo-external-db/test/storage/data_provider.spec.ts
+++ b/apps/velo-external-db/test/storage/data_provider.spec.ts
@@ -220,8 +220,9 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
 
         env.driver.stubEmptyFilterFor(ctx.filter)
         env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 1)
+        env.driver.stubEmptyOrderByFor(ctx.sort)
 
-        await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual(expect.arrayContaining([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] },
+        await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation, ctx.sort, ctx.skip, ctx.limit) ).resolves.toEqual(expect.arrayContaining([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] },
                                                         { _id: ctx.anotherNumberEntity._id, [ctx.aliasColumns[0]]: ctx.anotherNumberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.anotherNumberEntity[ctx.numericColumns[1].name] }
         ]))
     })
@@ -232,8 +233,9 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
 
         env.driver.stubEmptyFilterFor(ctx.filter)
         env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 1)
+        env.driver.stubEmptyOrderByFor(ctx.sort)
 
-        await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual(expect.arrayContaining([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] },
+        await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation, ctx.sort, ctx.skip, ctx.limit) ).resolves.toEqual(expect.arrayContaining([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] },
                                                                                                                                                         { _id: ctx.anotherNumberEntity._id, [ctx.aliasColumns[0]]: ctx.anotherNumberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.anotherNumberEntity[ctx.numericColumns[1].name] }
         ]))
     })
@@ -244,8 +246,9 @@ describe(`Data API: ${currentDbImplementationName()}`, () => {
 
         env.driver.givenFilterByIdWith(ctx.numberEntity._id, ctx.filter)
         env.driver.givenAggregateQueryWith(ctx.aggregation.processingStep, ctx.numericColumns, ctx.aliasColumns, ['_id'], ctx.aggregation.postFilteringStep, 2)
+        env.driver.stubEmptyOrderByFor(ctx.sort)
 
-        await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation) ).resolves.toEqual([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] }])
+        await expect( env.dataProvider.aggregate(ctx.numericCollectionName, ctx.filter, ctx.aggregation, ctx.sort, ctx.skip, ctx.limit) ).resolves.toEqual([{ _id: ctx.numberEntity._id, [ctx.aliasColumns[0]]: ctx.numberEntity[ctx.numericColumns[0].name], [ctx.aliasColumns[1]]: ctx.numberEntity[ctx.numericColumns[1].name] }])
     })
     
 

--- a/libs/external-db-mysql/src/mysql_data_provider.ts
+++ b/libs/external-db-mysql/src/mysql_data_provider.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util'
 import { asParamArrays, updateFieldsFor } from '@wix-velo/velo-external-db-commons'
 import { translateErrorCodes } from './sql_exception_translator'
 import { wildCardWith } from './mysql_utils'
-import { IDataProvider, AdapterFilter as Filter, AdapterAggregation as Aggregation, Item } from '@wix-velo/velo-external-db-types'
+import { IDataProvider, AdapterFilter as Filter, AdapterAggregation as Aggregation, Item, Sort } from '@wix-velo/velo-external-db-types'
 import { IMySqlFilterParser } from './sql_filter_transformer'
 import { MySqlQuery } from './types'
 
@@ -73,12 +73,13 @@ export default class DataProvider implements IDataProvider {
         await this.query(`TRUNCATE ${escapeTable(collectionName)}`).catch( translateErrorCodes )
     }
 
-    async aggregate(collectionName: string, filter: Filter, aggregation: Aggregation): Promise<Item[]> {
+    async aggregate(collectionName: string, filter: Filter, aggregation: Aggregation, sort: Sort[], skip: number, limit: number): Promise<Item[]> {
         const { filterExpr: whereFilterExpr, parameters: whereParameters } = this.filterParser.transform(filter)
         const { fieldsStatement, groupByColumns, havingFilter, parameters } = this.filterParser.parseAggregation(aggregation)
+        const { sortExpr } = this.filterParser.orderBy(sort)
 
-        const sql = `SELECT ${fieldsStatement} FROM ${escapeTable(collectionName)} ${whereFilterExpr} GROUP BY ${groupByColumns.map( escapeId ).join(', ')} ${havingFilter}`
-        const resultset = await this.query(sql, [...whereParameters, ...parameters])
+        const sql = `SELECT ${fieldsStatement} FROM ${escapeTable(collectionName)} ${whereFilterExpr} GROUP BY ${groupByColumns.map( escapeId ).join(', ')} ${havingFilter} ${sortExpr} LIMIT ?, ?`
+        const resultset = await this.query(sql, [...whereParameters, ...parameters, skip, limit])
                                     .catch( translateErrorCodes )
         return resultset
     }

--- a/libs/velo-external-db-core/src/converters/aggregation_transformer.spec.ts
+++ b/libs/velo-external-db-core/src/converters/aggregation_transformer.spec.ts
@@ -72,14 +72,6 @@ describe('Aggregation Transformer', () => {
     test('single id field with count function and without postFilter', () => {
         env.driver.stubEmptyFilterForUndefined()
 
-        const processingStep = {
-            _id: `$${ctx.fieldName}`,
-            [ctx.fieldAlias]: {
-                $sum: 1
-            }
-        }
-        const postFilteringStep = null
-
         const group = { by: [ctx.fieldName], aggregation: [{ name: ctx.fieldAlias, count: 1 }] } as Group
 
         expect(env.AggregationTransformer.transform({ group })).toEqual({

--- a/libs/velo-external-db-core/src/converters/filter_transformer.spec.ts
+++ b/libs/velo-external-db-core/src/converters/filter_transformer.spec.ts
@@ -132,6 +132,42 @@ describe('Filter Transformer', () => {
                 value: [env.FilterTransformer.transform(ctx.filter)]
             })
         })
+    }), 
+
+    describe('transform sort', () => { 
+        test('should handle wrong sort', () => {
+            expect(env.FilterTransformer.transformSort('')).toEqual([])
+            expect(env.FilterTransformer.transformSort(undefined)).toEqual([])
+            expect(env.FilterTransformer.transformSort(null)).toEqual([])
+        })
+
+        test('transform empty sort', () => {
+            expect(env.FilterTransformer.transformSort([])).toEqual([])
+        })
+
+        test('transform sort', () => {
+            const sort = [
+                { fieldName: ctx.fieldName, order: 'ASC' },
+            ]
+            expect(env.FilterTransformer.transformSort(sort)).toEqual([{
+                fieldName: ctx.fieldName,
+                direction: 'asc'
+            }])
+        })
+
+        test('transform sort with multiple fields', () => {
+            const sort = [
+                { fieldName: ctx.fieldName, order: 'ASC' },
+                { fieldName: ctx.anotherFieldName, order: 'DESC' },
+            ]
+            expect(env.FilterTransformer.transformSort(sort)).toEqual([{
+                fieldName: ctx.fieldName,
+                direction: 'asc'
+            }, {
+                fieldName: ctx.anotherFieldName,
+                direction: 'desc'
+            }])
+        })
     })
 
     interface Enviorment {
@@ -146,6 +182,7 @@ describe('Filter Transformer', () => {
         filter: Uninitialized,
         anotherFilter: Uninitialized,
         fieldName: Uninitialized,
+        anotherFieldName: Uninitialized,
         fieldValue: Uninitialized,
         operator: Uninitialized,
         fieldListValue: Uninitialized,
@@ -155,6 +192,7 @@ describe('Filter Transformer', () => {
         ctx.filter = gen.randomFilter()
         ctx.anotherFilter = gen.randomFilter()
         ctx.fieldName = chance.word()
+        ctx.anotherFieldName = chance.word()
         ctx.fieldValue = chance.word()
         ctx.operator = gen.randomOperator() as WixDataMultiFieldOperators | WixDataSingleFieldOperators
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]

--- a/libs/velo-external-db-core/src/converters/filter_transformer.ts
+++ b/libs/velo-external-db-core/src/converters/filter_transformer.ts
@@ -1,7 +1,8 @@
 import { AdapterOperators, isObject } from '@wix-velo/velo-external-db-commons'
 import { EmptyFilter } from './utils'
 import { errors } from '@wix-velo/velo-external-db-commons'
-import { AdapterFilter, AdapterOperator, WixDataFilter, WixDataMultiFieldOperators, } from '@wix-velo/velo-external-db-types'
+import { AdapterFilter, AdapterOperator, Sort, WixDataFilter, WixDataMultiFieldOperators, } from '@wix-velo/velo-external-db-types'
+import { Sorting } from '../spi-model/data_source'
 const { InvalidQuery } = errors
 
 export interface IFilterTransformer {
@@ -42,6 +43,19 @@ export default class FilterTransformer implements IFilterTransformer {
             fieldName,
             value
         }
+    }
+
+    transformSort(sort: any): Sort[] {
+        if (!this.isSortArray(sort)) {
+            return []
+        }
+
+        return (sort as Sorting[]).map(sorting => {
+            return {
+                fieldName: sorting.fieldName,
+                direction: sorting.order.toLowerCase() as 'asc' | 'desc'
+            }
+        })
     }
 
     isMultipleFieldOperator(filter: WixDataFilter) {
@@ -93,4 +107,17 @@ export default class FilterTransformer implements IFilterTransformer {
         return (!filter || !isObject(filter) || Object.keys(filter)[0] === undefined)
     }
 
+    isSortArray(sort: any): boolean {
+        
+        if (!Array.isArray(sort)) {
+            return false
+        }
+        return sort.every((s: any) => {
+            return this.isSortObject(s)
+        })   
+    }
+
+    isSortObject(sort:any): boolean {
+        return sort.fieldName && sort.order
+    }
 }

--- a/libs/velo-external-db-core/src/converters/filter_transformer.ts
+++ b/libs/velo-external-db-core/src/converters/filter_transformer.ts
@@ -18,9 +18,6 @@ export default class FilterTransformer implements IFilterTransformer {
     }
 
     transform(filter: any): AdapterFilter {
-
-        console.log(JSON.stringify(filter))
-
         if (this.isEmptyFilter(filter)) return EmptyFilter
 
         if (this.isMultipleFieldOperator(filter)) {

--- a/libs/velo-external-db-core/src/converters/utils.ts
+++ b/libs/velo-external-db-core/src/converters/utils.ts
@@ -8,10 +8,8 @@ export const projectionFieldFor = (fieldName: any, fieldAlias?: string) => {
 }
 
 export const projectionFunctionFor = (fieldName: string | number, fieldAlias: any, func: any) => {
-    if (isCountFunc(func, fieldName))
+    if (func === AdapterFunctions.count)
         return { alias: fieldAlias, function: AdapterFunctions.count, name: '*' }
-    const name = (fieldName as string).substring(1)
-    return { name, alias: fieldAlias || name, function: func }
+    
+    return { name: fieldName as string, alias: fieldAlias || fieldName as string, function: func }
 }
-
-const isCountFunc = (func: any, value: any ) => (func === AdapterFunctions.sum && value === 1)

--- a/libs/velo-external-db-core/src/data_hooks_utils.spec.ts
+++ b/libs/velo-external-db-core/src/data_hooks_utils.spec.ts
@@ -68,14 +68,18 @@ describe('Hooks Utils', () => {
             expect(dataPayloadFor(DataOperations.Get, randomBodyWith({ itemId: ctx.itemId, projection: ctx.projection }))).toEqual({ itemId: ctx.itemId, projection: ctx.projection })
         })
         test('Payload for Aggregate should return Aggregation query', () => {
-            expect(dataPayloadFor(DataOperations.Aggregate, randomBodyWith({ filter: ctx.filter, processingStep: ctx.processingStep, postFilteringStep: ctx.postFilteringStep })))
-                .toEqual(
-                    {
-                        filter: ctx.filter,
-                        processingStep: ctx.processingStep,
-                        postFilteringStep: ctx.postFilteringStep
-                    }
-                )
+            expect(dataPayloadFor(DataOperations.Aggregate, randomBodyWith({
+                initialFilter: ctx.filter, group: ctx.group, finalFilter: ctx.finalFilter, distinct: ctx.distinct
+                , paging: ctx.paging, sort: ctx.sort, projection: ctx.projection
+            }))).toEqual({
+                initialFilter: ctx.filter,
+                distinct: ctx.distinct,
+                group: ctx.group,
+                finalFilter: ctx.finalFilter,
+                sort: ctx.sort,
+                paging: ctx.paging,
+            }
+            )
         })
     })
 
@@ -90,8 +94,10 @@ describe('Hooks Utils', () => {
         items: Uninitialized,
         itemId: Uninitialized,
         itemIds: Uninitialized,
-        processingStep: Uninitialized,
-        postFilteringStep: Uninitialized
+        group: Uninitialized,
+        finalFilter: Uninitialized,
+        distinct: Uninitialized,
+        paging: Uninitialized,
     }
 
     beforeEach(() => {
@@ -104,5 +110,9 @@ describe('Hooks Utils', () => {
         ctx.items = chance.word()
         ctx.itemId = chance.word()
         ctx.itemIds = chance.word()
+        ctx.group = chance.word()
+        ctx.finalFilter = chance.word()
+        ctx.distinct = chance.word()
+        ctx.paging = chance.word()
     })
 })

--- a/libs/velo-external-db-core/src/data_hooks_utils.ts
+++ b/libs/velo-external-db-core/src/data_hooks_utils.ts
@@ -1,5 +1,6 @@
 import { Item, WixDataFilter } from '@wix-velo/velo-external-db-types'
-import { AggregationQuery, FindQuery, RequestContext } from './types'
+import { AggregateRequest } from './spi-model/data_source'
+import { FindQuery, RequestContext } from './types'
 
 
 export const DataHooksForAction: { [key: string]: string[] } = {
@@ -93,10 +94,12 @@ export const dataPayloadFor = (operation: DataOperations, body: any) => {
         case DataOperations.Aggregate:
             return {
                 initialFilter: body.initialFilter,
+                distinct: body.distinct,
                 group: body.group,
                 finalFilter: body.finalFilter,
                 sort: body.sort,
-            } as AggregationQuery
+                paging: body.paging,
+            } as Partial<AggregateRequest>
         case DataOperations.Count:
             return { filter: body.filter as WixDataFilter }
     }

--- a/libs/velo-external-db-core/src/data_hooks_utils.ts
+++ b/libs/velo-external-db-core/src/data_hooks_utils.ts
@@ -92,9 +92,10 @@ export const dataPayloadFor = (operation: DataOperations, body: any) => {
             return { itemIds: body.itemIds as string[] }
         case DataOperations.Aggregate:
             return {
-                filter: body.filter,
-                processingStep: body.processingStep,
-                postFilteringStep: body.postFilteringStep
+                initialFilter: body.initialFilter,
+                group: body.group,
+                finalFilter: body.finalFilter,
+                sort: body.sort,
             } as AggregationQuery
         case DataOperations.Count:
             return { filter: body.filter as WixDataFilter }

--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -121,7 +121,7 @@ export const createRouter = () => {
         const data = await schemaAwareDataService.find(
             queryRequest.collectionId, 
             filterTransformer.transform(query.filter), 
-            query.sort, 
+            filterTransformer.transformSort(query.sort), 
             offset, 
             limit, 
             query.fields
@@ -254,7 +254,7 @@ export const createRouter = () => {
             const customContext = {}
             const { initialFilter, group, finalFilter } = await executeDataHooksFor(DataActions.BeforeAggregate, dataPayloadFor(AGGREGATE, req.body), requestContextFor(AGGREGATE, req.body), customContext)
             roleAuthorizationService.authorizeRead(collectionId, extractRole(req.body))
-            const data = await schemaAwareDataService.aggregate(collectionId, filterTransformer.transform(initialFilter), aggregationTransformer.transform({ group, finalFilter }), sort, offset, limit)
+            const data = await schemaAwareDataService.aggregate(collectionId, filterTransformer.transform(initialFilter), aggregationTransformer.transform({ group, finalFilter }), filterTransformer.transformSort(sort), offset, limit)
             const dataAfterAction = await executeDataHooksFor(DataActions.AfterAggregate, data, requestContextFor(AGGREGATE, req.body), customContext)
 
             const responseParts = dataAfterAction.items.map((item: Item) => ({

--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -246,16 +246,16 @@ export const createRouter = () => {
 
     router.post('/data/aggregate', async (req, res, next) => {
         try {
-            const { collectionId } = req.body
-            const offset = req.body.paging ? req.body.paging.offset : 0
-            const limit = req.body.paging ? req.body.paging.limit : 50
-            const sort = req.body.sort || [] //should always get it?
+            const aggregationRequest = req.body as dataSource.AggregateRequest
+            const { collectionId, paging, sort } = aggregationRequest
+            const offset = paging ? paging.offset : 0
+            const limit = paging ? paging.limit : 50
 
             const customContext = {}
-            const { initialFilter, group, finalFilter } = await executeDataHooksFor(DataActions.BeforeAggregate, dataPayloadFor(AGGREGATE, req.body), requestContextFor(AGGREGATE, req.body), customContext)
-            roleAuthorizationService.authorizeRead(collectionId, extractRole(req.body))
+            const { initialFilter, group, finalFilter } = await executeDataHooksFor(DataActions.BeforeAggregate, dataPayloadFor(AGGREGATE, aggregationRequest), requestContextFor(AGGREGATE, aggregationRequest), customContext)
+            roleAuthorizationService.authorizeRead(collectionId, extractRole(aggregationRequest))
             const data = await schemaAwareDataService.aggregate(collectionId, filterTransformer.transform(initialFilter), aggregationTransformer.transform({ group, finalFilter }), filterTransformer.transformSort(sort), offset, limit)
-            const dataAfterAction = await executeDataHooksFor(DataActions.AfterAggregate, data, requestContextFor(AGGREGATE, req.body), customContext)
+            const dataAfterAction = await executeDataHooksFor(DataActions.AfterAggregate, data, requestContextFor(AGGREGATE, aggregationRequest), customContext)
 
             const responseParts = dataAfterAction.items.map((item: Item) => ({
                     item

--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -161,23 +161,6 @@ export const createRouter = () => {
         res.json(response)
     })
 
-    router.post('/data2/aggregate', async(req, res, next) => {
-        const aggregateRequest: dataSource.AggregateRequest = req.body;
-        
-
-
-        const data = await schemaAwareDataService.aggregate(
-            aggregateRequest.collectionId,
-            filterTransformer.transform(aggregateRequest.initialFilter),
-            {
-                projection: [],
-                postFilter: aggregateRequest.finalFilter,
-            }
-        )
-
-        res.json(data)
-    })
-
     router.post('/data2/insert', async(req, res, next) => {
         // todo: handle upserts.
         try {

--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -16,7 +16,7 @@ import { DataHooksForAction, DataOperations, dataPayloadFor, DataActions, reques
 import { SchemaHooksForAction, SchemaOperations, schemaPayloadFor, SchemaActions } from './schema_hooks_utils'
 import SchemaService from './service/schema'
 import OperationService from './service/operation'
-import { AnyFixMe } from '@wix-velo/velo-external-db-types'
+import { AnyFixMe, Item } from '@wix-velo/velo-external-db-types'
 import SchemaAwareDataService from './service/schema_aware_data'
 import FilterTransformer from './converters/filter_transformer'
 import AggregationTransformer from './converters/aggregation_transformer'
@@ -24,9 +24,6 @@ import { RoleAuthorizationService } from '@wix-velo/external-db-security'
 import { DataHooks, Hooks, RequestContext, SchemaHooks, ServiceContext } from './types'
 import { ConfigValidator } from '@wix-velo/external-db-config'
 import * as dataSource from './spi-model/data_source'
-import { json } from 'stream/consumers';
-import DataService from './service/data';
-
 
 const { InvalidRequest, ItemNotFound } = errors
 const { Find: FIND, Insert: INSERT, BulkInsert: BULK_INSERT, Update: UPDATE, BulkUpdate: BULK_UPDATE, Remove: REMOVE, BulkRemove: BULK_REMOVE, Aggregate: AGGREGATE, Count: COUNT, Get: GET } = DataOperations
@@ -137,7 +134,7 @@ export const createRouter = () => {
 
         const metadata = {
             pagingMetadata: {
-                count: limit,
+                count: data.items.length,
                 offset: offset,
                 total: data.totalCount,
                 tooManyToCount: false, //Check if always false
@@ -247,19 +244,39 @@ export const createRouter = () => {
         }
     })    
 
-    router.post('/data/aggregate', async(req, res, next) => {
+    router.post('/data/aggregate', async (req, res, next) => {
         try {
-            const { collectionName } = req.body
+            const { collectionId } = req.body
+            const offset = req.body.paging ? req.body.paging.offset : 0
+            const limit = req.body.paging ? req.body.paging.limit : 50
+            const sort = req.body.sort || [] //should always get it?
+
             const customContext = {}
-            const { filter, processingStep, postFilteringStep } = await executeDataHooksFor(DataActions.BeforeAggregate, dataPayloadFor(AGGREGATE, req.body), requestContextFor(AGGREGATE, req.body), customContext)
-            await roleAuthorizationService.authorizeRead(collectionName, extractRole(req.body))
-            const data = await schemaAwareDataService.aggregate(collectionName, filterTransformer.transform(filter), aggregationTransformer.transform({ processingStep, postFilteringStep }))
+            const { initialFilter, group, finalFilter } = await executeDataHooksFor(DataActions.BeforeAggregate, dataPayloadFor(AGGREGATE, req.body), requestContextFor(AGGREGATE, req.body), customContext)
+            roleAuthorizationService.authorizeRead(collectionId, extractRole(req.body))
+            const data = await schemaAwareDataService.aggregate(collectionId, filterTransformer.transform(initialFilter), aggregationTransformer.transform({ group, finalFilter }), sort, offset, limit)
             const dataAfterAction = await executeDataHooksFor(DataActions.AfterAggregate, data, requestContextFor(AGGREGATE, req.body), customContext)
-            res.json(dataAfterAction)
+
+            const responseParts = dataAfterAction.items.map((item: Item) => ({
+                    item
+                } as dataSource.AggregateResponsePart
+            ))
+
+            const metadata = {
+                pagingMetadata: {
+                    count: (dataAfterAction.items as Item[]).length,
+                    offset: offset,
+                    total: data.totalCount,
+                    tooManyToCount: false, //Check if always false
+                } as dataSource.PagingMetadataV2
+            } as dataSource.AggregateResponsePart
+
+            streamCollection([...responseParts, ...[metadata]], res)
         } catch (e) {
             next(e)
         }
     })
+
 
 
     router.post('/data/insert', async(req, res, next) => {

--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -223,14 +223,11 @@ export const createRouter = () => {
             const removeRequest: dataSource.RemoveRequest = req.body;
             const collectionName = removeRequest.collectionId
             
-            console.log('removeRequest.itemIds', JSON.stringify(removeRequest.itemIds))
-
             const idEqExpression = removeRequest.itemIds.map(itemId => ({_id: {$eq: itemId}}))
             const filter = {$or: idEqExpression}
 
             const objectsBeforeRemove = (await schemaAwareDataService.find(collectionName, filterTransformer.transform(filter), undefined, 0, removeRequest.itemIds.length)).items
 
-            console.log("!!!!!!!!",  JSON.stringify(objectsBeforeRemove))
             const data = await schemaAwareDataService.bulkDelete(collectionName, removeRequest.itemIds)
             
             const responseParts = objectsBeforeRemove.map(item => ({

--- a/libs/velo-external-db-core/src/service/data.spec.ts
+++ b/libs/velo-external-db-core/src/service/data.spec.ts
@@ -85,9 +85,10 @@ describe('Data Service', () => {
     })
 
     test('aggregate api', async() => {
-        driver.givenAggregateResult(ctx.entities, ctx.collectionName, ctx.filter, ctx.aggregation)
+        driver.givenAggregateResult(ctx.entities, ctx.collectionName, ctx.filter, ctx.aggregation, ctx.sort, ctx.skip, ctx.limit)
+        driver.givenCountResult(ctx.total, ctx.collectionName, ctx.filter)
 
-        return expect(env.dataService.aggregate(ctx.collectionName, ctx.filter, ctx.aggregation)).resolves.toEqual({ items: ctx.entities, totalCount: 0 })
+        return expect(env.dataService.aggregate(ctx.collectionName, ctx.filter, ctx.aggregation, ctx.sort, ctx.skip, ctx.limit)).resolves.toEqual({ items: ctx.entities, totalCount: ctx.total })
     })
 
 

--- a/libs/velo-external-db-core/src/service/data.ts
+++ b/libs/velo-external-db-core/src/service/data.ts
@@ -1,4 +1,4 @@
-import { AdapterAggregation as Aggregation, AdapterFilter as Filter, IDataProvider, Item, ResponseField } from '@wix-velo/velo-external-db-types'
+import { AdapterAggregation as Aggregation, AdapterFilter as Filter, IDataProvider, Item, ResponseField, Sort } from '@wix-velo/velo-external-db-types'
 import { asWixData } from '../converters/data_utils'
 import { getByIdFilterFor } from '../utils/data_utils'
 
@@ -63,11 +63,14 @@ export default class DataService {
         return this.storage.truncate(collectionName)
     }
 
-    async aggregate(collectionName: string, filter: Filter, aggregation: Aggregation) {
+
+    // sort, skip, limit are not really optional, after we'll implement in all the data providers we can remove the ?
+    async aggregate(collectionName: string, filter: Filter, aggregation: Aggregation, sort?: Sort[], skip?: number, limit?: number) {
+        const totalCount = this.storage.count(collectionName, filter)
         return {
-            items: ((await this.storage.aggregate?.(collectionName, filter, aggregation)) || [])
+            items: ((await this.storage.aggregate?.(collectionName, filter, aggregation, sort, skip, limit)) || [])
                                       .map( asWixData ),
-            totalCount: 0
+            totalCount: await totalCount
         }
     }
 }

--- a/libs/velo-external-db-core/src/service/schema_aware_data.spec.ts
+++ b/libs/velo-external-db-core/src/service/schema_aware_data.spec.ts
@@ -95,9 +95,9 @@ describe ('Schema Aware Data Service', () => {
         queryValidator.givenValidFilterForDefaultFieldsOf(ctx.filter) 
         queryValidator.givenValidAggregationForDefaultFieldsOf(ctx.aggregation)
         
-        data.givenAggregateResult(ctx.entities, ctx.collectionName, ctx.filter, ctx.aggregation)
+        data.givenAggregateResult(ctx.entities, ctx.collectionName, ctx.filter, ctx.aggregation, ctx.sort, ctx.skip, ctx.limit)
         
-        return expect(env.schemaAwareDataService.aggregate(ctx.collectionName, ctx.filter, ctx.aggregation)).resolves.toEqual({ items: ctx.entities, totalCount: 0 })
+        return expect(env.schemaAwareDataService.aggregate(ctx.collectionName, ctx.filter, ctx.aggregation, ctx.sort, ctx.skip, ctx.limit)).resolves.toEqual({ items: ctx.entities, totalCount: 0 })
     })
     
     const ctx = {

--- a/libs/velo-external-db-core/src/service/schema_aware_data.ts
+++ b/libs/velo-external-db-core/src/service/schema_aware_data.ts
@@ -1,4 +1,4 @@
-import { AdapterAggregation as Aggregation, AdapterFilter as Filter, AnyFixMe, Item, ItemWithId, ResponseField } from '@wix-velo/velo-external-db-types'
+import { AdapterAggregation as Aggregation, AdapterFilter as Filter, AnyFixMe, Item, ItemWithId, ResponseField, Sort } from '@wix-velo/velo-external-db-types'
 import QueryValidator from '../converters/query_validator'
 import DataService from './data'
 import CacheableSchemaInformation from './schema_information'
@@ -73,10 +73,11 @@ export default class SchemaAwareDataService {
         return await this.dataService.truncate(collectionName)
     }
     
-    async aggregate(collectionName: string, filter: Filter, aggregation: Aggregation) {
+    // sort, skip, limit are not really optional, after we'll implement in all the data providers we can remove the ?
+    async aggregate(collectionName: string, filter: Filter, aggregation: Aggregation, sort?: Sort[], skip?: number, limit?: number) {
         await this.validateAggregation(collectionName, aggregation)
         await this.validateFilter(collectionName, filter)
-        return await this.dataService.aggregate(collectionName, filter, aggregation)
+        return await this.dataService.aggregate(collectionName, filter, aggregation, sort, skip, limit)
     }
 
     async validateFilter(collectionName: string, filter: Filter, _fields?: ResponseField[]) {

--- a/libs/velo-external-db-core/src/spi-model/data_source.ts
+++ b/libs/velo-external-db-core/src/spi-model/data_source.ts
@@ -161,22 +161,24 @@ export interface Group {
     // properties to group by, if empty single group would be created
     by: string[];
     // aggregations, resulted group will contain field with given name and aggregation value
-    aggregation: Aggregation;
+    aggregation: Aggregation[];
 }
 
 export interface Aggregation {
     // result property name
     name: string;
+
+    //TODO: should be one of the following
     // property to calculate average of
-    avg: string;
+    avg?: string;
     // property to calculate min of
-    min: string;
+    min?: string;
     // property to calculate max of
-    max: string;
+    max?: string;
     // property to calculate sum of
-    sum: string;
+    sum?: string;
     // count items, value is always 1
-    count: number;
+    count?: number;
 }
 
 export interface AggregateResponsePart {

--- a/libs/velo-external-db-core/src/types.ts
+++ b/libs/velo-external-db-core/src/types.ts
@@ -1,6 +1,7 @@
 import { AdapterFilter, InputField, Item, Sort, WixDataFilter, AsWixSchema, AsWixSchemaHeaders, RoleConfig } from '@wix-velo/velo-external-db-types'
 import SchemaService from './service/schema'
 import SchemaAwareDataService from './service/schema_aware_data'
+import { AggregateRequest } from './spi-model/data_source';
 
 
 export interface FindQuery {
@@ -10,11 +11,7 @@ export interface FindQuery {
     limit?: number;
 }
 
-export type AggregationQuery = {
-    filter?: WixDataFilter,
-    processingStep?: WixDataFilter,
-    postProcessingStep?: WixDataFilter
-}
+
 
 export interface Payload {
     filter?: WixDataFilter | AdapterFilter
@@ -81,7 +78,7 @@ export interface DataHooks {
     afterRemove?: Hook<{ itemId: string }>
     beforeBulkRemove?: Hook<{ itemIds: string[] }>
     afterBulkRemove?: Hook<{ itemIds: string[] }>
-    beforeAggregate?: Hook<AggregationQuery>
+    beforeAggregate?: Hook<AggregateRequest>
     afterAggregate?: Hook<{ items: Item[] }>
     beforeCount?: Hook<WixDataFilter>
     afterCount?: Hook<{ totalCount: number }>

--- a/libs/velo-external-db-core/src/types.ts
+++ b/libs/velo-external-db-core/src/types.ts
@@ -1,7 +1,7 @@
 import { AdapterFilter, InputField, Item, Sort, WixDataFilter, AsWixSchema, AsWixSchemaHeaders, RoleConfig } from '@wix-velo/velo-external-db-types'
 import SchemaService from './service/schema'
 import SchemaAwareDataService from './service/schema_aware_data'
-import { AggregateRequest } from './spi-model/data_source';
+import { AggregateRequest, Group, Paging, Sorting } from './spi-model/data_source';
 
 
 export interface FindQuery {
@@ -15,12 +15,13 @@ export interface FindQuery {
 
 export interface Payload {
     filter?: WixDataFilter | AdapterFilter
-    sort?: Sort;
+    sort?: Sort[] | Sorting[];
     skip?: number;
     limit?: number;
-    postProcessingStep?: WixDataFilter | AdapterFilter;
-    processingStep?: WixDataFilter | AdapterFilter;
-    postFilteringStep?: WixDataFilter | AdapterFilter;
+    initialFilter: WixDataFilter | AdapterFilter;
+    group?: Group;
+    finalFilter?: WixDataFilter | AdapterFilter;
+    paging?: Paging;
     item?: Item;
     items?: Item[];
     itemId?: string;

--- a/libs/velo-external-db-core/test/drivers/data_provider_test_support.ts
+++ b/libs/velo-external-db-core/test/drivers/data_provider_test_support.ts
@@ -18,8 +18,8 @@ export const givenCountResult = (total: any, forCollectionName: any, filter: any
     when(dataProvider.count).calledWith(forCollectionName, filter)
                             .mockResolvedValue(total)
 
-export const givenAggregateResult = (total: any, forCollectionName: any, filter: any, andAggregation: any) =>
-    when(dataProvider.aggregate).calledWith(forCollectionName, filter, andAggregation)
+export const givenAggregateResult = (total: any, forCollectionName: any, filter: any, andAggregation: any, sort: any, skip: any, limit: any) =>
+    when(dataProvider.aggregate).calledWith(forCollectionName, filter, andAggregation, sort, skip, limit)
                                 .mockResolvedValue(total)
 
 export const expectInsertFor = (items: string | any[], forCollectionName: any) =>

--- a/libs/velo-external-db-core/test/drivers/data_service_test_support.ts
+++ b/libs/velo-external-db-core/test/drivers/data_service_test_support.ts
@@ -57,8 +57,8 @@ export const truncateResultTo = (forCollectionName: any) =>
     when(dataService.truncate).calledWith(forCollectionName)
                               .mockResolvedValue(1)
 
-export const givenAggregateResult = (items: any, forCollectionName: any, filter: any, aggregation: any) =>    
-    when(dataService.aggregate).calledWith(forCollectionName, filter, aggregation)
+export const givenAggregateResult = (items: any, forCollectionName: any, filter: any, aggregation: any, sort: any, skip: any, limit: any) =>    
+    when(dataService.aggregate).calledWith(forCollectionName, filter, aggregation, sort, skip, limit)
                                .mockResolvedValue({ items, totalCount: 0 })
 
 export const reset = () => {

--- a/libs/velo-external-db-core/test/drivers/filter_transformer_test_support.ts
+++ b/libs/velo-external-db-core/test/drivers/filter_transformer_test_support.ts
@@ -11,6 +11,10 @@ export const stubEmptyFilterFor = (filter: any) => {
         .mockReturnValue(EmptyFilter)
 }
 
+export const stubEmptyFilterForUndefined = () => {
+    stubEmptyFilterFor(undefined)
+}
+
 export const givenFilterByIdWith = (id: any, filter: any) => {
     when(filterTransformer.transform).calledWith(filter)
                                 .mockReturnValue({

--- a/libs/velo-external-db-types/src/index.ts
+++ b/libs/velo-external-db-types/src/index.ts
@@ -119,7 +119,8 @@ export interface IDataProvider {
     update(collectionName: string, items: Item[], fields?: any): Promise<number>;
     delete(collectionName: string, itemIds: string[]): Promise<number>;
     truncate(collectionName: string): Promise<void>;
-    aggregate?(collectionName: string, filter: AdapterFilter, aggregation: AdapterAggregation): Promise<Item[]>;
+    // sort, skip, limit are not really optional, after we'll implement in all the data providers we can remove the ?
+    aggregate?(collectionName: string, filter: AdapterFilter, aggregation: AdapterAggregation, sort?: Sort[], skip?: number, limit?: number ): Promise<Item[]>;
 }
 
 export type TableHeader = {

--- a/libs/velo-external-db-types/src/index.ts
+++ b/libs/velo-external-db-types/src/index.ts
@@ -226,15 +226,6 @@ export enum WixDataFunction {
     $sum = '$sum',
 }
 
-export type WixDataAggregation = {
-    processingStep: {
-        _id: string |  { [key: string]: any }
-        [key: string]: any
-        // [fieldAlias: string]: {[key in WixDataFunction]: string | number },
-    }
-    postFilteringStep: WixDataFilter
-}
-
 export type WixDataRole = 'OWNER' | 'BACKEND_CODE' | 'MEMBER' | 'VISITOR'
 export type VeloRole = 'Admin' | 'Member' | 'Visitor'
 


### PR DESCRIPTION
This PR implements: 

- Adjusting `AggregationTransformer` to transform from the new format.
- add skip, limit, sort to aggregation request, add it in mysql data provider
- add `sortTransformer` method to `filterTransformer` duo the change of the sort object from v1 to v2
- fix find with sort test (didn't check that the array is sorted after the last change)