### PR TITLE
Disable import of unsupported libraries

### DIFF
--- a/apps/velo-external-db/test/env/env.db.setup.js
+++ b/apps/velo-external-db/test/env/env.db.setup.js
@@ -3,16 +3,16 @@ import { registerTsProject } from 'nx/src/utils/register'
 registerTsProject('.', 'tsconfig.base.json')
 
 
-const { testResources: postgres } = require ('@wix-velo/external-db-postgres')
+// const { testResources: postgres } = require ('@wix-velo/external-db-postgres')
 const { testResources: mysql } = require ('@wix-velo/external-db-mysql')
-const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
-const { testResources: firestore } = require ('@wix-velo/external-db-firestore')
-const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
-const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
-const { testResources: googleSheet } = require('@wix-velo/external-db-google-sheets')
-const { testResources: airtable } = require('@wix-velo/external-db-airtable')
-const { testResources: dynamoDb } = require('@wix-velo/external-db-dynamodb')
-const { testResources: bigquery } = require('@wix-velo/external-db-bigquery')
+// const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
+// const { testResources: firestore } = require ('@wix-velo/external-db-firestore')
+// const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
+// const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
+// const { testResources: googleSheet } = require('@wix-velo/external-db-google-sheets')
+// const { testResources: airtable } = require('@wix-velo/external-db-airtable')
+// const { testResources: dynamoDb } = require('@wix-velo/external-db-dynamodb')
+// const { testResources: bigquery } = require('@wix-velo/external-db-bigquery')
 
 const { sleep } = require('@wix-velo/test-commons')
 const ci = require('./ci_utils')
@@ -23,40 +23,40 @@ const initEnv = async(testEngine) => {
             await mysql.initEnv()
             break
 
-        case 'spanner':
-            await spanner.initEnv()
-            break
+        // case 'spanner':
+        //     await spanner.initEnv()
+        //     break
 
-        case 'postgres':
-            await postgres.initEnv()
-            break
+        // case 'postgres':
+        //     await postgres.initEnv()
+        //     break
 
-        case 'firestore':
-            await firestore.initEnv()
-            break
+        // case 'firestore':
+        //     await firestore.initEnv()
+        //     break
 
-        case 'mssql':
-            await mssql.initEnv()
-            break
+        // case 'mssql':
+        //     await mssql.initEnv()
+        //     break
 
-        case 'mongo':
-            await mongo.initEnv()
-            break
-        case 'google-sheet':
-            await googleSheet.initEnv()
-            break
+        // case 'mongo':
+        //     await mongo.initEnv()
+        //     break
+        // case 'google-sheet':
+        //     await googleSheet.initEnv()
+        //     break
 
-        case 'airtable':
-            await airtable.initEnv()
-            break
+        // case 'airtable':
+        //     await airtable.initEnv()
+        //     break
         
-        case 'dynamodb':
-            await dynamoDb.initEnv()
-            break
+        // case 'dynamodb':
+        //     await dynamoDb.initEnv()
+        //     break
 
-        case 'bigquery':
-            await bigquery.initEnv()
-            break
+        // case 'bigquery':
+        //     await bigquery.initEnv()
+        //     break
     }
 }
 
@@ -66,37 +66,37 @@ const cleanup = async(testEngine) => {
             await mysql.cleanup()
             break
 
-        case 'spanner':
-            await spanner.cleanup()
-            break
+        // case 'spanner':
+        //     await spanner.cleanup()
+        //     break
 
-        case 'postgres':
-            await postgres.cleanup()
-            break
+        // case 'postgres':
+        //     await postgres.cleanup()
+        //     break
 
-        case 'firestore':
-            await firestore.cleanup()
-            break
+        // case 'firestore':
+        //     await firestore.cleanup()
+        //     break
 
-        case 'mssql':
-            await mssql.cleanup()
-            break
+        // case 'mssql':
+        //     await mssql.cleanup()
+        //     break
 
-        case 'google-sheet':
-            await googleSheet.cleanup()
-            break
+        // case 'google-sheet':
+        //     await googleSheet.cleanup()
+        //     break
 
-        case 'mongo':
-            await mongo.cleanup()
-            break
+        // case 'mongo':
+        //     await mongo.cleanup()
+        //     break
         
-        case 'dynamodb':
-            await dynamoDb.cleanup()
-            break
+        // case 'dynamodb':
+        //     await dynamoDb.cleanup()
+        //     break
 
-        case 'bigquery':
-            await bigquery.cleanup()
-            break
+        // case 'bigquery':
+        //     await bigquery.cleanup()
+        //     break
     }
 }
 

