### PR TITLE
Fix big query update bug

### DIFF
--- a/libs/external-db-bigquery/src/bigquery_data_provider.ts
+++ b/libs/external-db-bigquery/src/bigquery_data_provider.ts
@@ -46,6 +46,14 @@ export default class DataProvider implements IDataProvider {
     }
 
     async update(collectionName: string, items: Item[]) {   
+        // revert to this update when this bug is fixed - 
+        // https://community.retool.com/t/parameter-types-must-be-provided-for-null-values-via-the-types-field-in-query-options/13648/6
+        // const updateFields = updateFieldsFor(items[0])
+        // const queries = items.map(() => `UPDATE ${escapeIdentifier(collectionName)} SET ${updateFields.map(f => `${escapeIdentifier(f)} = ?`).join(', ')} WHERE _id = ?` )
+        //                      .join(';')
+        // const updateTables = items.map((i: Item) => [...updateFields, '_id'].reduce((obj, key) => ({ ...obj, [key]: i[key] }), {}))
+        //                         .map((u: any) => asParamArrays( patchDateTime(u) ))
+
         const queries = items.map((item) => `UPDATE ${escapeIdentifier(collectionName)} SET ${this.updateFieldsWithoutNulls(item).map(f => `${escapeIdentifier(f)} = ?`).join(', ')} WHERE _id = ?` )
                                 .join(';')
         const updateTables = items.map((item: Item) => [...this.updateFieldsWithoutNulls(item), '_id'].reduce((obj, key) => ({ ...obj, [key]: item[key] }), {}))

--- a/libs/external-db-bigquery/src/bigquery_data_provider.ts
+++ b/libs/external-db-bigquery/src/bigquery_data_provider.ts
@@ -50,12 +50,11 @@ export default class DataProvider implements IDataProvider {
                                 .join(';')
         const updateTables = items.map((item: Item) => [...this.updateFieldsWithoutNulls(item), '_id'].reduce((obj, key) => ({ ...obj, [key]: item[key] }), {}))
                                 .map((u: any) => asParamArrays( patchDateTime(u) ))
-        console.log({ updateTables: updateTables.flatMap(i => i), queries })
                                     
         const resultSet = await this.pool.query({ query: queries, params: updateTables.flatMap(i => i) })
                                     .catch( translateErrorCodes )
 
-        return resultSet[0].length   
+        return resultSet[0].length
     }
 
     async delete(collectionName: string, itemIds: string[]) {

--- a/libs/external-db-bigquery/src/bigquery_data_provider.ts
+++ b/libs/external-db-bigquery/src/bigquery_data_provider.ts
@@ -45,18 +45,17 @@ export default class DataProvider implements IDataProvider {
         return items.length
     }
 
-    async update(collectionName: string, items: Item[]) {        
-        const updateFields = updateFieldsFor(items[0])
-        const queries = items.map(() => `UPDATE ${escapeIdentifier(collectionName)} SET ${updateFields.map(f => `${escapeIdentifier(f)} = ?`).join(', ')} WHERE _id = ?` )
-                             .join(';')
-        const updateTables = items.map((i: Item) => [...updateFields, '_id'].reduce((obj, key) => ({ ...obj, [key]: i[key] }), {}))
+    async update(collectionName: string, items: Item[]) {   
+        const queries = items.map((item) => `UPDATE ${escapeIdentifier(collectionName)} SET ${this.updateFieldsWithoutNulls(item).map(f => `${escapeIdentifier(f)} = ?`).join(', ')} WHERE _id = ?` )
+                                .join(';')
+        const updateTables = items.map((item: Item) => [...this.updateFieldsWithoutNulls(item), '_id'].reduce((obj, key) => ({ ...obj, [key]: item[key] }), {}))
                                 .map((u: any) => asParamArrays( patchDateTime(u) ))
-                                
+        console.log({ updateTables: updateTables.flatMap(i => i), queries })
                                     
         const resultSet = await this.pool.query({ query: queries, params: updateTables.flatMap(i => i) })
                                     .catch( translateErrorCodes )
 
-        return resultSet[0].length
+        return resultSet[0].length   
     }
 
     async delete(collectionName: string, itemIds: string[]) {
@@ -83,6 +82,10 @@ export default class DataProvider implements IDataProvider {
                                     .catch( translateErrorCodes )
 
         return resultSet[0].map( unPatchDateTime )
+    }
+
+    updateFieldsWithoutNulls(item: Item) {
+        return updateFieldsFor(item).filter(f => item[f] !== null)
     }
 }
 


### PR DESCRIPTION
Duo to that [bug](https://community.retool.com/t/parameter-types-must-be-provided-for-null-values-via-the-types-field-in-query-options/13648/6), we cannot create queries that include null in the parameters.
That cause an error while trying to update items that part of their fields are null.

The solution is to build a query for each item so that only the not null columns would update.