### PR TITLE
get port as param or env

### DIFF
--- a/apps/velo-external-db/src/app.ts
+++ b/apps/velo-external-db/src/app.ts
@@ -30,11 +30,13 @@ const initConnector = async(hooks?: Hooks) => {
     return { externalDbRouter, cleanup: async() => await cleanup(), schemaProvider: providers.schemaProvider }
 }
 
-export const createApp = async() => {
+export const createApp = async(options?: { port?: string }) => {
+    const port = process.env.PORT || options?.port || 8080
     const app = express()
     const initConnectorResponse = await initConnector()
     app.use(initConnectorResponse.externalDbRouter.router)
-    const server = app.listen(8080, () => console.log('Connector listening on port 8080'))
+
+    const server = app.listen(port, () => console.log(`Connector listening on port ${port}`))
 
     return { server, ...initConnectorResponse, reload: () => initConnector() }
 }

--- a/apps/velo-external-db/test/e2e/app.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app.e2e.spec.ts
@@ -3,15 +3,24 @@ import { initApp, teardownApp, dbTeardown, setupDb, currentDbImplementationName,
 import { givenHideAppInfoEnvIsTrue } from '../drivers/app_info_config_test_support'
 
 const axios = require('axios').create({
-    baseURL: 'http://localhost:8080'
+    baseURL: 'http://localhost:3000'
 })
 
 describe(`Velo External DB: ${currentDbImplementationName()}`,  () => {
     beforeAll(async() => {
+        process.env.PORT = '3000'
         await setupDb()
-
+        
+        process.env.PORT = '3000'
+        console.log({ port: process.env.PORT })
+        
         await initApp()
+        console.log({ port2: process.env.PORT })
     }, 20000)
+
+    beforeEach(async() => {
+        process.env.PORT = '3000'
+    })
 
     afterAll(async() => await dbTeardown(), 20000)
 
@@ -32,6 +41,9 @@ describe(`Velo External DB: ${currentDbImplementationName()}`,  () => {
         })
     })
 
-    afterAll(async() => await teardownApp())
+    afterAll(async() => {
+        await teardownApp()
+        delete process.env.PORT
+    })
 
 })


### PR DESCRIPTION
in managed-adapter PR this line:
`const port = process.env.PORT || options?.port || 8080`
will become 
`const port = options?.port || 8080`

the process.env.PORT will be passed from `main.ts` and the relevant tests will pass the options object with the port,
didn't want to implement it in this PR to avoid too many conflicts, will implement it in managed-adapter