### PR TITLE
Spanner to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
                    "postgres", "postgres13", "postgres12", "postgres11", "postgres10", "postgres9",
                    "mysql", "mysql5",
                    "mssql", "mssql17",
+                   spanner
                    ]
 
     env:

--- a/apps/velo-external-db/src/storage/factory.ts
+++ b/apps/velo-external-db/src/storage/factory.ts
@@ -7,10 +7,10 @@ export const engineConnectorFor = async(_type: string, config: any): Promise<Dat
             const { postgresFactory } = require('@wix-velo/external-db-postgres')
             return await postgresFactory(config)
         }
-        // case 'spanner': {
-        //     const { spannerFactory } = require('@wix-velo/external-db-spanner')
-        //     return await spannerFactory(config)
-        // }
+        case 'spanner': {
+            const { spannerFactory } = require('@wix-velo/external-db-spanner')
+            return await spannerFactory(config)
+        }
         // case 'firestore': {
         //     const { firestoreFactory } = require('@wix-velo/external-db-firestore')
         //     return await firestoreFactory(config)

--- a/apps/velo-external-db/test/env/env.db.setup.js
+++ b/apps/velo-external-db/test/env/env.db.setup.js
@@ -5,7 +5,7 @@ registerTsProject('.', 'tsconfig.base.json')
 
 const { testResources: postgres } = require ('@wix-velo/external-db-postgres')
 const { testResources: mysql } = require ('@wix-velo/external-db-mysql')
-// const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
+const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
 // const { testResources: firestore } = require ('@wix-velo/external-db-firestore')
 const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
 // const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
