### PR TITLE
Hide App Info option with environment variable

### DIFF
--- a/apps/velo-external-db/src/app.ts
+++ b/apps/velo-external-db/src/app.ts
@@ -21,10 +21,10 @@ const initConnector = async(hooks?: Hooks) => {
             secretKey,
             vendor,
             adapterType,
-            commonExtended: true
+            commonExtended: true,
+            hideAppInfo
         },
         hooks,
-        hideAppInfo
     })
 
     return { externalDbRouter, cleanup: async() => await cleanup(), schemaProvider: providers.schemaProvider }

--- a/apps/velo-external-db/src/app.ts
+++ b/apps/velo-external-db/src/app.ts
@@ -5,7 +5,8 @@ import { engineConnectorFor } from './storage/factory'
 
 
 const initConnector = async(hooks?: Hooks) => {
-    const { vendor, type: adapterType } = readCommonConfig()
+    const { vendor, type: adapterType, hideAppInfo } = readCommonConfig()
+
     const configReader = create()
     const { authorization, secretKey, ...dbConfig } = await configReader.readConfig()
 
@@ -22,7 +23,8 @@ const initConnector = async(hooks?: Hooks) => {
             adapterType,
             commonExtended: true
         },
-        hooks
+        hooks,
+        hideAppInfo
     })
 
     return { externalDbRouter, cleanup: async() => await cleanup(), schemaProvider: providers.schemaProvider }

--- a/apps/velo-external-db/test/drivers/app_info_config_test_support.ts
+++ b/apps/velo-external-db/test/drivers/app_info_config_test_support.ts
@@ -1,0 +1,7 @@
+import { initApp, dbTeardown } from '../resources/e2e_resources'
+
+export const givenHideAppInfoEnvIsTrue = async() => {    
+    await dbTeardown()
+    process.env.HIDE_APP_INFO = 'true'
+    await initApp()
+}

--- a/apps/velo-external-db/test/drivers/app_info_config_test_support.ts
+++ b/apps/velo-external-db/test/drivers/app_info_config_test_support.ts
@@ -1,7 +1,6 @@
-import { initApp, dbTeardown } from '../resources/e2e_resources'
+import { initApp } from '../resources/e2e_resources'
 
 export const givenHideAppInfoEnvIsTrue = async() => {    
-    await dbTeardown()
     process.env.HIDE_APP_INFO = 'true'
     await initApp()
 }

--- a/apps/velo-external-db/test/e2e/app.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app.e2e.spec.ts
@@ -23,16 +23,14 @@ describe(`Velo External DB: ${currentDbImplementationName()}`,  () => {
         expect((await axios.post('/provision', { }, authOwner)).data).toEqual(expect.objectContaining({ protocolVersion: 2, vendor: 'azure' }))
     })
 
