### PR TITLE
Dynamo to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
                    "mssql", "mssql17",
                    spanner,
                    "mongo", "mongo4",
+                   "dynamodb"
                    ]
 
     env:

--- a/apps/velo-external-db/src/storage/factory.ts
+++ b/apps/velo-external-db/src/storage/factory.ts
@@ -35,10 +35,10 @@ export const engineConnectorFor = async(_type: string, config: any): Promise<Dat
         //     const { airtableFactory } = require('@wix-velo/external-db-airtable')
         //     return await airtableFactory(config)
         // }
-        // case 'dynamodb': {
-        //     const { dynamoDbFactory } = require('@wix-velo/external-db-dynamodb')
-        //     return await dynamoDbFactory(config)
-        // }
+        case 'dynamodb': {
+            const { dynamoDbFactory } = require('@wix-velo/external-db-dynamodb')
+            return await dynamoDbFactory(config)
+        }
         // case 'bigquery': {
         //     const { bigqueryFactory } = require('@wix-velo/external-db-bigquery')
         //     return await bigqueryFactory(config)

--- a/apps/velo-external-db/test/env/env.db.setup.js
+++ b/apps/velo-external-db/test/env/env.db.setup.js
@@ -11,7 +11,7 @@ const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
 const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
 // const { testResources: googleSheet } = require('@wix-velo/external-db-google-sheets')
 // const { testResources: airtable } = require('@wix-velo/external-db-airtable')
-// const { testResources: dynamoDb } = require('@wix-velo/external-db-dynamodb')
+const { testResources: dynamoDb } = require('@wix-velo/external-db-dynamodb')
 // const { testResources: bigquery } = require('@wix-velo/external-db-bigquery')
 
 const { sleep } = require('@wix-velo/test-commons')
