### PR TITLE
Handling bit type and default type for unkown datatype

### DIFF
--- a/libs/external-db-bigquery/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-bigquery/src/sql_schema_translator.spec.ts
@@ -138,9 +138,13 @@ describe('Sql Schema Column Translator', () => {
 
         describe('other fields', () => {
             test('boolean', () => {
-                ['BOOL'].forEach(t => {
+                ['BOOL', 'bit'].forEach(t => {
                     expect( env.schemaTranslator.translateType(t) ).toEqual('boolean')
                 })
+            })
+
+            test('unknown type should return text', () => { 
+                expect( env.schemaTranslator.translateType('unknown') ).toEqual('text')
             })
         })
     })

--- a/libs/external-db-bigquery/src/sql_schema_translator.ts
+++ b/libs/external-db-bigquery/src/sql_schema_translator.ts
@@ -31,10 +31,12 @@ export default class SchemaColumnTranslator {
                 
             case 'boolean':
             case 'bool':
+            case 'bit':
                 return 'boolean'
 
             default:
-                throw Error(`Unknown data type ${dbType}`)
+                console.log('Unknown type', type)
+                return 'text'
         }
     }
 

--- a/libs/external-db-mssql/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-mssql/src/sql_schema_translator.spec.ts
@@ -130,9 +130,13 @@ describe('Sql Schema Column Translator', () => {
 
         describe('other fields', () => {
             test('boolean', () => {
-                ['tinyint'].forEach(t => {
+                ['tinyint', 'bit'].forEach(t => {
                     expect( env.schemaTranslator.translateType(t) ).toEqual('boolean')
                 })
+            })
+
+            test('unknown type should return text', () => { 
+                expect( env.schemaTranslator.translateType('unknown') ).toEqual('text')
             })
         })
     })

--- a/libs/external-db-mssql/src/sql_schema_translator.ts
+++ b/libs/external-db-mssql/src/sql_schema_translator.ts
@@ -40,6 +40,7 @@ export default class SchemaColumnTranslator {
                 return 'boolean'
 
             default:
+                console.log('Unknown type', type)
                 return 'text'
         }
     }

--- a/libs/external-db-mssql/src/sql_schema_translator.ts
+++ b/libs/external-db-mssql/src/sql_schema_translator.ts
@@ -36,11 +36,11 @@ export default class SchemaColumnTranslator {
                 return 'text'
 
             case 'tinyint':
+            case 'bit':
                 return 'boolean'
 
             default:
-                console.log(type)
-                throw Error(type)
+                return 'text'
         }
     }
 

--- a/libs/external-db-mysql/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-mysql/src/sql_schema_translator.spec.ts
@@ -124,9 +124,13 @@ describe('Sql Schema Column Translator', () => {
 
         describe('other fields', () => {
             test('boolean', () => {
-                ['tinyint'].forEach(t => {
+                ['tinyint', 'bit'].forEach(t => {
                     expect( env.schemaTranslator.translateType(t) ).toEqual('boolean')
                 })
+            })
+            
+            test('unknown type should return text', () => { 
+                expect( env.schemaTranslator.translateType('unknown') ).toEqual('text')
             })
         })
     })

--- a/libs/external-db-mysql/src/sql_schema_translator.ts
+++ b/libs/external-db-mysql/src/sql_schema_translator.ts
@@ -41,14 +41,15 @@ export default class SchemaColumnTranslator implements IMySqlSchemaColumnTransla
                 return 'text'
 
             case 'tinyint':
+            case 'bit':
                 return 'boolean'
                 
             case 'json':
                 return 'object'
 
             default:
-                console.log(type)
-                throw Error(type)
+                console.log('Unknown type', type)
+                return 'text'
         }
     }
 

--- a/libs/external-db-postgres/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-postgres/src/sql_schema_translator.spec.ts
@@ -131,9 +131,13 @@ describe('Sql Schema Column Translator', () => {
 
         describe('other fields', () => {
             test('boolean', () => {
-                ['boolean'].forEach(t => {
+                ['boolean', 'bit'].forEach(t => {
                     expect( env.schemaTranslator.translateType(t) ).toEqual('boolean')
                 })
+            })
+
+            test('unknown type should return text', () => { 
+                expect( env.schemaTranslator.translateType('unknown') ).toEqual('text')
             })
         })
     })

--- a/libs/external-db-postgres/src/sql_schema_translator.ts
+++ b/libs/external-db-postgres/src/sql_schema_translator.ts
@@ -49,14 +49,15 @@ export default class SchemaColumnTranslator {
                 
             case 'bool':
             case 'boolean':
+            case 'bit':
                 return 'boolean'
 
             case 'json':
                 return 'object'    
 
             default:
-                console.log(type)
-                throw Error(type)
+                console.log('Unknown type', type)
+                return 'text'
         }
     }
 

--- a/libs/external-db-spanner/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-spanner/src/sql_schema_translator.spec.ts
@@ -127,9 +127,13 @@ describe('Sql Schema Column Translator', () => {
 
         describe('other fields', () => {
             test('boolean', () => {
-                ['BOOL'].forEach(t => {
+                ['BOOL', 'bit'].forEach(t => {
                     expect( env.schemaTranslator.translateType(t) ).toEqual({ type: 'boolean' })
                 })
+            })
+            
+            test('unknown type should return text', () => { 
+                expect( env.schemaTranslator.translateType('unknown') ).toEqual({ type: 'text' })
             })
         })
     })

--- a/libs/external-db-spanner/src/sql_schema_translator.ts
+++ b/libs/external-db-spanner/src/sql_schema_translator.ts
@@ -37,14 +37,15 @@ export default class SchemaColumnTranslator implements ISpannerSchemaColumnTrans
                 return { type: 'text', subtype: 'string' }
 
             case 'bool':
+            case 'bit':
                 return { type: 'boolean' }
 
             case 'json':
                 return { type: 'object' }
 
             default:
-                console.log(type)
-                throw Error(type)
+                console.log('Unknown type', type)
+                return { type: 'text' }
         }
     }
 


### PR DESCRIPTION
Fixes #350 
support bit column type.
If there's an unknown column type, return it as text.