-    if (currentDbImplementationName() !== 'google-sheet') {
-        test('answer app info with stub response', async() => {
-            givenHideAppInfoEnvIsTrue()
-            const { data: appInfo } = await axios.get('/')
+    test('answer app info with stub response', async() => {
+        await givenHideAppInfoEnvIsTrue()
+        const { data: appInfo } = await axios.get('/')
 
-            Object.values(env.enviormentVariables).forEach(value => {
-                expect(appInfo).not.toContain(value)
-            })
+        Object.values(env.enviormentVariables).forEach(value => {
+            expect(appInfo).not.toContain(value)
         })
-    }
+    })
 
     afterAll(async() => await teardownApp())
 

--- a/apps/velo-external-db/test/e2e/app.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { authOwner } from '@wix-velo/external-db-testkit'
-import { initApp, teardownApp, dbTeardown, setupDb, currentDbImplementationName } from '../resources/e2e_resources'
+import { initApp, teardownApp, dbTeardown, setupDb, currentDbImplementationName, env } from '../resources/e2e_resources'
+import { givenHideAppInfoEnvIsTrue } from '../drivers/app_info_config_test_support'
 
 const axios = require('axios').create({
     baseURL: 'http://localhost:8080'
@@ -22,6 +23,14 @@ describe(`Velo External DB: ${currentDbImplementationName()}`,  () => {
         expect((await axios.post('/provision', { }, authOwner)).data).toEqual(expect.objectContaining({ protocolVersion: 2, vendor: 'azure' }))
     })
 
+    test('answer app info with stub response', async() => {
+        givenHideAppInfoEnvIsTrue()
+        const { data: appInfo } = await axios.get('/')
+
+        Object.values(env.enviormentVariables).forEach(value => {
+            expect(appInfo).not.toContain(value)
+        })
+    })
 
     afterAll(async() => await teardownApp())
 

--- a/apps/velo-external-db/test/e2e/app.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app.e2e.spec.ts
@@ -23,14 +23,16 @@ describe(`Velo External DB: ${currentDbImplementationName()}`,  () => {
         expect((await axios.post('/provision', { }, authOwner)).data).toEqual(expect.objectContaining({ protocolVersion: 2, vendor: 'azure' }))
     })
 
-    test('answer app info with stub response', async() => {
-        givenHideAppInfoEnvIsTrue()
-        const { data: appInfo } = await axios.get('/')
+    if (currentDbImplementationName() !== 'google-sheet') {
+        test('answer app info with stub response', async() => {
+            givenHideAppInfoEnvIsTrue()
+            const { data: appInfo } = await axios.get('/')
 
-        Object.values(env.enviormentVariables).forEach(value => {
-            expect(appInfo).not.toContain(value)
+            Object.values(env.enviormentVariables).forEach(value => {
+                expect(appInfo).not.toContain(value)
+            })
         })
-    })
+    }
 
     afterAll(async() => await teardownApp())
 

--- a/apps/velo-external-db/test/resources/e2e_resources.ts
+++ b/apps/velo-external-db/test/resources/e2e_resources.ts
@@ -33,11 +33,13 @@ type Internals = () => App
 export let env:{
     app: App,
     externalDbRouter: ExternalDbRouter,
-    internals: Internals
+    internals: Internals,
+    enviormentVariables: Record<string, string>
 } = {
     app: Uninitialized,
     internals: Uninitialized,
-    externalDbRouter: Uninitialized
+    externalDbRouter: Uninitialized,
+    enviormentVariables: Uninitialized
 }
 
 const testSuits = {
@@ -54,12 +56,13 @@ const testSuits = {
 }
 
 export const testedSuit = () => testSuits[process.env.TEST_ENGINE]
-export const supportedOperations = testedSuit().supportedOperations
+export const supportedOperations = testedSuit().implementation.capabilities
 
 export const setupDb = () => testedSuit().setUpDb()
-export const currentDbImplementationName = () => testedSuit().name
+export const currentDbImplementationName = () => testedSuit().currentDbImplementationName
 export const initApp = async() => {
     env = await testedSuit().initApp()
+    env.enviormentVariables = testedSuit().implementation.enviormentVariables
 }
 export const teardownApp = async() => testedSuit().teardownApp()
 export const dbTeardown = async() => testedSuit().dbTeardown()

--- a/apps/velo-external-db/test/resources/e2e_resources.ts
+++ b/apps/velo-external-db/test/resources/e2e_resources.ts
@@ -56,7 +56,7 @@ const testSuits = {
 }
 
 export const testedSuit = () => testSuits[process.env.TEST_ENGINE]
-export const supportedOperations = testedSuit().implementation.capabilities
+export const supportedOperations = testedSuit().supportedOperations
 
 export const setupDb = () => testedSuit().setUpDb()
 export const currentDbImplementationName = () => testedSuit().currentDbImplementationName

--- a/libs/external-db-airtable/tests/e2e-testkit/airtable_resources.ts
+++ b/libs/external-db-airtable/tests/e2e-testkit/airtable_resources.ts
@@ -30,11 +30,15 @@ export const shutdownEnv = async() => {
 }
 
 export const setActive = () => {
-    process.env['AIRTABLE_API_KEY'] = 'key123'
-    process.env['META_API_KEY'] = 'meta123'
-    process.env['TYPE'] = 'airtable'
-    process.env['BASE_ID'] = 'app123'
-    process.env['BASE_URL'] = 'http://localhost:9000'
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'airtable',
+    AIRTABLE_API_KEY: 'key123',
+    META_API_KEY: 'meta123',
+    BASE_ID: 'app123',
+    BASE_URL: `http://localhost:${PORT}`
 }
 
 export const schemaProviderTestVariables = () => (

--- a/libs/external-db-bigquery/tests/e2e-testkit/bigquery_resources.ts
+++ b/libs/external-db-bigquery/tests/e2e-testkit/bigquery_resources.ts
@@ -19,9 +19,13 @@ export const cleanup = async() => {
 export const initEnv = async() => {}
 
 export const setActive = () => {
-    process.env['TYPE'] = 'bigquery'
-    process.env['PROJECT_ID'] = projectId
-    process.env['DATABASE_ID'] = databaseId
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'bigquery',
+    PROJECT_ID: projectId,
+    DATABASE_ID: databaseId
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/libs/external-db-config/package.json
+++ b/libs/external-db-config/package.json
@@ -1,5 +1,5 @@
 {
 	"name": "@wix-velo/external-db-config",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"type": "commonjs"
 }

--- a/libs/external-db-config/src/readers/common_config_reader.ts
+++ b/libs/external-db-config/src/readers/common_config_reader.ts
@@ -4,7 +4,7 @@ export default class CommonConfigReader implements IConfigReader {
     constructor() { }
 
     readConfig() {
-        const { CLOUD_VENDOR, TYPE, REGION, SECRET_NAME } = process.env
-        return { vendor: CLOUD_VENDOR, type: TYPE, region: REGION, secretId: SECRET_NAME }
+        const { CLOUD_VENDOR, TYPE, REGION, SECRET_NAME, HIDE_APP_INFO } = process.env
+        return { vendor: CLOUD_VENDOR, type: TYPE, region: REGION, secretId: SECRET_NAME, hideAppInfo: HIDE_APP_INFO ? HIDE_APP_INFO === 'true' : undefined }
     }
 }

--- a/libs/external-db-config/test/drivers/common_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/common_config_test_support.ts
@@ -10,14 +10,18 @@ export const defineValidConfig = (config: CommonConfig) => {
     if (config.type) {
         process.env['TYPE'] = config.type
     }
+    if (config.hideAppInfo !== undefined) {
+        process.env['HIDE_APP_INFO'] = config.hideAppInfo.toString()
+    }    
 }
 
 export const validConfig = (): CommonConfig => ({
     vendor: chance.word(),
-    type: chance.word()
+    type: chance.word(),
+    hideAppInfo: chance.bool(),
 })
 
-export const ExpectedProperties = ['CLOUD_VENDOR', 'TYPE']
+export const ExpectedProperties = ['CLOUD_VENDOR', 'TYPE', 'HIDE_APP_INFO']
 
 export const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 export const hasReadErrors = false

--- a/libs/external-db-config/test/test_types.ts
+++ b/libs/external-db-config/test/test_types.ts
@@ -35,6 +35,7 @@ export interface CommonConfig {
     type?: string
     vendor?: string
     secretKey?: string
+    hideAppInfo?: boolean
 }
 
 export interface FiresStoreConfig {

--- a/libs/external-db-dynamodb/tests/e2e-testkit/dynamodb_resources.ts
+++ b/libs/external-db-dynamodb/tests/e2e-testkit/dynamodb_resources.ts
@@ -24,11 +24,15 @@ export const shutdownEnv = async() => {
 }
 
 export const setActive = () => {
-    process.env['TYPE'] = 'dynamodb'
-    process.env['REGION'] = 'us-west-2'
-    process.env['AWS_SECRET_ACCESS_KEY'] = 'TEST_SECRET_ACCESS_KEY'
-    process.env['AWS_ACCESS_KEY_ID'] = 'TEST_ACCESS_KEY_ID'
-    process.env['ENDPOINT_URL'] = 'http://localhost:8000'
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'dynamodb',
+    REGION: 'us-west-2',
+    AWS_SECRET_ACCESS_KEY: 'TEST_SECRET_ACCESS_KEY',
+    AWS_ACCESS_KEY_ID: 'TEST_ACCESS_KEY_ID',
+    ENDPOINT_URL: 'http://localhost:8000'
 }
 
 const connectionConfig = () => ({ endpoint: 'http://localhost:8000',

--- a/libs/external-db-firestore/tests/e2e-testkit/firestore_resources.ts
+++ b/libs/external-db-firestore/tests/e2e-testkit/firestore_resources.ts
@@ -32,8 +32,12 @@ export const initEnv = async() => {
 
 export const setActive = () => {
     setEmulatorOn()
-    process.env['TYPE'] = 'firestore'
-    process.env['PROJECT_ID'] = 'test-project'
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'firestore',
+    PROJECT_ID: 'test-project'
 }
 
 export const shutdownEnv = async() => {

--- a/libs/external-db-google-sheets/tests/e2e-testkit/google_sheets_resources.ts
+++ b/libs/external-db-google-sheets/tests/e2e-testkit/google_sheets_resources.ts
@@ -32,8 +32,12 @@ export const shutdownEnv = async() => {
 }
 
 export const setActive = () => {
-    process.env['TYPE'] = 'google-sheet'
-    process.env['SHEET_ID'] = SHEET_ID
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'google-sheet',
+    SHEET_ID: SHEET_ID
 }
 
 export const name = 'google-sheets'

--- a/libs/external-db-mongo/tests/e2e-testkit/mongo_resources.ts
+++ b/libs/external-db-mongo/tests/e2e-testkit/mongo_resources.ts
@@ -26,8 +26,12 @@ export const shutdownEnv = async() => {
 }
 
 export const setActive = () => {
-    process.env['TYPE'] = 'mongo'
-    process.env['URI'] = 'mongodb://root:pass@localhost/testdb'
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'mongo',
+    URI: 'mongodb://root:pass@localhost/testdb'
 }
 
 export const name = 'mongo'

--- a/libs/external-db-mssql/tests/e2e-testkit/mssql_resources.ts
+++ b/libs/external-db-mssql/tests/e2e-testkit/mssql_resources.ts
@@ -42,12 +42,16 @@ export const shutdownEnv = async() => {
 }
 
 export const setActive = () => {
-    process.env['TYPE'] = 'mssql'
-    process.env['HOST'] = 'localhost'
-    process.env['USER'] = 'sa'
-    process.env['PASSWORD'] = 't9D4:EHfU6Xgccs-'
-    process.env['DB'] = 'tempdb'
-    process.env['UNSECURED_ENV'] = 'true'
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'mssql',
+    HOST: 'localhost',
+    USER: 'sa',
+    PASSWORD: 't9D4:EHfU6Xgccs-',
+    DB: 'tempdb',
+    UNSECURED_ENV: 'true'
 }
 
 export const name = 'mssql'

--- a/libs/external-db-mssql/tests/e2e-testkit/mssql_resources.ts
+++ b/libs/external-db-mssql/tests/e2e-testkit/mssql_resources.ts
@@ -42,7 +42,7 @@ export const shutdownEnv = async() => {
 }
 
 export const setActive = () => {
-    process.env = { ...process.env, ...enviormentVariables }
+    process.env = { ...process.env, ...enviormentVariables, UNSECURED_ENV: 'true' }
 }
 
 export const enviormentVariables = {
@@ -51,7 +51,6 @@ export const enviormentVariables = {
     USER: 'sa',
     PASSWORD: 't9D4:EHfU6Xgccs-',
     DB: 'tempdb',
-    UNSECURED_ENV: 'true'
 }
 
 export const name = 'mssql'

--- a/libs/external-db-mysql/tests/e2e-testkit/mysql_resources.ts
+++ b/libs/external-db-mysql/tests/e2e-testkit/mysql_resources.ts
@@ -27,11 +27,15 @@ export const shutdownEnv = async() => {
 }
 
 export const setActive = () => {
-    process.env['TYPE'] = 'mysql'
-    process.env['HOST'] = 'localhost'
-    process.env['USER'] = 'test-user'
-    process.env['PASSWORD'] = 'password'
-    process.env['DB'] = 'test-db'
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'mysql',
+    HOST: 'localhost',
+    USER: 'test-user',
+    PASSWORD: 'password',
+    DB: 'test-db'
 }
 
 export const name = 'mysql'

--- a/libs/external-db-postgres/tests/e2e-testkit/postgres_resources.ts
+++ b/libs/external-db-postgres/tests/e2e-testkit/postgres_resources.ts
@@ -20,12 +20,17 @@ export const initEnv = async() => {
 }
 
 export const setActive = () => {
-    process.env['TYPE'] = 'postgres'
-    process.env['HOST'] = 'localhost'
-    process.env['USER'] = 'test-user'
-    process.env['PASSWORD'] = 'password'
-    process.env['DB'] = 'test-db'
+    process.env = { ...process.env, ...enviormentVariables }
 }
+
+export const enviormentVariables = {
+    TYPE: 'postgres',
+    HOST: 'localhost',
+    USER: 'test-user',
+    PASSWORD: 'password',
+    DB: 'test-db'
+}
+
 
 export const shutdownEnv = async() => {
     await compose.stopOne('postgres', { cwd: __dirname, log: true })

--- a/libs/external-db-spanner/tests/e2e-testkit/spanner_resources.ts
+++ b/libs/external-db-spanner/tests/e2e-testkit/spanner_resources.ts
@@ -28,10 +28,14 @@ export const initEnv = async() => {
 
 export const setActive = () => {
     setEmulatorOn()
-    process.env['TYPE'] = 'spanner'
-    process.env['PROJECT_ID'] = 'test-project'
-    process.env['INSTANCE_ID'] = 'test-instance'
-    process.env['DATABASE_ID'] = 'test-database'
+    process.env = { ...process.env, ...enviormentVariables }
+}
+
+export const enviormentVariables = {
+    TYPE: 'spanner',
+    PROJECT_ID: 'test-project',
+    INSTANCE_ID: 'test-instance',
+    DATABASE_ID: 'test-database'
 }
 
 export const shutdownEnv = async() => {

--- a/libs/velo-external-db-core/package.json
+++ b/libs/velo-external-db-core/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@wix-velo/velo-external-db-core",
-  "version": "1.2.2",
+  "version": "1.2.3",
 	"type": "commonjs"
 }

--- a/libs/velo-external-db-core/src/health/app_info.spec.ts
+++ b/libs/velo-external-db-core/src/health/app_info.spec.ts
@@ -4,7 +4,6 @@ import * as driver from '../../test/drivers/app_info_test_support' //TODO: chang
 
 describe('App info Function', () => {
     test('get app info will retrieve valid config and will create app info object', async() => {
-        process.env['DEBUG'] = 'true'
         driver.defineValidConfigReaderClient(ctx.config)
         driver.defineValidOperationService()
         const appInfo = await appInfoFor(driver.operationService, driver.configReaderClient)
@@ -13,7 +12,18 @@ describe('App info Function', () => {
             configReaderStatus: driver.validConfigReaderStatus,
             config: maskSensitiveData(ctx.config),
             dbConnectionStatus: driver.validDBConnectionStatus,
-            debug: true
+        })
+    })
+
+    test('get app info will retrieve empty config when hideAppInfo is true', async() => {
+        driver.defineValidConfigReaderClient(ctx.config)
+        driver.defineValidOperationService()
+        const appInfo = await appInfoFor(driver.operationService, driver.configReaderClient, true)
+        
+        expect(appInfo).toEqual({
+            configReaderStatus: driver.validConfigReaderStatus,
+            config: {},
+            dbConnectionStatus: driver.validDBConnectionStatus,
         })
     })
 
@@ -42,7 +52,6 @@ describe('App info Function', () => {
     beforeEach(() => {
         driver.reset()
         ctx.config = genCommon.randomObject()
-        delete process.env['DEBUG']
     })
 
 

--- a/libs/velo-external-db-core/src/health/app_info.spec.ts
+++ b/libs/velo-external-db-core/src/health/app_info.spec.ts
@@ -4,15 +4,16 @@ import * as driver from '../../test/drivers/app_info_test_support' //TODO: chang
 
 describe('App info Function', () => {
     test('get app info will retrieve valid config and will create app info object', async() => {
+        process.env['DEBUG'] = 'true'
         driver.defineValidConfigReaderClient(ctx.config)
         driver.defineValidOperationService()
-
         const appInfo = await appInfoFor(driver.operationService, driver.configReaderClient)
         
         expect(appInfo).toEqual({
             configReaderStatus: driver.validConfigReaderStatus,
             config: maskSensitiveData(ctx.config),
             dbConnectionStatus: driver.validDBConnectionStatus,
+            debug: true
         })
     })
 
@@ -41,6 +42,7 @@ describe('App info Function', () => {
     beforeEach(() => {
         driver.reset()
         ctx.config = genCommon.randomObject()
+        delete process.env['DEBUG']
     })
 
 

--- a/libs/velo-external-db-core/src/health/app_info.ts
+++ b/libs/velo-external-db-core/src/health/app_info.ts
@@ -12,11 +12,26 @@ export const maskSensitiveData = (cfg: {[key: string]: any}) => {
 export const appInfoFor = async(operationService: AnyFixMe, configReaderClient: AnyFixMe) => {
     const connectionStatus = await operationService.connectionStatus()
     const { message: configReaderStatus, authorizationMessage: authorizationConfigStatus } = await configReaderClient.configStatus()
+    const config = maskSensitiveData(await configReaderClient.readConfig())
+    const debug = process.env['DEBUG'] === 'true'
+    
+    if (!debug) {
+        if (config['authorization'] ) {
+            config['authorization'] = Object.keys(config['authorization']).length
+        }
+        
+        Object.keys(config).forEach(key => {
+            if (key !== 'authorization') {
+                delete config[key]
+            }
+        })
+    }
     
     return {
         configReaderStatus: configReaderStatus,
         authorizationConfigStatus, 
-        config: maskSensitiveData(configReaderClient.readConfig()),
-        dbConnectionStatus: connectionStatus.error || connectionStatus.status 
+        config,
+        dbConnectionStatus: connectionStatus.error || connectionStatus.status,
+        debug
     }
 }

--- a/libs/velo-external-db-core/src/health/app_info.ts
+++ b/libs/velo-external-db-core/src/health/app_info.ts
@@ -9,29 +9,17 @@ export const maskSensitiveData = (cfg: {[key: string]: any}) => {
 
 // 1. fix config reader config client when moving configReader to ts
 // 2. operation service - when declaring it as OperationService, there's a problem with mock and tests, create interface?
-export const appInfoFor = async(operationService: AnyFixMe, configReaderClient: AnyFixMe) => {
+export const appInfoFor = async(operationService: AnyFixMe, configReaderClient: AnyFixMe, hideAppInfo?:boolean) => {
     const connectionStatus = await operationService.connectionStatus()
     const { message: configReaderStatus, authorizationMessage: authorizationConfigStatus } = await configReaderClient.configStatus()
-    const config = maskSensitiveData(await configReaderClient.readConfig())
-    const debug = process.env['DEBUG'] === 'true'
+
+    const config = hideAppInfo ? {} :  maskSensitiveData (await configReaderClient.readConfig())
     
-    if (!debug) {
-        if (config['authorization'] ) {
-            config['authorization'] = Object.keys(config['authorization']).length
-        }
-        
-        Object.keys(config).forEach(key => {
-            if (key !== 'authorization') {
-                delete config[key]
-            }
-        })
-    }
     
     return {
         configReaderStatus: configReaderStatus,
         authorizationConfigStatus, 
         config,
         dbConnectionStatus: connectionStatus.error || connectionStatus.status,
-        debug
     }
 }

--- a/libs/velo-external-db-core/src/index.ts
+++ b/libs/velo-external-db-core/src/index.ts
@@ -31,9 +31,10 @@ export class ExternalDbRouter {
     schemaService: SchemaService
     roleAuthorizationService: RoleAuthorizationService
     cleanup: ConnectionCleanUp
+    hideAppInfo: boolean
     router: Router
     config: ExternalDbRouterConfig
-    constructor({ connector, config, hooks }: { connector: DbConnector, config: ExternalDbRouterConfig, hooks: {schemaHooks?: SchemaHooks, dataHooks?: DataHooks} }) {
+    constructor({ connector, config, hooks, hideAppInfo }: { connector: DbConnector, config: ExternalDbRouterConfig, hooks: {schemaHooks?: SchemaHooks, dataHooks?: DataHooks}, hideAppInfo?: boolean }) {
         this.isInitialized(connector)
         this.connector = connector
         this.configValidator = new ConfigValidator(connector.configValidator, new AuthorizationConfigValidator(config.authorization), new CommonConfigValidator({ secretKey: config.secretKey, vendor: config.vendor, type: config.adapterType }, config.commonExtended))
@@ -50,13 +51,14 @@ export class ExternalDbRouter {
 
         this.roleAuthorizationService = new RoleAuthorizationService(config.authorization?.roleConfig?.collectionPermissions) 
         this.cleanup = connector.cleanup
-        
-        initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...config, type: connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks)
+        this.hideAppInfo = hideAppInfo || false
+
+        initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...config, type: connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks, this.hideAppInfo)
         this.router = createRouter()
     }
 
     reloadHooks(hooks?: Hooks) {
-        initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...this.config, type: this.connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks)
+        initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...this.config, type: this.connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks || {}, this.hideAppInfo)
     }
 
     isInitialized(connector: DbConnector) {

--- a/libs/velo-external-db-core/src/index.ts
+++ b/libs/velo-external-db-core/src/index.ts
@@ -31,10 +31,9 @@ export class ExternalDbRouter {
     schemaService: SchemaService
     roleAuthorizationService: RoleAuthorizationService
     cleanup: ConnectionCleanUp
-    hideAppInfo: boolean
     router: Router
     config: ExternalDbRouterConfig
-    constructor({ connector, config, hooks, hideAppInfo }: { connector: DbConnector, config: ExternalDbRouterConfig, hooks: {schemaHooks?: SchemaHooks, dataHooks?: DataHooks}, hideAppInfo?: boolean }) {
+    constructor({ connector, config, hooks }: { connector: DbConnector, config: ExternalDbRouterConfig, hooks: {schemaHooks?: SchemaHooks, dataHooks?: DataHooks}}) {
         this.isInitialized(connector)
         this.connector = connector
         this.configValidator = new ConfigValidator(connector.configValidator, new AuthorizationConfigValidator(config.authorization), new CommonConfigValidator({ secretKey: config.secretKey, vendor: config.vendor, type: config.adapterType }, config.commonExtended))
@@ -51,14 +50,13 @@ export class ExternalDbRouter {
 
         this.roleAuthorizationService = new RoleAuthorizationService(config.authorization?.roleConfig?.collectionPermissions) 
         this.cleanup = connector.cleanup
-        this.hideAppInfo = hideAppInfo || false
 
-        initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...config, type: connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks, this.hideAppInfo)
+        initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...config, type: connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks)
         this.router = createRouter()
     }
 
     reloadHooks(hooks?: Hooks) {
-        initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...this.config, type: this.connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks || {}, this.hideAppInfo)
+        initServices(this.schemaAwareDataService, this.schemaService, this.operationService, this.configValidator, { ...this.config, type: this.connector.type }, this.filterTransformer, this.aggregationTransformer, this.roleAuthorizationService, hooks || {})
     }
 
     isInitialized(connector: DbConnector) {

--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -26,12 +26,12 @@ import { ConfigValidator } from '@wix-velo/external-db-config'
 const { InvalidRequest, ItemNotFound } = errors
 const { Find: FIND, Insert: INSERT, BulkInsert: BULK_INSERT, Update: UPDATE, BulkUpdate: BULK_UPDATE, Remove: REMOVE, BulkRemove: BULK_REMOVE, Aggregate: AGGREGATE, Count: COUNT, Get: GET } = DataOperations
 
-let schemaService: SchemaService, operationService: OperationService, externalDbConfigClient: ConfigValidator, schemaAwareDataService: SchemaAwareDataService, cfg: { secretKey?: any; type?: any; vendor?: any }, filterTransformer: FilterTransformer, aggregationTransformer: AggregationTransformer, roleAuthorizationService: RoleAuthorizationService, dataHooks: DataHooks, schemaHooks: SchemaHooks, hideAppInfo: boolean
+let schemaService: SchemaService, operationService: OperationService, externalDbConfigClient: ConfigValidator, schemaAwareDataService: SchemaAwareDataService, cfg: { secretKey?: any; type?: any; vendor?: any, hideAppInfo?: boolean }, filterTransformer: FilterTransformer, aggregationTransformer: AggregationTransformer, roleAuthorizationService: RoleAuthorizationService, dataHooks: DataHooks, schemaHooks: SchemaHooks
 
 export const initServices = (_schemaAwareDataService: SchemaAwareDataService, _schemaService: SchemaService, _operationService: OperationService,
-                             _externalDbConfigClient: ConfigValidator, _cfg: { secretKey?: string, type?: string, vendor?: string },
+                             _externalDbConfigClient: ConfigValidator, _cfg: { secretKey?: string, type?: string, vendor?: string, hideAppInfo?: boolean },
                              _filterTransformer: FilterTransformer, _aggregationTransformer: AggregationTransformer,
-                             _roleAuthorizationService: RoleAuthorizationService, _hooks: Hooks, _hideAppInfo: boolean) => {
+                             _roleAuthorizationService: RoleAuthorizationService, _hooks: Hooks) => {
     schemaService = _schemaService
     operationService = _operationService
     externalDbConfigClient = _externalDbConfigClient
@@ -42,7 +42,6 @@ export const initServices = (_schemaAwareDataService: SchemaAwareDataService, _s
     roleAuthorizationService = _roleAuthorizationService
     dataHooks = _hooks?.dataHooks || {}
     schemaHooks = _hooks?.schemaHooks || {}
-    hideAppInfo = _hideAppInfo
 }
 
 const serviceContext = (): ServiceContext => ({
@@ -89,7 +88,8 @@ export const createRouter = () => {
 
     // *************** INFO **********************
     router.get('/', async(req, res) => {
-        const appInfo = await appInfoFor(operationService, externalDbConfigClient, hideAppInfo)
+        const { hideAppInfo } = cfg
+        const appInfo = await appInfoFor(operationService, externalDbConfigClient, cfg.hideAppInfo)
         const appInfoPage = await getAppInfoPage(appInfo, hideAppInfo) 
 
         res.send(appInfoPage)

--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -26,12 +26,12 @@ import { ConfigValidator } from '@wix-velo/external-db-config'
 const { InvalidRequest, ItemNotFound } = errors
 const { Find: FIND, Insert: INSERT, BulkInsert: BULK_INSERT, Update: UPDATE, BulkUpdate: BULK_UPDATE, Remove: REMOVE, BulkRemove: BULK_REMOVE, Aggregate: AGGREGATE, Count: COUNT, Get: GET } = DataOperations
 
-let schemaService: SchemaService, operationService: OperationService, externalDbConfigClient: ConfigValidator, schemaAwareDataService: SchemaAwareDataService, cfg: { secretKey?: any; type?: any; vendor?: any }, filterTransformer: FilterTransformer, aggregationTransformer: AggregationTransformer, roleAuthorizationService: RoleAuthorizationService, dataHooks: DataHooks, schemaHooks: SchemaHooks
+let schemaService: SchemaService, operationService: OperationService, externalDbConfigClient: ConfigValidator, schemaAwareDataService: SchemaAwareDataService, cfg: { secretKey?: any; type?: any; vendor?: any }, filterTransformer: FilterTransformer, aggregationTransformer: AggregationTransformer, roleAuthorizationService: RoleAuthorizationService, dataHooks: DataHooks, schemaHooks: SchemaHooks, hideAppInfo: boolean
 
 export const initServices = (_schemaAwareDataService: SchemaAwareDataService, _schemaService: SchemaService, _operationService: OperationService,
                              _externalDbConfigClient: ConfigValidator, _cfg: { secretKey?: string, type?: string, vendor?: string },
                              _filterTransformer: FilterTransformer, _aggregationTransformer: AggregationTransformer,
-                             _roleAuthorizationService: RoleAuthorizationService, _hooks?: Hooks) => {
+                             _roleAuthorizationService: RoleAuthorizationService, _hooks: Hooks, _hideAppInfo: boolean) => {
     schemaService = _schemaService
     operationService = _operationService
     externalDbConfigClient = _externalDbConfigClient
@@ -42,6 +42,7 @@ export const initServices = (_schemaAwareDataService: SchemaAwareDataService, _s
     roleAuthorizationService = _roleAuthorizationService
     dataHooks = _hooks?.dataHooks || {}
     schemaHooks = _hooks?.schemaHooks || {}
+    hideAppInfo = _hideAppInfo
 }
 
 const serviceContext = (): ServiceContext => ({
@@ -88,8 +89,8 @@ export const createRouter = () => {
 
     // *************** INFO **********************
     router.get('/', async(req, res) => {
-        const appInfo = await appInfoFor(operationService, externalDbConfigClient)
-        const appInfoPage = await getAppInfoPage(appInfo)
+        const appInfo = await appInfoFor(operationService, externalDbConfigClient, hideAppInfo)
+        const appInfoPage = await getAppInfoPage(appInfo, hideAppInfo) 
 
         res.send(appInfoPage)
     })

--- a/libs/velo-external-db-core/src/types.ts
+++ b/libs/velo-external-db-core/src/types.ts
@@ -116,6 +116,7 @@ export interface ExternalDbRouterConfig {
     vendor?: string
     adapterType?: string
     commonExtended?: boolean
+    hideAppInfo?: boolean
 }
 
 export type Hooks = {

--- a/libs/velo-external-db-core/src/utils/router_utils.build.ts
+++ b/libs/velo-external-db-core/src/utils/router_utils.build.ts
@@ -3,15 +3,13 @@ import * as ejs from 'ejs'
 import { AnyFixMe } from '@wix-velo/velo-external-db-types'
 const fs = require('fs').promises
 
-const getAppInfoTemplate = async() => {
-    return await fs.readFile(path.join( __dirname, 'views', 'index.ejs'), 'utf8')
+const getAppInfoTemplate = async(hideAppInfo: boolean) => {
+    const fileName = hideAppInfo ? 'index-without-data.ejs' : 'index.ejs' 
+    return await fs.readFile(path.join( __dirname, 'views', fileName), 'utf8')
 }
 
-export const getAppInfoPage = async(appInfo: AnyFixMe) => {
-    const appInfoTemplate = await getAppInfoTemplate()
+export const getAppInfoPage = async(appInfo: AnyFixMe, hideAppInfo: boolean) => {
+    const appInfoTemplate = await getAppInfoTemplate(hideAppInfo)
     const appInfoPage = ejs.render(appInfoTemplate, appInfo)
     return appInfoPage
 }
-
-
-

--- a/libs/velo-external-db-core/src/utils/router_utils.ts
+++ b/libs/velo-external-db-core/src/utils/router_utils.ts
@@ -2,18 +2,19 @@ import path = require('path')
 import ejs = require('ejs')
 import { promises as fs } from 'fs'
 
-const getAppInfoTemplate = async() => { // TODO: fix this hack!
+const getAppInfoTemplate = async(hideAppInfo: boolean) => { // TODO: fix this hack!
+    const fileName = hideAppInfo ? 'index-without-data.ejs' : 'index.ejs' 
     try {
-        return await fs.readFile(path.join( __dirname, '..', 'views', 'index.ejs'), 'utf8')
+        return await fs.readFile(path.join( __dirname, '..', 'views', fileName), 'utf8')
     } catch (err) {
-        return await fs.readFile(path.join( __dirname, 'views', 'index.ejs'), 'utf8')
+        return await fs.readFile(path.join( __dirname, 'views', fileName), 'utf8')
     }
 
     
 }
 
-export const getAppInfoPage = async(appInfo: any) => {
-    const appInfoTemplate = await getAppInfoTemplate()
+export const getAppInfoPage = async(appInfo: any, hideAppInfo: boolean) => {
+    const appInfoTemplate = await getAppInfoTemplate(hideAppInfo)
     const appInfoPage = ejs.render(appInfoTemplate, appInfo)
     return appInfoPage
 }

--- a/libs/velo-external-db-core/src/utils/router_utils.ts
+++ b/libs/velo-external-db-core/src/utils/router_utils.ts
@@ -2,7 +2,7 @@ import path = require('path')
 import ejs = require('ejs')
 import { promises as fs } from 'fs'
 
-const getAppInfoTemplate = async(hideAppInfo: boolean) => { // TODO: fix this hack!
+const getAppInfoTemplate = async(hideAppInfo?: boolean) => { // TODO: fix this hack!
     const fileName = hideAppInfo ? 'index-without-data.ejs' : 'index.ejs' 
     try {
         return await fs.readFile(path.join( __dirname, '..', 'views', fileName), 'utf8')
@@ -13,7 +13,7 @@ const getAppInfoTemplate = async(hideAppInfo: boolean) => { // TODO: fix this ha
     
 }
 
-export const getAppInfoPage = async(appInfo: any, hideAppInfo: boolean) => {
+export const getAppInfoPage = async(appInfo: any, hideAppInfo?: boolean) => {
     const appInfoTemplate = await getAppInfoTemplate(hideAppInfo)
     const appInfoPage = ejs.render(appInfoTemplate, appInfo)
     return appInfoPage

--- a/libs/velo-external-db-core/src/views/index-without-data.ejs
+++ b/libs/velo-external-db-core/src/views/index-without-data.ejs
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang=en>
+<head>
+	<meta charset=utf-8>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Velo External DB</title>
+	<link href="https://fonts.googleapis.com/css?family=Roboto" rel="preload" as="font">
+	<link type="image/png" href="https://www.wix.com/favicon.ico" rel="shortcut icon">
+    <link rel='stylesheet' href='/assets/stylesheets/style.css' />
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-U1DAWAznBHeqEIlVSCgzq+c9gqGAJn5c/t99JyeKa9xxaYpSvHU5awsuZVVFIhvj" crossorigin="anonymous"></script>
+</head>
+
+
+<%
+const img =  dbConnectionStatus === 'Connected to database successfully' ? '/assets/wix-logo.svg': '/assets/sad-wix.svg' 
+%>
+
+<body>
+
+	<div class="container">
+		<div class="hero">
+			<div style="text-align:center;">
+				<picture>
+					<img src=<%=img%> width="427" height="231">
+				</picture>
+			</div>
+		</div>
+		<style>
+			.list-group {
+				width: auto;
+				max-width: 650px;
+				margin: 3rem auto;
+			}
+		</style>
+		
+		
+		<%
+		const connectionColor =  dbConnectionStatus === 'Connected to database successfully' ? 'success': 'danger' 
+		const configStatusColor = configReaderStatus === 'External DB Config read successfully' ? 'success' : 'danger'
+		let authorizationStatusColor
+		if (authorizationConfigStatus === 'Permissions config read successfully') {
+			authorizationStatusColor = 'success'
+		} else if (authorizationConfigStatus === 'Permissions config not defined, using default') {
+			authorizationStatusColor = 'warning'
+		} else {
+			authorizationStatusColor = 'danger'
+		}
+		%>
+
+		<div class="list-group">
+			<div class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=configStatusColor%> py-3" aria-current="true">
+				<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
+					<path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+				  </svg>
+				<div class="d-flex gap-2 w-100 justify-content-between">
+					<div>
+						<h6 class="mb-0">DB Config Status</h6>
+						<p class="mb-0 opacity-75">
+							<%= configReaderStatus %>
+						</p>
+					</div>
+				</div>
+			</div>
+		
+			<div class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=authorizationStatusColor%> py-3" aria-current="true">
+				<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
+					<path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+				  </svg>
+				<div class="d-flex gap-2 w-100 justify-content-between">
+					<div>
+						<h6 class="mb-0">Permissions Config Status</h6>
+						<p class="mb-0 opacity-75">
+							<%= authorizationConfigStatus %>
+						</p>
+					</div>
+				</div>
+			</div>
+		
+
+			<div id="roleConfig" style="display: none;" >
+				<pre style = "background-color:#d9cdcd1f;" aria-current="true" style="display:none; border:0; padding: 0;"><%= JSON.stringify(config.authorization, null, 2) %></pre>
+			</div>
+			<div class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=connectionColor%> py-3" aria-current="true"> 
+				<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-hdd-stack"
+					viewBox="0 0 16 16">
+					<path
+						d="M14 10a1 1 0 0 1 1 1v1a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-1a1 1 0 0 1 1-1h12zM2 9a2 2 0 0 0-2 2v1a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-1a2 2 0 0 0-2-2H2z" />
+					<path
+						d="M5 11.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zm-2 0a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zM14 3a1 1 0 0 1 1 1v1a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h12zM2 2a2 2 0 0 0-2 2v1a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H2z" />
+					<path d="M5 4.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zm-2 0a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0z" />
+				</svg>
+				<div class="d-flex gap-2 w-100 justify-content-between">
+					<div>
+						<h6 class="mb-0">Connection Status</h6>
+						<p class="mb-0 opacity-75">
+							<%= dbConnectionStatus %>
+						</p>
+					</div>
+				</div>
+			</div>
+		
+		
+		
+			<div class="clipboard-example align-items-center w-100 py-2">
+				<div class="input-group mb-3">
+					<span class="input-group-text">Configuration</span>
+					<input id="in01"
+						   type="text"
+						   class="form-control"
+						   aria-describedby="btn01"
+						   value='{"secretKey": "<your-secret-key>"}'
+		
+					>
+					<button id="btn01"
+							data-clipboard-target="#in01"
+							class="btn btn-secondary"
+							type="button"
+							data-clipboard-demo=""
+							data-clipboard-target="#in01"
+							data-bs-toggle="tooltip"
+							data-bs-placement="bottom"
+							title="Copy to Clipboard"
+					>Copy</button>
+					
+				</div>
+			</div>
+			<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
+			<script>
+				let btn = document.getElementById('btn01');
+				let clipboard = new ClipboardJS(btn);
+			</script>
+		</div>		
+	</div>
+</body>
+
+</html>

--- a/libs/velo-external-db-core/src/views/index.ejs
+++ b/libs/velo-external-db-core/src/views/index.ejs
@@ -96,8 +96,12 @@ const img =  dbConnectionStatus === 'Connected to database successfully' ? '/ass
 				</div>
 			</button>
 		
+
+			<%
+			const authorizationToggleText = Number.isInteger(config.authorization) ? 'The number of permissions rules that were set successfully' : 'Config part that read successfully'
+			%>
 			<div id="roleConfig" style="display: none;" >
-				Config part that read successfully:
+				<%= authorizationToggleText %>
 				<pre style = "background-color:#d9cdcd1f;" aria-current="true" style="display:none; border:0; padding: 0;"><%= JSON.stringify(config.authorization, null, 2) %></pre>
 			</div>
 			<div class="list-group-item list-group-item-action d-flex gap-3  list-group-item-<%=connectionColor%> py-3" aria-current="true"> 


### PR DESCRIPTION
When `HIDE_APP_INFO` env not equal to 'true' the app-info will look as it looked before:
![image](https://user-images.githubusercontent.com/82806105/215775407-6ea527b0-8d91-4cd6-92d1-93981a19e0e8.png)

Otherwise, `HIDE_APP_INFO = 'true'` the config won't be sent to the HTML page, and the two sections won't be clickable.

fix #310 