@@ -50,9 +50,9 @@ const initEnv = async(testEngine) => {
         //     await airtable.initEnv()
         //     break
         
-        // case 'dynamodb':
-        //     await dynamoDb.initEnv()
-        //     break
+        case 'dynamodb':
+            await dynamoDb.initEnv()
+            break
 
         // case 'bigquery':
         //     await bigquery.initEnv()
@@ -90,9 +90,9 @@ const cleanup = async(testEngine) => {
             await mongo.cleanup()
             break
         
-        // case 'dynamodb':
-        //     await dynamoDb.cleanup()
-        //     break
+        case 'dynamodb':
+            await dynamoDb.cleanup()
+            break
 
         // case 'bigquery':
         //     await bigquery.cleanup()

--- a/apps/velo-external-db/test/env/env.db.teardown.js
+++ b/apps/velo-external-db/test/env/env.db.teardown.js
@@ -6,7 +6,7 @@ const { testResources: mssql } = require ('@wix-velo/external-db-mssql')
 const { testResources: mongo } = require ('@wix-velo/external-db-mongo')
 // const { testResources: googleSheet } = require('@wix-velo/external-db-google-sheets')
 // const { testResources: airtable } = require('@wix-velo/external-db-airtable')
-// const { testResources: dynamo } = require('@wix-velo/external-db-dynamodb')
+const { testResources: dynamo } = require('@wix-velo/external-db-dynamodb')
 // const { testResources: bigquery } = require('@wix-velo/external-db-bigquery')
 
 const ci = require('./ci_utils')
@@ -41,9 +41,9 @@ const shutdownEnv = async(testEngine) => {
         //     await airtable.shutdownEnv()
         //     break
         
-        // case 'dynamodb':
-        //     await dynamo.shutdownEnv()
-        //     break
+        case 'dynamodb':
+            await dynamo.shutdownEnv()
+            break
 
         case 'mongo': 
             await mongo.shutdownEnv()

--- a/apps/velo-external-db/test/resources/e2e_resources.ts
+++ b/apps/velo-external-db/test/resources/e2e_resources.ts
@@ -37,7 +37,7 @@ const testSuits = {
     mongo: new E2EResources(mongo, createAppWithWixDataBaseUrl),
     'google-sheet': new E2EResources(googleSheet, createApp),
     airtable: new E2EResources(airtable, createApp),
-    dynamodb: new E2EResources(dynamo, createApp),
+    dynamodb: new E2EResources(dynamo, createAppWithWixDataBaseUrl),
     bigquery: new E2EResources(bigquery, createApp),
 }
 

--- a/apps/velo-external-db/test/resources/provider_resources.ts
+++ b/apps/velo-external-db/test/resources/provider_resources.ts
@@ -76,7 +76,7 @@ const testSuits = {
     mssql: suiteDef('Sql Server', mssqlTestEnvInit, mssql.testResources),
     mongo: suiteDef('Mongo', mongoTestEnvInit, mongo.testResources),
     airtable: suiteDef('Airtable', airTableTestEnvInit, airtable.testResources.supportedOperations),
-    dynamodb: suiteDef('DynamoDb', dynamoTestEnvInit, dynamo.testResources.supportedOperations),
+    dynamodb: suiteDef('DynamoDb', dynamoTestEnvInit, dynamo.testResources),
     bigquery: suiteDef('BigQuery', bigqueryTestEnvInit, bigquery.testResources.supportedOperations),
     'google-sheet': suiteDef('Google-Sheet', googleSheetTestEnvInit, googleSheet.supportedOperations),
 }

--- a/libs/external-db-dynamodb/src/dynamo_capabilities.ts
+++ b/libs/external-db-dynamodb/src/dynamo_capabilities.ts
@@ -1,13 +1,12 @@
 import { AdapterOperators } from '@wix-velo/velo-external-db-commons'
 import { CollectionOperation, DataOperation, FieldType } from '@wix-velo/velo-external-db-types'
 
-const { query, count, queryReferenced, aggregate, } = DataOperation
 const { eq, ne, string_contains, string_begins, gt, gte, lt, lte, include } = AdapterOperators
 const UnsupportedCapabilities = [DataOperation.insertReferences, DataOperation.removeReferences, DataOperation.queryReferenced]
 
 
 export const ReadWriteOperations = Object.values(DataOperation).filter(op => !UnsupportedCapabilities.includes(op))
-export const ReadOnlyOperations = [query, count, queryReferenced, aggregate]
+
 export const FieldTypes = Object.values(FieldType)
 export const CollectionOperations = Object.values(CollectionOperation)
 export const ColumnsCapabilities = {

--- a/libs/external-db-dynamodb/src/dynamo_capabilities.ts
+++ b/libs/external-db-dynamodb/src/dynamo_capabilities.ts
@@ -1,0 +1,21 @@
+import { AdapterOperators } from '@wix-velo/velo-external-db-commons'
+import { CollectionOperation, DataOperation, FieldType } from '@wix-velo/velo-external-db-types'
+
+const { query, count, queryReferenced, aggregate, } = DataOperation
+const { eq, ne, string_contains, string_begins, gt, gte, lt, lte, include } = AdapterOperators
+const UnsupportedCapabilities = [DataOperation.insertReferences, DataOperation.removeReferences, DataOperation.queryReferenced]
+
+
+export const ReadWriteOperations = Object.values(DataOperation).filter(op => !UnsupportedCapabilities.includes(op))
+export const ReadOnlyOperations = [query, count, queryReferenced, aggregate]
+export const FieldTypes = Object.values(FieldType)
+export const CollectionOperations = Object.values(CollectionOperation)
+export const ColumnsCapabilities = {
+    text: { sortable: false, columnQueryOperators: [eq, ne, string_contains, string_begins, include, gt, gte, lt, lte] },
+    url: { sortable: false, columnQueryOperators: [eq, ne, string_contains, string_begins, include, gt, gte, lt, lte] },
+    number: { sortable: false, columnQueryOperators: [eq, ne, gt, gte, lt, lte, include] },
+    boolean: { sortable: false, columnQueryOperators: [eq] },
+    image: { sortable: false, columnQueryOperators: [] },
+    object: { sortable: false, columnQueryOperators: [eq, ne, string_contains, string_begins, include, gt, gte, lt, lte] },
+    datetime: { sortable: false, columnQueryOperators: [eq, ne, gt, gte, lt, lte] },
+}

--- a/libs/external-db-dynamodb/src/dynamo_data_provider.ts
+++ b/libs/external-db-dynamodb/src/dynamo_data_provider.ts
@@ -5,6 +5,7 @@ import { DynamoDB } from '@aws-sdk/client-dynamodb'
 import FilterParser from './sql_filter_transformer'
 import { IDataProvider, AdapterFilter as Filter, Item } from '@wix-velo/velo-external-db-types'
 import * as dynamoRequests from './dynamo_data_requests_utils'
+import { translateErrorCodes } from './sql_exception_translator'
 
 export default class DataProvider implements IDataProvider {
     filterParser: FilterParser
@@ -40,10 +41,13 @@ export default class DataProvider implements IDataProvider {
         return Count || 0
     }
 
-    async insert(collectionName: string, items: Item[]): Promise<number> {
+    async insert(collectionName: string, items: Item[], _fields?: any[], upsert: boolean = false): Promise<number> {
         validateTable(collectionName)
         await this.docClient
-                  .batchWrite(dynamoRequests.batchPutItemsCommand(collectionName, items.map(patchDateTime)))
+                  .transactWrite({
+                      TransactItems: items.map((item: Item) => dynamoRequests.insertSingleItemCommand(collectionName, patchDateTime(item), upsert))
+                  }).catch(e => translateErrorCodes(e, collectionName, {items}))
+
         return items.length
     }
 

--- a/libs/external-db-dynamodb/src/dynamo_data_provider.ts
+++ b/libs/external-db-dynamodb/src/dynamo_data_provider.ts
@@ -41,12 +41,12 @@ export default class DataProvider implements IDataProvider {
         return Count || 0
     }
 
-    async insert(collectionName: string, items: Item[], _fields?: any[], upsert: boolean = false): Promise<number> {
+    async insert(collectionName: string, items: Item[], _fields?: any[], upsert = false): Promise<number> {
         validateTable(collectionName)
         await this.docClient
                   .transactWrite({
                       TransactItems: items.map((item: Item) => dynamoRequests.insertSingleItemCommand(collectionName, patchDateTime(item), upsert))
-                  }).catch(e => translateErrorCodes(e, collectionName, {items}))
+                  }).catch(e => translateErrorCodes(e, collectionName, { items }))
 
         return items.length
     }

--- a/libs/external-db-dynamodb/src/dynamo_data_requests_utils.ts
+++ b/libs/external-db-dynamodb/src/dynamo_data_requests_utils.ts
@@ -1,4 +1,5 @@
-import { updateFieldsFor } from '@wix-velo/velo-external-db-commons' 
+import { BatchWriteCommandInput } from '@aws-sdk/lib-dynamodb'
+import { updateFieldsFor } from '@wix-velo/velo-external-db-commons'
 import { Item } from '@wix-velo/velo-external-db-types'
 import { isEmptyObject } from './dynamo_utils'
 import { DynamoParsedFilter } from './types'
@@ -9,7 +10,7 @@ export const findCommand = (collectionName: string, filter: DynamoParsedFilter, 
         delete filter.ProjectionExpression
     }
     return {
-        TableName: collectionName, 
+        TableName: collectionName,
         ...filter,
         Limit: limit
     }
@@ -17,7 +18,7 @@ export const findCommand = (collectionName: string, filter: DynamoParsedFilter, 
 
 export const countCommand = (collectionName: string, filter: DynamoParsedFilter) => {
     return {
-        TableName: collectionName, 
+        TableName: collectionName,
         ...filter,
         Select: 'COUNT'
     }
@@ -28,19 +29,9 @@ export const getAllIdsCommand = (collectionName: string) => ({
     AttributesToGet: ['_id']
 })
 
-export const batchPutItemsCommand = (collectionName: string, items: Item[]) => ({
-    RequestItems: {
-        [collectionName]: items.map(putSingleItemCommand)
-    }
-})
 
-export const putSingleItemCommand = (item: Item) => ({
-    PutRequest: {
-        Item: item
-    }
-})
 
-export const batchDeleteItemsCommand = (collectionName: string, itemIds: string[]) => ({
+export const batchDeleteItemsCommand = (collectionName: string, itemIds: string[]): BatchWriteCommandInput => ({
     RequestItems: {
         [collectionName]: itemIds.map(deleteSingleItemCommand)
         }
@@ -54,7 +45,24 @@ export const deleteSingleItemCommand = (id: string) => ({
     }
 })
 
-export const updateSingleItemCommand = (collectionName: string, item: Item) =>  {
+export const insertSingleItemCommand = (collectionName: string, item: Item, upsert: boolean) => {
+    const upsertCondition = upsert ? {} : {
+        ConditionExpression: "attribute_not_exists(#_id)",
+        ExpressionAttributeNames: {
+            "#_id": "_id"
+        }
+    }
+    
+    return {
+        Put: {
+            TableName: collectionName,
+            Item: item,
+            ...upsertCondition
+        }
+    }
+}
+
+export const updateSingleItemCommand = (collectionName: string, item: Item) => {
     const updateFields = updateFieldsFor(item)
     const updateExpression = `SET ${updateFields.map(f => `#${f} = :${f}`).join(', ')}`
     const expressionAttributeNames = updateFields.reduce((pv, cv) => ({ ...pv, [`#${cv}`]: cv }), {})

--- a/libs/external-db-dynamodb/src/dynamo_data_requests_utils.ts
+++ b/libs/external-db-dynamodb/src/dynamo_data_requests_utils.ts
@@ -47,9 +47,9 @@ export const deleteSingleItemCommand = (id: string) => ({
 
 export const insertSingleItemCommand = (collectionName: string, item: Item, upsert: boolean) => {
     const upsertCondition = upsert ? {} : {
-        ConditionExpression: "attribute_not_exists(#_id)",
+        ConditionExpression: 'attribute_not_exists(#_id)',
         ExpressionAttributeNames: {
-            "#_id": "_id"
+            '#_id': '_id'
         }
     }
     

--- a/libs/external-db-dynamodb/src/dynamo_schema_provider.ts
+++ b/libs/external-db-dynamodb/src/dynamo_schema_provider.ts
@@ -151,7 +151,7 @@ export default class SchemaProvider implements ISchemaProvider {
         const { Item } = await this.docClient
                                    .get(dynamoRequests.getCollectionFromSystemTableExpression(collectionName))
 
-        if (!Item && !toReturn ) throw new CollectionDoesNotExists('Collection does not exists')
+        if (!Item && !toReturn ) throw new CollectionDoesNotExists('Collection does not exists', collectionName)
         return Item
     }
 

--- a/libs/external-db-dynamodb/src/dynamo_schema_provider.ts
+++ b/libs/external-db-dynamodb/src/dynamo_schema_provider.ts
@@ -1,11 +1,11 @@
-import { SystemTable, validateTable, reformatFields } from './dynamo_utils'
+import { SystemTable, validateTable } from './dynamo_utils'
 import { translateErrorCodes } from './sql_exception_translator'
 import { SystemFields, validateSystemFields, errors, EmptyCapabilities } from '@wix-velo/velo-external-db-commons'
 import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
 import * as dynamoRequests from './dynamo_schema_requests_utils'
 import { DynamoDB } from '@aws-sdk/client-dynamodb'
 import { CollectionCapabilities, Encryption, InputField, ISchemaProvider, SchemaOperations, Table } from '@wix-velo/velo-external-db-types'
-import { CollectionOperations, ColumnsCapabilities, FieldTypes, ReadOnlyOperations, ReadWriteOperations } from './dynamo_capabilities'
+import { CollectionOperations, ColumnsCapabilities, FieldTypes, ReadWriteOperations } from './dynamo_capabilities'
 import { supportedOperations } from './supported_operations'
 const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist } = errors
 
@@ -27,7 +27,7 @@ export default class SchemaProvider implements ISchemaProvider {
         return Items ? Items.map((table: { [x:string]: any, tableName?: any, fields?: any }) => ({
             id: table.tableName,
             fields: [...SystemFields, ...table.fields].map(this.appendAdditionalRowDetails),
-            capabilities: this.collectionCapabilities(table.fields)
+            capabilities: this.collectionCapabilities()
         })) : []
     }
 
@@ -105,7 +105,7 @@ export default class SchemaProvider implements ISchemaProvider {
         return {
             id: collectionName,
             fields: [...SystemFields, ...collection.fields].map(this.appendAdditionalRowDetails),
-            capabilities: this.collectionCapabilities(collection.fields)
+            capabilities: this.collectionCapabilities()
         }
     }
 
@@ -171,7 +171,7 @@ export default class SchemaProvider implements ISchemaProvider {
         }
     }
 
-    private collectionCapabilities(fieldNames: string[]): CollectionCapabilities {
+    private collectionCapabilities(): CollectionCapabilities {
         return {
             dataOperations: ReadWriteOperations,
             fieldTypes: FieldTypes,

--- a/libs/external-db-dynamodb/src/dynamo_schema_provider.ts
+++ b/libs/external-db-dynamodb/src/dynamo_schema_provider.ts
@@ -73,7 +73,7 @@ export default class SchemaProvider implements ISchemaProvider {
         await validateSystemFields(column.name)
         
         const { fields } = await this.collectionDataFor(collectionName)
-        if (fields.find((f: { name: any }) => f.name === column.name)) {
+        if (fields.find((f) => f.name === column.name)) {
             throw new FieldAlreadyExists('Collection already has a field with the same name')
         }
 
@@ -88,7 +88,7 @@ export default class SchemaProvider implements ISchemaProvider {
 
         const { fields } = await this.collectionDataFor(collectionName)
 
-        if (!fields.some((f: { name: any }) => f.name === columnName)) {
+        if (!fields.some((f) => f.name === columnName)) {
             throw new FieldDoesNotExist('Collection does not contain a field with this name', collectionName, columnName)
         }
         await this.docClient
@@ -116,7 +116,7 @@ export default class SchemaProvider implements ISchemaProvider {
         
         const { fields } = await this.collectionDataFor(collectionName)
 
-        if (!fields.some((f: { name: any }) => f.name === column.name)) {
+        if (!fields.some((f) => f.name === column.name)) {
             throw new FieldDoesNotExist('Collection does not contain a field with this name', collectionName, column.name)
         }
         
@@ -146,13 +146,13 @@ export default class SchemaProvider implements ISchemaProvider {
                   .delete(dynamoRequests.deleteTableFromSystemTableExpression(collectionName))
     }
     
-    async collectionDataFor(collectionName: string, toReturn?: boolean | undefined): Promise<any> {
+    async collectionDataFor(collectionName: string, toReturn?: boolean | undefined) {
         validateTable(collectionName)
         const { Item } = await this.docClient
                                    .get(dynamoRequests.getCollectionFromSystemTableExpression(collectionName))
 
         if (!Item && !toReturn ) throw new CollectionDoesNotExists('Collection does not exists', collectionName)
-        return Item
+        return Item as { tableName: string, fields: { name: string, type: string, subtype?: string }[] }
     }
 
     async systemTableExists() {

--- a/libs/external-db-dynamodb/src/dynamo_schema_provider.ts
+++ b/libs/external-db-dynamodb/src/dynamo_schema_provider.ts
@@ -121,7 +121,7 @@ export default class SchemaProvider implements ISchemaProvider {
         }
         
         await this.docClient
-                    .update(dynamoRequests.updateColumnsExpression(collectionName, fields.map((f: { name: any }) => f.name === column.name ? column : f)))
+                    .update(dynamoRequests.updateColumnsExpression(collectionName, fields.map((f) => f.name === column.name ? column : f)))
                     
     }
 

--- a/libs/external-db-dynamodb/src/dynamo_schema_requests_utils.ts
+++ b/libs/external-db-dynamodb/src/dynamo_schema_requests_utils.ts
@@ -1,7 +1,8 @@
 
+import { InputField } from '@wix-velo/velo-external-db-types'
 import { SystemTable } from './dynamo_utils'
 
-export const removeColumnExpression = (collectionName: any, columns: any) => ({
+export const updateColumnsExpression = (collectionName: any, columns: any) => ({
     TableName: SystemTable,
     Key: {
         tableName: collectionName
@@ -29,6 +30,22 @@ export const addColumnExpression = (collectionName: any, column: any) => ({
             ':attrValue': [column]
         },
         ReturnValues: 'UPDATED_NEW'
+})
+
+export const changeColumnTypeExpression = (collectionName: string, column: InputField) => ({
+    TableName: SystemTable,
+    Key: {
+        tableName: collectionName
+    },
+    UpdateExpression: 'SET #attrName = list_append(list_append(:attrValue1, list_remove(#attrName, :attrValue2)), :attrValue3)',
+    ExpressionAttributeNames: {
+        '#attrName': 'fields'
+    },
+    ExpressionAttributeValues: {
+        ':attrValue1': [column],
+        ':attrValue2': column.name,
+        ':attrValue3': [column]
+    },
 })
 
 export const createTableExpression = (collectionName: any) => ({

--- a/libs/external-db-dynamodb/src/dynamo_utils.ts
+++ b/libs/external-db-dynamodb/src/dynamo_utils.ts
@@ -1,5 +1,4 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
-import { InputField, ResponseField } from '@wix-velo/velo-external-db-types'
 import { Counter } from './sql_filter_transformer'
 const { InvalidQuery } = errors
 

--- a/libs/external-db-dynamodb/src/dynamo_utils.ts
+++ b/libs/external-db-dynamodb/src/dynamo_utils.ts
@@ -38,5 +38,5 @@ export const canQuery = (filterExpr: { ExpressionAttributeNames: { [s: string]: 
 
 export const isEmptyObject = (obj: Record<string, unknown>) => Object.keys(obj).length === 0
 
-export const fieldNameWithCounter = (fieldName: string, counter: Counter) => `#${fieldName}${counter.nameCounter++}`
-export const attributeValueNameWithCounter = (fieldName: any, counter: Counter) => `:${fieldName}${counter.valueCounter++}`
+export const fieldNameWithCounter = (fieldName: string, counter: Counter) => `#${fieldName.split('.').join('.#').split('.').map(s => s.concat(`${counter.nameCounter++}`)).join('.')}`
+export const attributeValueNameWithCounter = (fieldName: any, counter: Counter) => `:${fieldName.split('.')[0]}${counter.valueCounter++}`

--- a/libs/external-db-dynamodb/src/dynamo_utils.ts
+++ b/libs/external-db-dynamodb/src/dynamo_utils.ts
@@ -28,14 +28,6 @@ export const patchFixDates = (record: { [x: string]: any }) => {
     return fixedRecord
 }
 
-
-export const reformatFields = (field: InputField): ResponseField => {
-    return {
-        field: field.name,
-        type: field.type,
-    }
-}
-
 export const patchCollectionKeys = () => (['_id'])
 
 export const canQuery = (filterExpr: { ExpressionAttributeNames: { [s: string]: unknown } | ArrayLike<unknown> }, collectionKeys: unknown[]) => {

--- a/libs/external-db-dynamodb/src/sql_exception_translator.ts
+++ b/libs/external-db-dynamodb/src/sql_exception_translator.ts
@@ -5,7 +5,7 @@ const { CollectionDoesNotExists, DbConnectionError } = errors
 export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string, metaData?: { items?: Item[] }) => {
     switch (err.name) {
         case 'ResourceNotFoundException':
-            return new CollectionDoesNotExists('Collection does not exists')
+            return new CollectionDoesNotExists('Collection does not exists', collectionName)
         case 'CredentialsProviderError':
             return new DbConnectionError('AWS_SECRET_ACCESS_KEY or AWS_ACCESS_KEY_ID are missing')
         case 'InvalidSignatureException':

--- a/libs/external-db-dynamodb/src/sql_exception_translator.ts
+++ b/libs/external-db-dynamodb/src/sql_exception_translator.ts
@@ -1,7 +1,8 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
+import { Item } from '@wix-velo/velo-external-db-types'
 const { CollectionDoesNotExists, DbConnectionError } = errors
 
-export const notThrowingTranslateErrorCodes = (err: any) => {
+export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string, metaData?: { items?: Item[] }) => {
     switch (err.name) {
         case 'ResourceNotFoundException':
             return new CollectionDoesNotExists('Collection does not exists')
@@ -9,6 +10,11 @@ export const notThrowingTranslateErrorCodes = (err: any) => {
             return new DbConnectionError('AWS_SECRET_ACCESS_KEY or AWS_ACCESS_KEY_ID are missing')
         case 'InvalidSignatureException':
             return new DbConnectionError('AWS_SECRET_ACCESS_KEY or AWS_ACCESS_KEY_ID are invalid')
+        case 'TransactionCanceledException':
+            if (err.message.includes('ConditionalCheckFailed')) {
+                const itemId = metaData?.items?.[err.CancellationReasons.findIndex((reason: any) => reason.Code === 'ConditionalCheckFailed')]._id
+                return new errors.ItemAlreadyExists('Item already exists', collectionName, itemId)
+            }
     }
 
     switch (err.message) {
@@ -21,7 +27,7 @@ export const notThrowingTranslateErrorCodes = (err: any) => {
     }
 }
 
-export const translateErrorCodes = (err: any) => {
-    throw notThrowingTranslateErrorCodes(err)
+export const translateErrorCodes = (err: any, collectionName?: string, metaData?: {items?: Item[]}) => {
+    throw notThrowingTranslateErrorCodes(err, collectionName, metaData)
     
 }

--- a/libs/external-db-dynamodb/src/sql_exception_translator.ts
+++ b/libs/external-db-dynamodb/src/sql_exception_translator.ts
@@ -1,6 +1,6 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
 import { Item } from '@wix-velo/velo-external-db-types'
-const { CollectionDoesNotExists, DbConnectionError } = errors
+const { CollectionDoesNotExists, DbConnectionError, ItemAlreadyExists } = errors
 
 export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string, metaData?: { items?: Item[] }) => {
     switch (err.name) {
@@ -13,7 +13,7 @@ export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string
         case 'TransactionCanceledException':
             if (err.message.includes('ConditionalCheckFailed')) {
                 const itemId = metaData?.items?.[err.CancellationReasons.findIndex((reason: any) => reason.Code === 'ConditionalCheckFailed')]._id
-                return new errors.ItemAlreadyExists('Item already exists', collectionName, itemId)
+                return new ItemAlreadyExists('Item already exists', collectionName, itemId)
             }
     }
 

--- a/libs/external-db-dynamodb/src/sql_filter_transformer.spec.ts
+++ b/libs/external-db-dynamodb/src/sql_filter_transformer.spec.ts
@@ -205,6 +205,29 @@ describe('Sql Parser', () => {
             })
         })
 
+        describe('handle queries on nested fields', () => {
+            test('correctly transform nested field query', () => {
+                const operator = ctx.filterWithoutInclude.operator
+                const filter = {
+                    operator,
+                    fieldName: `${ctx.fieldName}.${ctx.nestedFieldName}.${ctx.anotherNestedFieldName}`,
+                    value: ctx.filterWithoutInclude.value
+                }
+
+                expect( env.filterParser.parseFilter(filter) ).toEqual([{
+                    filterExpr: {
+                        FilterExpression: `#${ctx.fieldName}0.#${ctx.nestedFieldName}1.#${ctx.anotherNestedFieldName}2 ${env.filterParser.adapterOperatorToDynamoOperator(operator)} :${ctx.fieldName}0`,
+                        ExpressionAttributeNames: {
+                            [`#${ctx.fieldName}0`]: ctx.fieldName,
+                            [`#${ctx.nestedFieldName}1`]: ctx.nestedFieldName,
+                            [`#${ctx.anotherNestedFieldName}2`]: ctx.anotherNestedFieldName
+                        },
+                        ExpressionAttributeValues: { [`:${ctx.fieldName}0`]: ctx.filterWithoutInclude.value }
+                    }
+                }])
+            })
+        })
+
         describe('handle multi field operator', () => {
             each([
                 and, or
@@ -276,9 +299,13 @@ describe('Sql Parser', () => {
         fieldListValue: Uninitialized,
         anotherFieldName: Uninitialized,
         moreFieldName: Uninitialized,
+        nestedFieldName: Uninitialized,
+        anotherNestedFieldName: Uninitialized,
         filter: Uninitialized,
         idFilterNotEqual: Uninitialized,
         anotherFilter: Uninitialized,
+        filterWithoutInclude: Uninitialized,
+
     }
 
 
@@ -292,6 +319,8 @@ describe('Sql Parser', () => {
         ctx.fieldName = chance.word()
         ctx.anotherFieldName = chance.word()
         ctx.moreFieldName = chance.word()
+        ctx.nestedFieldName = chance.word()
+        ctx.anotherNestedFieldName = chance.word()
 
         ctx.fieldValue = chance.word()
         ctx.fieldListValue = [chance.word(), chance.word(), chance.word(), chance.word(), chance.word()]
@@ -299,6 +328,7 @@ describe('Sql Parser', () => {
         ctx.filter = gen.randomWrappedFilter()
         ctx.idFilterNotEqual = idFilter({ withoutEqual: true })
         ctx.anotherFilter = gen.randomWrappedFilter()
+        ctx.filterWithoutInclude = gen.randomDomainFilterWithoutInclude()
     })
 
     beforeAll(function() {

--- a/libs/external-db-dynamodb/src/sql_filter_transformer.ts
+++ b/libs/external-db-dynamodb/src/sql_filter_transformer.ts
@@ -65,7 +65,25 @@ export default class FilterParser {
         }
         
         const expressionAttributeName = attributeNameWithCounter(fieldName, counter)
-        
+       
+        if (this.isNestedField(fieldName)) {
+            console.log('HERE')
+            
+            const expressionAttributeValue = attributeValueNameWithCounter(fieldName, counter)
+            return [{
+                filterExpr: {
+                    FilterExpression: `${expressionAttributeName} ${this.adapterOperatorToDynamoOperator(operator)} ${expressionAttributeValue}`,
+                    ExpressionAttributeNames: expressionAttributeName.split('.').reduce((pV, cV) => ({
+                        ...pV,
+                        [cV]: cV.slice(1, cV.length - 1)
+                    }), {}),
+                    ExpressionAttributeValues: {
+                        [expressionAttributeValue]: this.valueForOperator(value, operator)
+                    }
+                }
+            }]
+        }
+
         if (this.isSingleFieldOperator(operator)) {
             const expressionAttributeValue = attributeValueNameWithCounter(fieldName, counter)
             return [{
@@ -80,7 +98,7 @@ export default class FilterParser {
                 }
             }]
         }
-
+        
         if (this.isSingleFieldStringOperator(operator)) {
             const expressionAttributeValue = attributeValueNameWithCounter(fieldName, counter)
             return [{
@@ -139,6 +157,10 @@ export default class FilterParser {
         }
 
         return value
+    }
+
+    isNestedField(fieldName: string) {
+        return fieldName.includes('.')
     }
 
     adapterOperatorToDynamoOperator(operator: any) {

--- a/libs/external-db-dynamodb/src/sql_filter_transformer.ts
+++ b/libs/external-db-dynamodb/src/sql_filter_transformer.ts
@@ -67,8 +67,6 @@ export default class FilterParser {
         const expressionAttributeName = attributeNameWithCounter(fieldName, counter)
        
         if (this.isNestedField(fieldName)) {
-            console.log('HERE')
-            
             const expressionAttributeValue = attributeValueNameWithCounter(fieldName, counter)
             return [{
                 filterExpr: {

--- a/libs/external-db-dynamodb/src/supported_operations.ts
+++ b/libs/external-db-dynamodb/src/supported_operations.ts
@@ -2,7 +2,6 @@ import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
 
 const notSupportedOperations = [
-    SchemaOperations.QueryNestedFields,
     SchemaOperations.FindWithSort,
     SchemaOperations.Aggregate,
     SchemaOperations.StartWithCaseInsensitive,

--- a/libs/external-db-dynamodb/src/supported_operations.ts
+++ b/libs/external-db-dynamodb/src/supported_operations.ts
@@ -8,7 +8,8 @@ const notSupportedOperations = [
     SchemaOperations.StartWithCaseInsensitive,
     SchemaOperations.FindObject,
     SchemaOperations.IncludeOperator,
-    SchemaOperations.Matches
+    SchemaOperations.Matches,
+    SchemaOperations.NonAtomicBulkInsert
 ]
 
 

--- a/libs/external-db-dynamodb/src/supported_operations.ts
+++ b/libs/external-db-dynamodb/src/supported_operations.ts
@@ -1,4 +1,16 @@
+import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
-const { List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject, IncludeOperator, FilterByEveryField } = SchemaOperations
 
-export const supportedOperations =  [ List, ListHeaders, Create, Drop, AddColumn, RemoveColumn, Describe, BulkDelete, Truncate, DeleteImmediately, UpdateImmediately, Projection, StartWithCaseSensitive, NotOperator, FindObject, IncludeOperator, FilterByEveryField ]
+const notSupportedOperations = [
+    SchemaOperations.QueryNestedFields,
+    SchemaOperations.FindWithSort,
+    SchemaOperations.Aggregate,
+    SchemaOperations.StartWithCaseInsensitive,
+    SchemaOperations.FindObject,
+    SchemaOperations.IncludeOperator,
+    SchemaOperations.Matches
+]
+
+
+
+export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))

--- a/libs/external-db-dynamodb/tests/e2e-testkit/dynamodb_resources.ts
+++ b/libs/external-db-dynamodb/tests/e2e-testkit/dynamodb_resources.ts
@@ -1,6 +1,7 @@
 import * as compose from 'docker-compose'
 import init from '../../src/connection_provider'
 export { supportedOperations } from '../../src/supported_operations'
+export * as capabilities from '../../src/dynamo_capabilities'
 
 export const connection = async() => {
     const { connection, schemaProvider, cleanup } = init(connectionConfig(), accessOptions())

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:full-image": "nx run velo-external-db:build-image ",
     "lint": "eslint --cache ./",
     "lint:fix": "eslint --cache --fix ./",
-    "test": "npm run test:core; npm run test:mysql; npm run test:postgres; npm run test:mssql; npm run test:spanner; npm run test:mongo;",
+    "test": "npm run test:core; npm run test:mysql; npm run test:postgres; npm run test:mssql; npm run test:spanner; npm run test:mongo; npm run test:dynamodb",
     "test:core": "nx run-many --skip-nx-cache --target=test --projects=@wix-velo/external-db-config,@wix-velo/velo-external-db-core,@wix-velo/external-db-security",
     "test:postgres": "TEST_ENGINE=postgres nx run-many --skip-nx-cache --target=test --projects=@wix-velo/external-db-postgres,velo-external-db",
     "test:postgres13": "npm run test:postgres",

--- a/workspace.json
+++ b/workspace.json
@@ -6,6 +6,7 @@
     "@wix-velo/external-db-mysql": "libs/external-db-mysql",
     "@wix-velo/external-db-mssql": "libs/external-db-mssql",
     "@wix-velo/external-db-spanner": "libs/external-db-spanner",
+    "@wix-velo/external-db-dynamodb": "libs/external-db-dynamodb",
     "@wix-velo/external-db-security": "libs/external-db-security",
     "@wix-velo/test-commons": "libs/test-commons",
     "@wix-velo/velo-external-db-commons": "libs/velo-external-db-commons",


### PR DESCRIPTION
apps: 
- [x] remove comment from [factory](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/src/storage/factory.ts) 
- [x] remove comment from [e2e.db.setup](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/env/env.db.setup.js)
- [x] remove comment from [e2e.db.teardown](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/env/env.db.teardown.js)
- [x] in [e2e_resources](https://github.com/wix/velo-external-db/blob/managed-adapter/apps/velo-external-db/test/resources/e2e_resources.ts) replace `createApp` with `createAppWithWixDataBaseUrl`
- [x] in provider_resources, replace `<impl>.testResources.supportedOperations` with `<impl>.testResources`

Current implementation changes: 
  
  Schema:

  - [x] create [capabilities file](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_capabilities.ts)
  - [x] change [schemas list](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L28-L33) format.
  - [x] change [describe collection](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L79-L93) format.
  - [x] implement [change column type](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_schema_provider.ts#L67-L71) method.
  - [x] change [default precision](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_schema_translator.ts#L128) to be (15,2) - if relevant.
  
Data: 

- [x] support [upsert](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_data_provider.ts#L41-L50).
- [x] add sort, skip, limit in [aggregate](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/mysql_data_provider.ts#L77-L87) function.
- [x] support querying by nested fields (+sql_filter_transformer tests).

Error handling: 

- [x] return `collectionName` with each error code ([sql_exception_translator](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts)).
- [x] on field [doesn't exist](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L21), return the field name.
- [x] on field [already exist](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L23), return the field name.
- [x] on item [already exists](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/src/sql_exception_translator.ts#L35), return the duplicated _id

e2e: 
- [x] export capabilities from [implementation_resources](https://github.com/wix/velo-external-db/blob/managed-adapter/libs/external-db-mysql/tests/e2e-testkit/mysql_resources.ts#L6)

general: 

- [x] in [workspace](https://github.com/wix/velo-external-db/blob/managed-adapter/workspace.json#L5), add the lib
- [x] in [package.json - test script](https://github.com/wix/velo-external-db/blob/managed-adapter/package.json#L10), test the current implementation too.
- [x] in [main.yml](https://github.com/wix/velo-external-db/blob/managed-adapter/.github/workflows/main.yml#L40-L42), add the current implementation.