### PR TITLE
remove secret key from spanner config validator

### DIFF
--- a/libs/external-db-spanner/src/spanner_config_validator.ts
+++ b/libs/external-db-spanner/src/spanner_config_validator.ts
@@ -5,7 +5,7 @@ export class ConfigValidator implements IConfigValidator {
     requiredKeys: string[]
     config: any
     constructor(config: any) {
-        this.requiredKeys = ['projectId', 'instanceId', 'databaseId', 'secretKey']
+        this.requiredKeys = ['projectId', 'instanceId', 'databaseId']
         this.config = config
     }
 


### PR DESCRIPTION
It has been removed from all implementations, forgotten in spanner.
`secretKey` appears to be missing, although it is not. 