@@ -23,9 +23,9 @@ const initEnv = async(testEngine) => {
             await mysql.initEnv()
             break
 
-        // case 'spanner':
-        //     await spanner.initEnv()
-        //     break
+        case 'spanner':
+            await spanner.initEnv()
+            break
 
         case 'postgres':
             await postgres.initEnv()
@@ -66,9 +66,9 @@ const cleanup = async(testEngine) => {
             await mysql.cleanup()
             break
 
-        // case 'spanner':
-        //     await spanner.cleanup()
-        //     break
+        case 'spanner':
+            await spanner.cleanup()
+            break
 
         case 'postgres':
             await postgres.cleanup()

--- a/apps/velo-external-db/test/env/env.db.teardown.js
+++ b/apps/velo-external-db/test/env/env.db.teardown.js
@@ -1,6 +1,6 @@
 const { testResources: postgres } = require ('@wix-velo/external-db-postgres')
 const { testResources: mysql } = require ('@wix-velo/external-db-mysql')
-// const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
+const { testResources: spanner } = require ('@wix-velo/external-db-spanner')
 // const { testResources: firestore } = require ('@wix-velo/external-db-firestore')
 const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
 // const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
@@ -17,9 +17,9 @@ const shutdownEnv = async(testEngine) => {
             await mysql.shutdownEnv()
             break
 
-        // case 'spanner':
-        //     await spanner.shutdownEnv()
-        //     break
+        case 'spanner':
+            await spanner.shutdownEnv()
+            break
 
         case 'postgres':
             await postgres.shutdownEnv()

--- a/apps/velo-external-db/test/resources/e2e_resources.ts
+++ b/apps/velo-external-db/test/resources/e2e_resources.ts
@@ -30,7 +30,7 @@ const createAppWithWixDataBaseUrl = createApp.bind(null, wixDataBaseUrl())
 const testSuits = {
     mysql: new E2EResources(mysql, createAppWithWixDataBaseUrl),
     postgres: new E2EResources(postgres, createAppWithWixDataBaseUrl),
-    spanner: new E2EResources(spanner, createApp),
+    spanner: new E2EResources(spanner, createAppWithWixDataBaseUrl),
     firestore: new E2EResources(firestore, createApp),
     mssql: new E2EResources(mssql, createAppWithWixDataBaseUrl),
     mongo: new E2EResources(mongo, createApp),

--- a/apps/velo-external-db/test/resources/provider_resources.ts
+++ b/apps/velo-external-db/test/resources/provider_resources.ts
@@ -71,7 +71,7 @@ const googleSheetTestEnvInit = async() => await dbInit(googleSheet)
 const testSuits = {
     mysql: suiteDef('MySql', mysqlTestEnvInit, mysql.testResources),
     postgres: suiteDef('Postgres', postgresTestEnvInit, postgres.testResources),
-    spanner: suiteDef('Spanner', spannerTestEnvInit, spanner.testResources.supportedOperations),
+    spanner: suiteDef('Spanner', spannerTestEnvInit, spanner.testResources),
     firestore: suiteDef('Firestore', firestoreTestEnvInit, firestore.testResources.supportedOperations),
     mssql: suiteDef('Sql Server', mssqlTestEnvInit, mssql.testResources),
     mongo: suiteDef('Mongo', mongoTestEnvInit, mongo.testResources.supportedOperations),

--- a/libs/external-db-spanner/src/spanner_capabilities.ts
+++ b/libs/external-db-spanner/src/spanner_capabilities.ts
@@ -1,0 +1,21 @@
+import { AdapterOperators } from '@wix-velo/velo-external-db-commons'
+import { CollectionOperation, DataOperation, FieldType } from '@wix-velo/velo-external-db-types'
+
+const { query, count, queryReferenced, aggregate, } = DataOperation
+const { eq, ne, string_contains, string_begins, string_ends, gt, gte, lt, lte, include } = AdapterOperators
+const UnsupportedCapabilities = [DataOperation.insertReferences, DataOperation.removeReferences, DataOperation.queryReferenced]
+
+
+export const ReadWriteOperations = Object.values(DataOperation).filter(op => !UnsupportedCapabilities.includes(op))
+export const ReadOnlyOperations = [query, count, queryReferenced, aggregate]
+export const FieldTypes = Object.values(FieldType)
+export const CollectionOperations = Object.values(CollectionOperation)
+export const ColumnsCapabilities = {
+    text: { sortable: true, columnQueryOperators: [eq, ne, string_contains, string_begins, string_ends, include, gt, gte, lt, lte] },
+    url: { sortable: true, columnQueryOperators: [eq, ne, string_contains, string_begins, string_ends, include, gt, gte, lt, lte] },
+    number: { sortable: true, columnQueryOperators: [eq, ne, gt, gte, lt, lte, include] },
+    boolean: { sortable: true, columnQueryOperators: [eq] },
+    image: { sortable: false, columnQueryOperators: [] },
+    object: { sortable: false, columnQueryOperators: [eq, ne, string_contains, string_begins, string_ends, include, gt, gte, lt, lte] },
+    datetime: { sortable: true, columnQueryOperators: [eq, ne, gt, gte, lt, lte] },
+}

--- a/libs/external-db-spanner/src/spanner_data_provider.ts
+++ b/libs/external-db-spanner/src/spanner_data_provider.ts
@@ -50,8 +50,8 @@ export default class DataProvider implements IDataProvider {
 
         const preparedItems = items.map((item: any) => patchFloat(item, floatFields)).map(this.asDBEntity.bind(this))
         
-        upsert ? await this.database.table(collectionName).upsert(preparedItems).catch(translateErrorCodes) :
-                 await this.database.table(collectionName).insert(preparedItems).catch(translateErrorCodes)
+        upsert ? await this.database.table(collectionName).upsert(preparedItems).catch((err) => translateErrorCodes(err, collectionName)) :
+                 await this.database.table(collectionName).insert(preparedItems).catch((err) => translateErrorCodes(err, collectionName))
 
         return items.length
     }
@@ -87,7 +87,7 @@ export default class DataProvider implements IDataProvider {
                            .update(
                                (items.map((item: any) => patchFloat(item, floatFields)))
                                      .map(this.asDBEntity.bind(this))
-                           ).catch(translateErrorCodes)
+                           ).catch((err) => translateErrorCodes(err, collectionName))
         return items.length
     }
 

--- a/libs/external-db-spanner/src/spanner_data_provider.ts
+++ b/libs/external-db-spanner/src/spanner_data_provider.ts
@@ -45,7 +45,7 @@ export default class DataProvider implements IDataProvider {
         return objs[0]['num']
     }
 
-    async insert(collectionName: string, items: Item[], fields: any, upsert?: boolean): Promise <number> { 
+    async insert(collectionName: string, items: Item[], fields: any, upsert = false): Promise <number> { 
         const floatFields = extractFloatFields(fields)
 
         const preparedItems = items.map((item: any) => patchFloat(item, floatFields)).map(this.asDBEntity.bind(this))

--- a/libs/external-db-spanner/src/spanner_schema_provider.ts
+++ b/libs/external-db-spanner/src/spanner_schema_provider.ts
@@ -4,7 +4,7 @@ import SchemaColumnTranslator from './sql_schema_translator'
 import { notThrowingTranslateErrorCodes } from './sql_exception_translator'
 import { recordSetToObj, escapeId, patchFieldName, unpatchFieldName, escapeFieldId } from './spanner_utils'
 import { Database as SpannerDb } from '@google-cloud/spanner'
-import { CollectionCapabilities, Encryption, InputField, ISchemaProvider, ResponseField, SchemaOperations, Table } from '@wix-velo/velo-external-db-types'
+import { CollectionCapabilities, Encryption, InputField, ISchemaProvider, SchemaOperations, Table } from '@wix-velo/velo-external-db-types'
 import { CollectionOperations, ColumnsCapabilities, FieldTypes, ReadOnlyOperations, ReadWriteOperations } from './spanner_capabilities'
 const { CollectionDoesNotExists, CollectionAlreadyExists } = errors
 

--- a/libs/external-db-spanner/src/spanner_schema_provider.ts
+++ b/libs/external-db-spanner/src/spanner_schema_provider.ts
@@ -91,7 +91,7 @@ export default class SchemaProvider implements ISchemaProvider {
         const res = recordSetToObj(rows)
 
         if (res.length === 0) {
-            throw new CollectionDoesNotExists('Collection does not exists')
+            throw new CollectionDoesNotExists('Collection does not exists', collectionName)
         }
 
         return {

--- a/libs/external-db-spanner/src/spanner_schema_provider.ts
+++ b/libs/external-db-spanner/src/spanner_schema_provider.ts
@@ -130,7 +130,7 @@ export default class SchemaProvider implements ISchemaProvider {
         const type = this.sqlSchemaTranslator.translateType(row.type).type as keyof typeof ColumnsCapabilities
         return {
             field: unpatchFieldName(row.field),
-            type,
+            ...this.sqlSchemaTranslator.translateType(row.type),
             capabilities: ColumnsCapabilities[type] ?? EmptyCapabilities
         }
     }

--- a/libs/external-db-spanner/src/sql_exception_translator.ts
+++ b/libs/external-db-spanner/src/sql_exception_translator.ts
@@ -1,7 +1,16 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
 const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist, DbConnectionError, CollectionAlreadyExists, ItemAlreadyExists, InvalidQuery, UnrecognizedError } = errors
+const extractId = (msg: string | null) => {
+    msg = msg || ''
+    const regex = /String\("([A-Za-z0-9-]+)"\)/i
+    const match = msg.match(regex)
+    if (match) {
+      return match[1]
+    }
+    return ''
+  }
 
-export const notThrowingTranslateErrorCodes = (err: any) => {
+export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string) => {
     switch (err.code) {
         case 9:
             if (err.details.includes('column')) {
@@ -17,13 +26,16 @@ export const notThrowingTranslateErrorCodes = (err: any) => {
             } else if (err.details.includes('Database')) {
                 return new DbConnectionError(`Database does not exists or you don't have access to it, sql message: ${err.details}`)
             } else if (err.details.includes('Table')) {
-                return new CollectionDoesNotExists(err.details)
+                console.log({ details: err.details, collectionName })
+                
+                return new CollectionDoesNotExists(err.details, collectionName)
             } else {
                 return new InvalidQuery(`${err.details}`)
             }
         case 6:
             if (err.details.includes('already exists')) 
-                return new ItemAlreadyExists(`Item already exists: ${err.details}`)
+                return new ItemAlreadyExists(`Item already exists: ${err.details}`, collectionName, extractId(err.details))
+
             else
                 return new InvalidQuery(`${err.details}`)
         case 7:
@@ -35,6 +47,6 @@ export const notThrowingTranslateErrorCodes = (err: any) => {
     }
 }
 
-export const translateErrorCodes = (err: any) => {
-    throw notThrowingTranslateErrorCodes(err)
+export const translateErrorCodes = (err: any, collectionName?: string) => {
+    throw notThrowingTranslateErrorCodes(err, collectionName)
 }

--- a/libs/external-db-spanner/src/sql_exception_translator.ts
+++ b/libs/external-db-spanner/src/sql_exception_translator.ts
@@ -20,7 +20,7 @@ export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string
             }
         case 5:
             if (err.details.includes('Column')) {
-                return new FieldDoesNotExist(err.details)
+                return new FieldDoesNotExist(err.details, collectionName)
             } else if (err.details.includes('Instance')) {
                 return new DbConnectionError(`Access to database denied - wrong credentials or host is unavailable, sql message:  ${err.details} `)
             } else if (err.details.includes('Database')) {

--- a/libs/external-db-spanner/src/sql_filter_transformer.ts
+++ b/libs/external-db-spanner/src/sql_filter_transformer.ts
@@ -116,6 +116,16 @@ export default class FilterParser {
                 }]
         }
 
+        if (this.isNestedField(fieldName)) {
+            const [nestedFieldName, ...nestedFieldPath] = fieldName.split('.')
+            const literals = this.valueForOperator(nestedFieldName, value, operator, counter).sql
+
+            return [{
+                filterExpr: `JSON_VALUE(${this.inlineVariableIfNeeded(nestedFieldName, inlineFields)}, '$.${nestedFieldPath.join('.')}') ${this.adapterOperatorToMySqlOperator(operator, value)} ${literals}`.trim(),
+                parameters: this.parametersFor(nestedFieldName, value, counter)
+            }]
+        }
+
         if (this.isSingleFieldOperator(operator)) {
             const literals = this.valueForOperator(fieldName, value, operator, counter).sql
 
@@ -154,6 +164,10 @@ export default class FilterParser {
         }
 
         return []
+    }
+
+    isNestedField(fieldName: string) {
+        return fieldName.includes('.')
     }
 
     parametersFor(name: string, value: any, counter: Counter) {

--- a/libs/external-db-spanner/src/supported_operations.ts
+++ b/libs/external-db-spanner/src/supported_operations.ts
@@ -1,5 +1,6 @@
 import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
-const notSupportedOperations = [SchemaOperations.QueryNestedFields]
+//change column types - https://cloud.google.com/spanner/docs/schema-updates#supported_schema_updates
+const notSupportedOperations = [SchemaOperations.QueryNestedFields, SchemaOperations.ChangeColumnType]
 
 export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-spanner/src/supported_operations.ts
+++ b/libs/external-db-spanner/src/supported_operations.ts
@@ -1,6 +1,6 @@
 import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
 //change column types - https://cloud.google.com/spanner/docs/schema-updates#supported_schema_updates
-const notSupportedOperations = [SchemaOperations.QueryNestedFields, SchemaOperations.ChangeColumnType]
+const notSupportedOperations = [SchemaOperations.ChangeColumnType]
 
 export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-spanner/tests/e2e-testkit/spanner_resources.ts
+++ b/libs/external-db-spanner/tests/e2e-testkit/spanner_resources.ts
@@ -2,6 +2,8 @@ import * as compose from 'docker-compose'
 import init from '../../src/connection_provider'
 export { supportedOperations } from '../../src/supported_operations'
 
+export * as capabilities from '../../src/spanner_capabilities' 
+
 const setEmulatorOn = () => process.env['SPANNER_EMULATOR_HOST'] = 'localhost:9010'
 
 export const connection = () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:full-image": "nx run velo-external-db:build-image ",
     "lint": "eslint --cache ./",
     "lint:fix": "eslint --cache --fix ./",
-    "test": "npm run test:core; npm run test:mysql; npm run test:postgres; npm run test:mssql",
+    "test": "npm run test:core; npm run test:mysql; npm run test:postgres; npm run test:mssql; npm run test:spanner",
     "test:core": "nx run-many --skip-nx-cache --target=test --projects=@wix-velo/external-db-config,@wix-velo/velo-external-db-core,@wix-velo/external-db-security",
     "test:postgres": "TEST_ENGINE=postgres nx run-many --skip-nx-cache --target=test --projects=@wix-velo/external-db-postgres,velo-external-db",
     "test:postgres13": "npm run test:postgres",

--- a/workspace.json
+++ b/workspace.json
@@ -5,6 +5,7 @@
     "@wix-velo/external-db-postgres": "libs/external-db-postgres",
     "@wix-velo/external-db-mysql": "libs/external-db-mysql",
     "@wix-velo/external-db-mssql": "libs/external-db-mssql",
+    "@wix-velo/external-db-spanner": "libs/external-db-spanner",
     "@wix-velo/external-db-security": "libs/external-db-security",
     "@wix-velo/test-commons": "libs/test-commons",
     "@wix-velo/velo-external-db-commons": "libs/velo-external-db-commons",


### PR DESCRIPTION
apps: 
- [x] remove comment from [factory](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/src/storage/factory.ts) 
- [x] remove comment from [e2e.db.setup](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/env/env.db.setup.js)
- [x] remove comment from [e2e.db.teardown](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/env/env.db.teardown.js)
- [x] in [e2e_resources](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/resources/e2e_resources.ts) replace `createApp` with `createAppWithWixDataBaseUrl`
- [x] in provider_resources, replace `<impl>.testResources.supportedOperations` with `<impl>.testResources`

Current implementation changes: 
  
  Schema:

  - [x] create [capabilities file](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_capabilities.ts)
  - [x] change [schemas list](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L28-L33) format.
  - [x] change [describe collection](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L79-L93) format.
  - [x] implement [change column type](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L67-L71) method. - **Not supported** - see [here](https://cloud.google.com/spanner/docs/schema-updates#supported_schema_updates)
  - [x] change [default precision](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_schema_translator.ts#L128) to be (15,2) - if relevant.
  
Data: 

- [x] support [upsert](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_data_provider.ts#L41-L50).
- [x] add sort, skip, limit in [aggregate](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_data_provider.ts#L77-L87) function.
- [x] support querying by nested fields (+sql_filter_transformer tests).

Error handling: 

- [x] return `collectionName` with each error code ([sql_exception_translator](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts)).
- [x] on field [doesn't exist](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L21), return the field name.
- [x] on field [already exist](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L23), return the field name.
- [x] on item [already exists](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L35), return the duplicated _id

e2e: 
- [x] export capabilities from [implementation_resources](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/tests/e2e-testkit/mysql_resources.ts#L6)

general: 

- [x] in [workspace](https://github.com/wix/velo-external-db/blob/managed-adapter/workspace.json#L5), add the lib
- [x] in [package.json - test script](https://github.com/wix/velo-external-db/blob/managed-adapter/package.json#L10), test the current implementation too.
- [x] in [main.yml](https://github.com/wix/velo-external-db/blob/managed-adapter/.github/workflows/main.yml#L40-L42), add the current implementation.