--- a/apps/velo-external-db/test/env/env.db.teardown.js
+++ b/apps/velo-external-db/test/env/env.db.teardown.js
@@ -1,13 +1,13 @@
-const { testResources: postgres } = require ('@wix-velo/external-db-postgres')
+// const { testResources: postgres } = require ('@wix-velo/external-db-postgres')
 const { testResources: mysql } = require ('@wix-velo/external-db-mysql')
-const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
-const { testResources: firestore } = require ('@wix-velo/external-db-firestore')
-const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
-const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
-const { testResources: googleSheet } = require('@wix-velo/external-db-google-sheets')
-const { testResources: airtable } = require('@wix-velo/external-db-airtable')
-const { testResources: dynamo } = require('@wix-velo/external-db-dynamodb')
-const { testResources: bigquery } = require('@wix-velo/external-db-bigquery')
+// const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
+// const { testResources: firestore } = require ('@wix-velo/external-db-firestore')
+// const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
+// const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
+// const { testResources: googleSheet } = require('@wix-velo/external-db-google-sheets')
+// const { testResources: airtable } = require('@wix-velo/external-db-airtable')
+// const { testResources: dynamo } = require('@wix-velo/external-db-dynamodb')
+// const { testResources: bigquery } = require('@wix-velo/external-db-bigquery')
 
 const ci = require('./ci_utils')
 
@@ -17,41 +17,41 @@ const shutdownEnv = async(testEngine) => {
             await mysql.shutdownEnv()
             break
 
-        case 'spanner':
-            await spanner.shutdownEnv()
-            break
+        // case 'spanner':
+        //     await spanner.shutdownEnv()
+        //     break
 
-        case 'postgres':
-            await postgres.shutdownEnv()
-            break
+        // case 'postgres':
+        //     await postgres.shutdownEnv()
+        //     break
 
-        case 'firestore':
-            await firestore.shutdownEnv()
-            break
+        // case 'firestore':
+        //     await firestore.shutdownEnv()
+        //     break
 
-        case 'mssql':
-            await mssql.shutdownEnv()
-            break
+        // case 'mssql':
+        //     await mssql.shutdownEnv()
+        //     break
 
-        case 'google-sheet':
-            await googleSheet.shutdownEnv()
-            break
+        // case 'google-sheet':
+        //     await googleSheet.shutdownEnv()
+        //     break
 
-        case 'airtable':
-            await airtable.shutdownEnv()
-            break
+        // case 'airtable':
+        //     await airtable.shutdownEnv()
+        //     break
         
-        case 'dynamodb':
-            await dynamo.shutdownEnv()
-            break
+        // case 'dynamodb':
+        //     await dynamo.shutdownEnv()
+        //     break
 
-        case 'mongo': 
-            await mongo.shutdownEnv()
-            break
+        // case 'mongo': 
+        //     await mongo.shutdownEnv()
+        //     break
         
-        case 'bigquery':
-            await bigquery.shutdownEnv()
-            break
+        // case 'bigquery':
+        //     await bigquery.shutdownEnv()
+        //     break
     }
 }
 


### PR DESCRIPTION
This PR disables the import of unsupported libraries in the tests, right now it's all the libraries except MySQL.
Now it's possible again to run one E2E tests by using the following command: 
`TEST_ENGINE=<engine-name>  nx test --test-file <test-name>   --verbose`
for example, If I want to run only the `app_schema.e2e.spec.ts` I will use the next command:  
`TEST_ENGINE=mysql  nx test --test-file app_schema.e2e.spec.ts   --verbose`
