### PR TITLE
Mongo to V3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,8 @@ jobs:
                    "postgres", "postgres13", "postgres12", "postgres11", "postgres10", "postgres9",
                    "mysql", "mysql5",
                    "mssql", "mssql17",
-                   spanner
+                   spanner,
+                   "mongo", "mongo4",
                    ]
 
     env:

--- a/apps/velo-external-db/src/storage/factory.ts
+++ b/apps/velo-external-db/src/storage/factory.ts
@@ -23,10 +23,10 @@ export const engineConnectorFor = async(_type: string, config: any): Promise<Dat
             const { mySqlFactory } = require('@wix-velo/external-db-mysql')
             return await mySqlFactory(config)
         }
-        // case 'mongo': {
-        //     const { mongoFactory } = require('@wix-velo/external-db-mongo')
-        //     return await mongoFactory(config)
-        // }
+        case 'mongo': {
+            const { mongoFactory } = require('@wix-velo/external-db-mongo')
+            return await mongoFactory(config)
+        }
         // case 'google-sheet': {
         //     const { googleSheetFactory } = require('@wix-velo/external-db-google-sheets')
         //     return await googleSheetFactory(config)

--- a/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
@@ -1,13 +1,7 @@
 import axios from 'axios'
 import each from 'jest-each'
 import * as Chance from 'chance'
-import { 
-    Uninitialized, 
-    gen as genCommon, 
-    testIfSupportedOperationsIncludes, 
-    streamToArray,
-    testIfSupportedOperationsNotIncludes 
-} from '@wix-velo/test-commons'
+import { Uninitialized, gen as genCommon, testIfSupportedOperationsIncludes, streamToArray } from '@wix-velo/test-commons'
 import { InputField, SchemaOperations, Item } from '@wix-velo/velo-external-db-types'
 import { dataSpi } from '@wix-velo/velo-external-db-core'
 import { authAdmin, authOwner, authVisitor } from '@wix-velo/external-db-testkit'
@@ -17,7 +11,7 @@ import * as matchers from '../drivers/schema_api_rest_matchers'
 import * as data from '../drivers/data_api_rest_test_support'
 import * as authorization from '../drivers/authorization_test_support'
 import { initApp, teardownApp, dbTeardown, setupDb, currentDbImplementationName, supportedOperations } from '../resources/e2e_resources'
-const { UpdateImmediately, DeleteImmediately, Truncate, Aggregate, FindWithSort, Projection, FilterByEveryField, QueryNestedFields, continueInsertingOnError } = SchemaOperations
+const { UpdateImmediately, DeleteImmediately, Truncate, Aggregate, FindWithSort, Projection, FilterByEveryField, QueryNestedFields, NonAtomicBulkInsert, AtomicBulkInsert } = SchemaOperations
 
 const chance = Chance()
 
@@ -86,7 +80,7 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
         )
     })
 
-    testIfSupportedOperationsNotIncludes(supportedOperations, [continueInsertingOnError])('insert api should fail if item already exists', async() => {
+    testIfSupportedOperationsIncludes(supportedOperations, [AtomicBulkInsert])('insert api should fail if item already exists', async() => {
         await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
         await data.givenItems([ ctx.items[1] ], ctx.collectionName, authAdmin)
 
@@ -104,7 +98,7 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
         )
     })
 
-    testIfSupportedOperationsIncludes(supportedOperations, [continueInsertingOnError])('insert api should throw 409 error if item already exists and continue inserting the rest', async() => {
+    testIfSupportedOperationsIncludes(supportedOperations, [NonAtomicBulkInsert])('insert api should throw 409 error if item already exists and continue inserting the rest', async() => {
         await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
         await data.givenItems([ ctx.items[1] ], ctx.collectionName, authAdmin)
 

--- a/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
@@ -1,8 +1,14 @@
 import axios from 'axios'
 import each from 'jest-each'
-import Chance = require('chance')
-import { Uninitialized, gen as genCommon, testIfSupportedOperationsIncludes, streamToArray } from '@wix-velo/test-commons'
-import { SchemaOperations } from '@wix-velo/velo-external-db-types'
+import * as Chance from 'chance'
+import { 
+    Uninitialized, 
+    gen as genCommon, 
+    testIfSupportedOperationsIncludes, 
+    streamToArray,
+    testIfSupportedOperationsNotIncludes 
+} from '@wix-velo/test-commons'
+import { InputField, SchemaOperations, Item } from '@wix-velo/velo-external-db-types'
 import { dataSpi } from '@wix-velo/velo-external-db-core'
 import { authAdmin, authOwner, authVisitor } from '@wix-velo/external-db-testkit'
 import * as gen from '../gen'
@@ -11,7 +17,7 @@ import * as matchers from '../drivers/schema_api_rest_matchers'
 import * as data from '../drivers/data_api_rest_test_support'
 import * as authorization from '../drivers/authorization_test_support'
 import { initApp, teardownApp, dbTeardown, setupDb, currentDbImplementationName, supportedOperations } from '../resources/e2e_resources'
-const { UpdateImmediately, DeleteImmediately, Truncate, Aggregate, FindWithSort, Projection, FilterByEveryField, QueryNestedFields } = SchemaOperations
+const { UpdateImmediately, DeleteImmediately, Truncate, Aggregate, FindWithSort, Projection, FilterByEveryField, QueryNestedFields, continueInsertingOnError } = SchemaOperations
 
 const chance = Chance()
 
@@ -80,7 +86,7 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
         )
     })
 
-    test('insert api should fail if item already exists', async() => {
+    testIfSupportedOperationsNotIncludes(supportedOperations, [continueInsertingOnError])('insert api should fail if item already exists', async() => {
         await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
         await data.givenItems([ ctx.items[1] ], ctx.collectionName, authAdmin)
 
@@ -90,6 +96,23 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
 
         await expect(response).rejects.toThrow('409')
 
+        await expect(data.queryCollectionAsArray(ctx.collectionName, [], undefined, authOwner)).resolves.toEqual(expect.toIncludeAllMembers(
+            [ 
+                ...expectedItems, 
+                data.pagingMetadata(expectedItems.length, expectedItems.length)
+            ])
+        )
+    })
+
+    testIfSupportedOperationsIncludes(supportedOperations, [continueInsertingOnError])('insert api should throw 409 error if item already exists and continue inserting the rest', async() => {
+        await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
+        await data.givenItems([ ctx.items[1] ], ctx.collectionName, authAdmin)
+
+        const response = axiosInstance.post('/data/insert', data.insertRequest(ctx.collectionName, ctx.items, false),  { responseType: 'stream', ...authAdmin })
+
+        const expectedItems = ctx.items.map(i => dataSpi.QueryResponsePart.item(i))
+                
+        await expect(response).rejects.toThrow('409')
         await expect(data.queryCollectionAsArray(ctx.collectionName, [], undefined, authOwner)).resolves.toEqual(expect.toIncludeAllMembers(
             [ 
                 ...expectedItems, 
@@ -347,8 +370,24 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
         })
     })
 
+    interface Ctx {
+        collectionName: string
+        column: InputField
+        numberColumns: InputField[]
+        objectColumn: InputField
+        item:  Item
+        items:  Item[]
+        modifiedItem: Item
+        modifiedItems: Item[]
+        anotherItem: Item
+        numberItem: Item
+        anotherNumberItem: Item
+        objectItem: Item
+        nestedFieldName: string
+        pastVeloDate: { $date: string; }
+    }
 
-    const ctx = {
+    const ctx: Ctx  = {
         collectionName: Uninitialized,
         column: Uninitialized,
         numberColumns: Uninitialized,

--- a/apps/velo-external-db/test/env/env.db.setup.js
+++ b/apps/velo-external-db/test/env/env.db.setup.js
@@ -8,7 +8,7 @@ const { testResources: mysql } = require ('@wix-velo/external-db-mysql')
 const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
 // const { testResources: firestore } = require ('@wix-velo/external-db-firestore')
 const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
-// const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
+const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
 // const { testResources: googleSheet } = require('@wix-velo/external-db-google-sheets')
 // const { testResources: airtable } = require('@wix-velo/external-db-airtable')
 // const { testResources: dynamoDb } = require('@wix-velo/external-db-dynamodb')
@@ -39,9 +39,9 @@ const initEnv = async(testEngine) => {
             await mssql.initEnv()
             break
 
-        // case 'mongo':
-        //     await mongo.initEnv()
-        //     break
+        case 'mongo':
+            await mongo.initEnv()
+            break
         // case 'google-sheet':
         //     await googleSheet.initEnv()
         //     break
@@ -86,9 +86,9 @@ const cleanup = async(testEngine) => {
         //     await googleSheet.cleanup()
         //     break
 
-        // case 'mongo':
-        //     await mongo.cleanup()
-        //     break
+        case 'mongo':
+            await mongo.cleanup()
+            break
         
         // case 'dynamodb':
         //     await dynamoDb.cleanup()

--- a/apps/velo-external-db/test/env/env.db.teardown.js
+++ b/apps/velo-external-db/test/env/env.db.teardown.js
@@ -3,7 +3,7 @@ const { testResources: mysql } = require ('@wix-velo/external-db-mysql')
 const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
 // const { testResources: firestore } = require ('@wix-velo/external-db-firestore')
 const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
-// const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
+const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
 // const { testResources: googleSheet } = require('@wix-velo/external-db-google-sheets')
 // const { testResources: airtable } = require('@wix-velo/external-db-airtable')
 // const { testResources: dynamo } = require('@wix-velo/external-db-dynamodb')
@@ -45,9 +45,9 @@ const shutdownEnv = async(testEngine) => {
         //     await dynamo.shutdownEnv()
         //     break
 
-        // case 'mongo': 
-        //     await mongo.shutdownEnv()
-        //     break
+        case 'mongo': 
+            await mongo.shutdownEnv()
+            break
         
         // case 'bigquery':
         //     await bigquery.shutdownEnv()

--- a/apps/velo-external-db/test/resources/e2e_resources.ts
+++ b/apps/velo-external-db/test/resources/e2e_resources.ts
@@ -33,7 +33,7 @@ const testSuits = {
     spanner: new E2EResources(spanner, createAppWithWixDataBaseUrl),
     firestore: new E2EResources(firestore, createApp),
     mssql: new E2EResources(mssql, createAppWithWixDataBaseUrl),
-    mongo: new E2EResources(mongo, createApp),
+    mongo: new E2EResources(mongo, createAppWithWixDataBaseUrl),
     'google-sheet': new E2EResources(googleSheet, createApp),
     airtable: new E2EResources(airtable, createApp),
     dynamodb: new E2EResources(dynamo, createApp),

--- a/apps/velo-external-db/test/resources/provider_resources.ts
+++ b/apps/velo-external-db/test/resources/provider_resources.ts
@@ -74,7 +74,7 @@ const testSuits = {
     spanner: suiteDef('Spanner', spannerTestEnvInit, spanner.testResources),
     firestore: suiteDef('Firestore', firestoreTestEnvInit, firestore.testResources.supportedOperations),
     mssql: suiteDef('Sql Server', mssqlTestEnvInit, mssql.testResources),
-    mongo: suiteDef('Mongo', mongoTestEnvInit, mongo.testResources.supportedOperations),
+    mongo: suiteDef('Mongo', mongoTestEnvInit, mongo.testResources),
     airtable: suiteDef('Airtable', airTableTestEnvInit, airtable.testResources.supportedOperations),
     dynamodb: suiteDef('DynamoDb', dynamoTestEnvInit, dynamo.testResources.supportedOperations),
     bigquery: suiteDef('BigQuery', bigqueryTestEnvInit, bigquery.testResources.supportedOperations),

--- a/libs/external-db-mongo/src/exception_translator.ts
+++ b/libs/external-db-mongo/src/exception_translator.ts
@@ -1,15 +1,17 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
 const { ItemAlreadyExists } = errors
 
-const notThrowingTranslateErrorCodes = (err: any) => {
+const extractItemIdFromError = (err: any) => err.message.split('"')[1]
+
+const notThrowingTranslateErrorCodes = (err: any, collectionName: string) => {
     switch (err.code) {
-        case 11000:
-            return new ItemAlreadyExists(`Item already exists: ${err.message}`)
+        case 11000:            
+            return new ItemAlreadyExists(`Item already exists: ${err.message}`, collectionName, extractItemIdFromError(err))
         default: 
             return new Error (`default ${err.message}`) 
     }
 }
 
-export const translateErrorCodes = (err: any) => {
-    throw notThrowingTranslateErrorCodes(err)
+export const translateErrorCodes = (err: any, collectionName: string) => {    
+    throw notThrowingTranslateErrorCodes(err, collectionName)
 }

--- a/libs/external-db-mongo/src/mongo_capabilities.ts
+++ b/libs/external-db-mongo/src/mongo_capabilities.ts
@@ -1,0 +1,19 @@
+import { AdapterOperators } from '@wix-velo/velo-external-db-commons'
+import { CollectionOperation, DataOperation, FieldType } from '@wix-velo/velo-external-db-types'
+
+const { query, count, queryReferenced, aggregate, } = DataOperation
+const { eq, ne, string_contains, string_begins, string_ends, gt, gte, lt, lte, include } = AdapterOperators
+
+export const ReadWriteOperations = Object.values(DataOperation)
+export const ReadOnlyOperations = [query, count, queryReferenced, aggregate]
+export const FieldTypes = Object.values(FieldType)
+export const CollectionOperations = Object.values(CollectionOperation)
+export const ColumnsCapabilities = {
+    text: { sortable: true, columnQueryOperators: [eq, ne, string_contains, string_begins, string_ends, include, gt, gte, lt, lte] },
+    url: { sortable: true, columnQueryOperators: [eq, ne, string_contains, string_begins, string_ends, include, gt, gte, lt, lte] },
+    number: { sortable: true, columnQueryOperators: [eq, ne, gt, gte, lt, lte, include] },
+    boolean: { sortable: true, columnQueryOperators: [eq] },
+    image: { sortable: false, columnQueryOperators: [] },
+    object: { sortable: false, columnQueryOperators: [] },
+    datetime: { sortable: true, columnQueryOperators: [eq, ne, gt, gte, lt, lte] },
+}

--- a/libs/external-db-mongo/src/mongo_data_provider.ts
+++ b/libs/external-db-mongo/src/mongo_data_provider.ts
@@ -34,7 +34,7 @@ export default class DataProvider implements IDataProvider {
                                 .count(filterExpr)
     }
 
-    async insert(collectionName: string, items: Item[] ): Promise<number> {
+    async insert(collectionName: string, items: Item[], _fields: any[], _upsert?: boolean): Promise<number> {
         validateTable(collectionName)
         const result = await this.client.db()
                                         .collection(collectionName)

--- a/libs/external-db-mongo/src/mongo_data_provider.ts
+++ b/libs/external-db-mongo/src/mongo_data_provider.ts
@@ -38,7 +38,7 @@ export default class DataProvider implements IDataProvider {
         validateTable(collectionName)
         const { insertedCount, upsertedCount } = await this.client.db()
                                                                   .collection(collectionName) 
-                                                                  .bulkWrite(insertExpressionFor(items, upsert))
+                                                                  .bulkWrite(insertExpressionFor(items, upsert), { ordered: false })
                                                                   .catch(e => translateErrorCodes(e, collectionName))
         
         return insertedCount + upsertedCount

--- a/libs/external-db-mongo/src/mongo_schema_provider.ts
+++ b/libs/external-db-mongo/src/mongo_schema_provider.ts
@@ -155,7 +155,7 @@ export default class SchemaProvider implements ISchemaProvider {
         }
     }
 
-    async collectionDataFor(collectionName: string) { //fixme: any
+    async collectionDataFor(collectionName: string) {
         validateTable(collectionName)
         return await this.client.db()
                                 .collection(SystemTable)

--- a/libs/external-db-mongo/src/mongo_schema_provider.ts
+++ b/libs/external-db-mongo/src/mongo_schema_provider.ts
@@ -134,7 +134,7 @@ export default class SchemaProvider implements ISchemaProvider {
         validateTable(collectionName)
         const collection = await this.collectionDataFor(collectionName)
         if (!collection) {
-            throw new CollectionDoesNotExists('Collection does not exists')
+            throw new CollectionDoesNotExists('Collection does not exists', collectionName)
         }
         return {
             id: collectionName,

--- a/libs/external-db-mongo/src/mongo_utils.spec.ts
+++ b/libs/external-db-mongo/src/mongo_utils.spec.ts
@@ -1,5 +1,5 @@
 const { InvalidQuery } = require('@wix-velo/velo-external-db-commons').errors
-import { unpackIdFieldForItem, validateTable } from './mongo_utils'
+import { unpackIdFieldForItem, validateTable, insertExpressionFor } from './mongo_utils'
 
 describe('Mongo Utils', () => {
     describe('unpackIdFieldForItem', () => {
@@ -46,6 +46,21 @@ describe('Mongo Utils', () => {
 
         test('validateTable will not throw with valid table name', () => {
             expect(() => validateTable('someTable')).not.toThrow()
+        })
+    })
+
+    describe('insertExpressionFor', () => {
+        test('insertExpressionFor with upsert set to false will return insert expression', () => {
+            expect(insertExpressionFor([{ _id: 'itemId' }], false)[0]).toEqual({ insertOne: { document: { _id: 'itemId' } } })
+        })
+        test('insertExpressionFor with upsert set to true will return update expression', () => {
+            expect(insertExpressionFor([{ _id: 'itemId' }], true)[0]).toEqual({
+                                                                                updateOne: { 
+                                                                                            filter: { _id: 'itemId' },
+                                                                                            update: { $set: { _id: 'itemId' } },
+                                                                                            upsert: true
+                                                                                        } 
+                                                                            })
         })
     })
 })

--- a/libs/external-db-mongo/src/mongo_utils.spec.ts
+++ b/libs/external-db-mongo/src/mongo_utils.spec.ts
@@ -1,5 +1,5 @@
 const { InvalidQuery } = require('@wix-velo/velo-external-db-commons').errors
-import { unpackIdFieldForItem, validateTable, insertExpressionFor } from './mongo_utils'
+import { unpackIdFieldForItem, validateTable, insertExpressionFor, isEmptyObject } from './mongo_utils'
 
 describe('Mongo Utils', () => {
     describe('unpackIdFieldForItem', () => {
@@ -62,5 +62,14 @@ describe('Mongo Utils', () => {
                                                                                         } 
                                                                             })
         })
+    })
+
+    describe('isEmptyObject', () => {
+        test('isEmptyObject will return true for empty object', () => {
+            expect(isEmptyObject({})).toBe(true)
+            expect(isEmptyObject({ a: {} }.a)).toBe(true)
+        }
+    )
+
     })
 })

--- a/libs/external-db-mongo/src/mongo_utils.ts
+++ b/libs/external-db-mongo/src/mongo_utils.ts
@@ -42,6 +42,7 @@ const updateExpressionForItem = (item: { _id: any }) => ({
     }
 })
 
+
 export const updateExpressionFor = (items: any[]) => items.map(updateExpressionForItem)
 
 export const unpackIdFieldForItem = (item: { [x: string]: any, _id?: any }) => {
@@ -55,4 +56,9 @@ export const unpackIdFieldForItem = (item: { [x: string]: any, _id?: any }) => {
 
 export const EmptySort = {
     sortExpr: { sort: [] },
+}
+
+export interface CollectionObject {
+    _id: string,
+    fields: { name: string, type: string, subtype?: string }[]
 }

--- a/libs/external-db-mongo/src/mongo_utils.ts
+++ b/libs/external-db-mongo/src/mongo_utils.ts
@@ -75,3 +75,5 @@ export interface CollectionObject {
     _id: string,
     fields: { name: string, type: string, subtype?: string }[]
 }
+
+export const isEmptyObject = (obj: any) => Object.keys(obj).length === 0 && obj.constructor === Object

--- a/libs/external-db-mongo/src/mongo_utils.ts
+++ b/libs/external-db-mongo/src/mongo_utils.ts
@@ -35,15 +35,28 @@ export const isConnected = (client: { topology: { isConnected: () => any } }) =>
     return client && client.topology && client.topology.isConnected()
 }
 
-const updateExpressionForItem = (item: { _id: any }) => ({
-    updateOne: {
-        filter: { _id: item._id },
-        update: { $set: { ...item } }
+const insertExpressionForItem = (item: { _id: any }) => ({
+    insertOne: {
+        document: { ...item, _id: item._id as any } 
     }
 })
 
+const updateExpressionForItem = (item: { _id: any }, upsert: boolean) => ({
+    updateOne: {
+        filter: { _id: item._id },
+        update: { $set: { ...item } },
+        upsert
+    }
+})
 
-export const updateExpressionFor = (items: any[]) => items.map(updateExpressionForItem)
+export const insertExpressionFor = (items: any[], upsert: boolean) => {
+    return upsert?
+        items.map(i => updateExpressionForItem(i, upsert)):
+        items.map(i => insertExpressionForItem(i))
+}
+
+
+export const updateExpressionFor = (items: any[], upsert = false) => items.map(i => updateExpressionForItem(i, upsert))
 
 export const unpackIdFieldForItem = (item: { [x: string]: any, _id?: any }) => {
     if (isObject(item._id)) {

--- a/libs/external-db-mongo/src/sql_filter_transformer.spec.ts
+++ b/libs/external-db-mongo/src/sql_filter_transformer.spec.ts
@@ -1,5 +1,5 @@
 import each from 'jest-each'
-import Chance = require('chance')
+import * as Chance from 'chance'
 import { AdapterOperators, errors } from '@wix-velo/velo-external-db-commons'
 import { AdapterFunctions } from '@wix-velo/velo-external-db-types'
 import { Uninitialized, gen } from '@wix-velo/test-commons'
@@ -416,6 +416,28 @@ describe('Sql Parser', () => {
                         havingFilter: { $match: {} },
                     })
                 })
+
+                test('orderAggregationBy', () => {
+                    expect(env.filterParser.orderAggregationBy([
+                        { fieldName: ctx.fieldName, direction: ctx.direction },
+                    ])).toEqual({
+                        $sort: { 
+                            [ctx.fieldName]: ctx.direction === 'asc' ? 1 : -1 
+                        }
+                    })
+
+                    expect(env.filterParser.orderAggregationBy([
+                        { fieldName: ctx.fieldName, direction: ctx.direction },
+                        { fieldName: ctx.anotherFieldName, direction: ctx.anotherDirection },
+                    ])).toEqual({
+                        $sort: { 
+                            [ctx.fieldName]: ctx.direction === 'asc' ? 1 : -1,
+                            [ctx.anotherFieldName]: ctx.anotherDirection === 'asc' ? 1 : -1 
+                        }
+                    })
+
+
+                })
             })
 
         })
@@ -423,16 +445,18 @@ describe('Sql Parser', () => {
     })
 
     interface Context {
-        fieldName: any
-        fieldValue: any
-        anotherValue: any
-        moreValue: any
-        fieldListValue: any
-        anotherFieldName: any
-        moreFieldName: any
-        filter: any
-        anotherFilter: any
-        offset: any
+        fieldName: string
+        fieldValue: string
+        anotherValue: string
+        moreValue: string
+        fieldListValue: string[]
+        anotherFieldName: string
+        moreFieldName: string
+        filter: { fieldName: string; operator: string; value: string | string[] }
+        anotherFilter: { fieldName: string; operator: string; value: string | string[]; }
+        offset: number
+        direction: 'asc' | 'desc'
+        anotherDirection: 'asc' | 'desc'
     }
 
     const ctx : Context = {
@@ -446,6 +470,8 @@ describe('Sql Parser', () => {
         filter: Uninitialized,
         anotherFilter: Uninitialized,
         offset: Uninitialized,
+        direction: Uninitialized,
+        anotherDirection: Uninitialized,
     }
 
     interface Enviorment {
@@ -470,6 +496,9 @@ describe('Sql Parser', () => {
         ctx.anotherFilter = gen.randomWrappedFilter()
 
         ctx.offset = chance.natural({ min: 2, max: 20 })
+
+        ctx.direction = chance.pickone(['asc', 'desc'])
+        ctx.anotherDirection = chance.pickone(['asc', 'desc'])
     })
 
     beforeAll(function() {

--- a/libs/external-db-mongo/src/sql_filter_transformer.ts
+++ b/libs/external-db-mongo/src/sql_filter_transformer.ts
@@ -141,6 +141,15 @@ export default class FilterParser {
         }
     }
 
+    orderAggregationBy(sort: Sort[]) {
+        return {
+            $sort: sort.reduce((acc, s) => {
+                const direction = s.direction === 'asc'? 1 : -1 
+                return { ...acc, [s.fieldName]: direction }
+            }, {})
+        }
+    }
+
     parseSort({ fieldName, direction }: Sort): { expr: MongoFieldSort } | [] {
         if (typeof fieldName !== 'string') {
             return []

--- a/libs/external-db-mongo/src/supported_operations.ts
+++ b/libs/external-db-mongo/src/supported_operations.ts
@@ -1,5 +1,1 @@
-import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
-import { SchemaOperations } from '@wix-velo/velo-external-db-types'
-const notSupportedOperations = [SchemaOperations.QueryNestedFields]
-
-export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))
+export { AllSchemaOperations as supportedOperations } from '@wix-velo/velo-external-db-commons'

--- a/libs/external-db-mongo/src/supported_operations.ts
+++ b/libs/external-db-mongo/src/supported_operations.ts
@@ -1,1 +1,5 @@
-export { AllSchemaOperations as supportedOperations } from '@wix-velo/velo-external-db-commons'
+import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
+import { SchemaOperations } from '@wix-velo/velo-external-db-types'
+const notSupportedOperations = [SchemaOperations.AtomicBulkInsert]
+
+export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.ts
+++ b/libs/external-db-mongo/tests/drivers/sql_filter_transformer_test_support.ts
@@ -7,6 +7,7 @@ export const filterParser = {
     parseFilter: jest.fn(),
     orderBy: jest.fn(),
     parseAggregation: jest.fn(),
+    orderAggregationBy: jest.fn(),
     selectFieldsFor: jest.fn()
 }
 
@@ -23,6 +24,8 @@ export const stubEmptyFilterFor = (filter: any) => {
 export const stubEmptyOrderByFor = (sort: any) => {
     when(filterParser.orderBy).calledWith(sort)
                               .mockReturnValue(EmptySort)
+    when(filterParser.orderAggregationBy).calledWith(sort)
+                              .mockReturnValue({ $sort: {} })
 }
 
 export const givenOrderByFor = (column: any, sort: any) => {
@@ -97,6 +100,7 @@ export const givenIncludeFilterForIdColumn = (filter: any, value: any) =>
 export const reset = () => {
     filterParser.transform.mockClear()
     filterParser.orderBy.mockClear()
+    filterParser.orderAggregationBy.mockClear()
     filterParser.parseAggregation.mockClear()
     filterParser.parseFilter.mockClear()
     filterParser.selectFieldsFor.mockClear()

--- a/libs/external-db-mongo/tests/e2e-testkit/mongo_resources.ts
+++ b/libs/external-db-mongo/tests/e2e-testkit/mongo_resources.ts
@@ -2,6 +2,8 @@ import * as compose from 'docker-compose'
 import init from '../../src/connection_provider'
 export { supportedOperations } from '../../src/supported_operations'
 
+export * as capabilities from '../../src/mongo_capabilities' 
+
 export const connection = async() => {
     const { connection, schemaProvider, cleanup } = await init({ connectionUri: 'mongodb://root:pass@localhost/testdb' })
 

--- a/libs/external-db-mssql/src/supported_operations.ts
+++ b/libs/external-db-mssql/src/supported_operations.ts
@@ -1,5 +1,5 @@
 import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
-const notSupportedOperations = [SchemaOperations.QueryNestedFields, SchemaOperations.FindObject, SchemaOperations.continueInsertingOnError]
+const notSupportedOperations = [SchemaOperations.QueryNestedFields, SchemaOperations.FindObject, SchemaOperations.NonAtomicBulkInsert]
 
 export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-mssql/src/supported_operations.ts
+++ b/libs/external-db-mssql/src/supported_operations.ts
@@ -1,5 +1,5 @@
 import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
-const notSupportedOperations = [SchemaOperations.QueryNestedFields, SchemaOperations.FindObject]
+const notSupportedOperations = [SchemaOperations.QueryNestedFields, SchemaOperations.FindObject, SchemaOperations.continueInsertingOnError]
 
 export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-mysql/src/supported_operations.ts
+++ b/libs/external-db-mysql/src/supported_operations.ts
@@ -1,5 +1,5 @@
 import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
-const notSupportedOperations = [SchemaOperations.continueInsertingOnError]
+const notSupportedOperations = [SchemaOperations.NonAtomicBulkInsert]
 
 export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-mysql/src/supported_operations.ts
+++ b/libs/external-db-mysql/src/supported_operations.ts
@@ -1,1 +1,5 @@
-export { AllSchemaOperations as supportedOperations } from '@wix-velo/velo-external-db-commons'
+import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
+import { SchemaOperations } from '@wix-velo/velo-external-db-types'
+const notSupportedOperations = [SchemaOperations.continueInsertingOnError]
+
+export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-postgres/src/supported_operations.ts
+++ b/libs/external-db-postgres/src/supported_operations.ts
@@ -1,5 +1,5 @@
 import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
-const notSupportedOperations = [SchemaOperations.continueInsertingOnError]
+const notSupportedOperations = [SchemaOperations.NonAtomicBulkInsert]
 
 export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-postgres/src/supported_operations.ts
+++ b/libs/external-db-postgres/src/supported_operations.ts
@@ -1,1 +1,5 @@
-export { AllSchemaOperations as supportedOperations } from '@wix-velo/velo-external-db-commons'
+import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
+import { SchemaOperations } from '@wix-velo/velo-external-db-types'
+const notSupportedOperations = [SchemaOperations.continueInsertingOnError]
+
+export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-spanner/src/supported_operations.ts
+++ b/libs/external-db-spanner/src/supported_operations.ts
@@ -1,6 +1,6 @@
 import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
 //change column types - https://cloud.google.com/spanner/docs/schema-updates#supported_schema_updates
-const notSupportedOperations = [SchemaOperations.ChangeColumnType]
+const notSupportedOperations = [SchemaOperations.ChangeColumnType, SchemaOperations.NonAtomicBulkInsert]
 
 export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/test-commons/src/libs/gen.ts
+++ b/libs/test-commons/src/libs/gen.ts
@@ -1,5 +1,6 @@
 import * as Chance from 'chance'
 import { AdapterOperators } from '@wix-velo/velo-external-db-commons'
+import { Item } from '@wix-velo/velo-external-db-types'
 const { eq, gt, gte, include, lt, lte, ne, string_begins, string_ends, string_contains } = AdapterOperators 
 
 const chance = Chance()
@@ -48,8 +49,8 @@ export const randomCollections = () => randomArrayOf( randomCollectionName )
 
 export const randomFieldName = () => chance.word({ length: 5 })
 
-export const randomEntity = (columns?: any[]) => {
-    const entity : {[x:string]: any} = {
+export const randomEntity = (columns?: string[]) => {
+    const entity : Item = {
         _id: chance.guid(),
         _createdDate: veloDate(),
         _updatedDate: veloDate(),
@@ -65,7 +66,7 @@ export const randomEntity = (columns?: any[]) => {
 }
 
 export const randomNumberEntity = (columns: any[]) => {
-    const entity : {[x:string]: any} = {
+    const entity : Item = {
         _id: chance.guid(),
         _createdDate: veloDate(),
         _updatedDate: veloDate(),

--- a/libs/test-commons/src/libs/test-commons.ts
+++ b/libs/test-commons/src/libs/test-commons.ts
@@ -13,10 +13,6 @@ export const shouldRunOnlyOn = (impl: string[], current: string) => impl.include
 //@ts-ignore
 export const testIfSupportedOperationsIncludes = (supportedOperations: SchemaOperations[], operation: string[]): any => operation.every((o: any) => supportedOperations.includes(o)) ? test : test.skip
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-//@ts-ignore
-export const testIfSupportedOperationsNotIncludes = (supportedOperations: SchemaOperations[], operation: string[]): any => operation.every((o: any) => !supportedOperations.includes(o)) ? test : test.skip 
-
 export const testSupportedOperations = (supportedOperations: SchemaOperations[], arrayTable: any[][]): string[][] => {
     return arrayTable.filter(i => {
         const lastItem = i[i.length - 1]

--- a/libs/test-commons/src/libs/test-commons.ts
+++ b/libs/test-commons/src/libs/test-commons.ts
@@ -13,6 +13,10 @@ export const shouldRunOnlyOn = (impl: string[], current: string) => impl.include
 //@ts-ignore
 export const testIfSupportedOperationsIncludes = (supportedOperations: SchemaOperations[], operation: string[]): any => operation.every((o: any) => supportedOperations.includes(o)) ? test : test.skip
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+//@ts-ignore
+export const testIfSupportedOperationsNotIncludes = (supportedOperations: SchemaOperations[], operation: string[]): any => operation.every((o: any) => !supportedOperations.includes(o)) ? test : test.skip 
+
 export const testSupportedOperations = (supportedOperations: SchemaOperations[], arrayTable: any[][]): string[][] => {
     return arrayTable.filter(i => {
         const lastItem = i[i.length - 1]

--- a/libs/velo-external-db-types/src/collection_types.ts
+++ b/libs/velo-external-db-types/src/collection_types.ts
@@ -85,6 +85,7 @@ export enum SchemaOperations {
     IncludeOperator = 'include',
     FilterByEveryField = 'filterByEveryField',
     QueryNestedFields = 'queryNestedFields',
+    continueInsertingOnError = 'continueInsertingOnError',
 }
 
 export type InputField = FieldAttributes & { name: string }

--- a/libs/velo-external-db-types/src/collection_types.ts
+++ b/libs/velo-external-db-types/src/collection_types.ts
@@ -85,7 +85,8 @@ export enum SchemaOperations {
     IncludeOperator = 'include',
     FilterByEveryField = 'filterByEveryField',
     QueryNestedFields = 'queryNestedFields',
-    continueInsertingOnError = 'continueInsertingOnError',
+    NonAtomicBulkInsert = 'NonAtomicBulkInsert',
+    AtomicBulkInsert = 'AtomicBulkInsert'
 }
 
 export type InputField = FieldAttributes & { name: string }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:full-image": "nx run velo-external-db:build-image ",
     "lint": "eslint --cache ./",
     "lint:fix": "eslint --cache --fix ./",
-    "test": "npm run test:core; npm run test:mysql; npm run test:postgres; npm run test:mssql; npm run test:spanner",
+    "test": "npm run test:core; npm run test:mysql; npm run test:postgres; npm run test:mssql; npm run test:spanner; npm run test:mongo;",
     "test:core": "nx run-many --skip-nx-cache --target=test --projects=@wix-velo/external-db-config,@wix-velo/velo-external-db-core,@wix-velo/external-db-security",
     "test:postgres": "TEST_ENGINE=postgres nx run-many --skip-nx-cache --target=test --projects=@wix-velo/external-db-postgres,velo-external-db",
     "test:postgres13": "npm run test:postgres",

--- a/workspace.json
+++ b/workspace.json
@@ -9,6 +9,7 @@
     "@wix-velo/external-db-security": "libs/external-db-security",
     "@wix-velo/test-commons": "libs/test-commons",
     "@wix-velo/velo-external-db-commons": "libs/velo-external-db-commons",
+    "@wix-velo/external-db-mongo": "libs/external-db-mongo",
     "@wix-velo/velo-external-db-core": "libs/velo-external-db-core",
     "@wix-velo/velo-external-db-types": "libs/velo-external-db-types",
     "@wix-velo/external-db-testkit": "libs/external-db-testkit",


### PR DESCRIPTION
### Apps: 
- [x] remove comment from [factory](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/src/storage/factory.ts) 
- [x] remove comment from [e2e.db.setup](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/env/env.db.setup.js)
- [x] remove comment from [e2e.db.teardown](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/env/env.db.teardown.js)
- [x] in [e2e_resources](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/resources/e2e_resources.ts) replace `createApp` with `createAppWithWixDataBaseUrl`

### Current implementation changes: 
  
  Schema:

  - [x] create [capabilities file](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_capabilities.ts)
  - [x] change [schemas list](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L28-L33) format.
  - [x] change [describe collection](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L79-L93) format.
  - [x] implement [change column type](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L67-L71) method.
  - [x] change [default precision](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_schema_translator.ts#L128) to be (15,2) - if relevant.
  
Data: 

- [x] support [upsert](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_data_provider.ts#L41-L50).
- [x] add sort, skip, limit in [aggregate](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_data_provider.ts#L77-L87) function.
- [x] support querying by nested fields (+sql_filter_transformer tests).

Error handling: 

- [x] return `collectionName` with each error code ([sql_exception_translator](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts)).
- [x] on field [doesn't exist](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L21), return the field name.
- [x] on field [already exist](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L23), return the field name.
- [x] on item [already exists](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L35), return the duplicated _id

e2e: 
- [x] export capabilities from [implementation_resources](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/tests/e2e-testkit/mysql_resources.ts#L6)

general: 

- [x] in [workspace](https://github.com/wix/velo-external-db/blob/managed-adapter/workspace.json#L5), add the lib
- [x] in [package.json - test script](https://github.com/wix/velo-external-db/blob/managed-adapter/package.json#L10), test the current implementation too.
- [x] in [main.yml](https://github.com/wix/velo-external-db/blob/managed-adapter/.github/workflows/main.yml#L40-L42), add the current implementation.