### PR TITLE
Fix request context

### DIFF
--- a/libs/velo-external-db-core/src/data_hooks_utils.spec.ts
+++ b/libs/velo-external-db-core/src/data_hooks_utils.spec.ts
@@ -2,7 +2,7 @@ import each from 'jest-each'
 import * as Chance from 'chance'
 import { Uninitialized } from '@wix-velo/test-commons'
 import { randomBodyWith } from '../test/gen'
-import { DataHooksForAction, dataPayloadFor, DataActions } from './data_hooks_utils'
+import { DataHooksForAction, dataPayloadFor, DataActions, requestContextFor } from './data_hooks_utils'
 import { DataOperation } from '@wix-velo/velo-external-db-types'
 
 const { query: Query, insert: Insert, update: Update, remove: Remove, count: Count, aggregate: Aggregate } = DataOperation
@@ -109,6 +109,16 @@ describe('Hooks Utils', () => {
         })
     })
 
+    describe('requestContextFor', () => {
+        test('should return request context object', () => {
+            expect(requestContextFor(ctx.randomOperation, ctx.bodyWithAllProps, { metaSiteId: ctx.metaSiteId }))
+                .toEqual({
+                    metaSiteId: ctx.metaSiteId,
+                    collectionIds: [ctx.collectionId],
+                    operation: ctx.randomOperation,
+                })
+        })
+    })
 
     const ctx = {
         filter: Uninitialized,
@@ -128,7 +138,9 @@ describe('Hooks Utils', () => {
         overwriteExisting: Uninitialized,
         bodyWithAllProps: Uninitialized,
         cursorPaging: Uninitialized,
-        initialFilter: Uninitialized
+        initialFilter: Uninitialized,
+        randomOperation: Uninitialized,
+        metaSiteId: Uninitialized,
     }
 
     beforeEach(() => {
@@ -152,6 +164,7 @@ describe('Hooks Utils', () => {
         ctx.bodyWithAllProps = randomBodyWith({
             ...ctx
         })
-
+        ctx.randomOperation = chance.pickone([Query, Insert, Update, Remove, Count, Aggregate])
+        ctx.metaSiteId = chance.word()
     })
 })

--- a/libs/velo-external-db-core/src/data_hooks_utils.ts
+++ b/libs/velo-external-db-core/src/data_hooks_utils.ts
@@ -107,11 +107,8 @@ export const dataPayloadFor = (operation: DataOperation, body: any) => {
     }
 }
 
-export const requestContextFor = (operation: any, body: any): RequestContext => ({ 
+export const requestContextFor = (operation: any, body: any, { metaSiteId }: Record<string, any>): RequestContext => ({ 
     operation, 
-    collectionId: body.collectionId, 
-    instanceId: body.requestContext.instanceId,
-    memberId: body.requestContext.memberId,
-    role: body.requestContext.role,
-    settings: body.requestContext.settings
+    collectionIds: body.collectionIds || [body.collectionId],
+    metaSiteId
 })

--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -140,7 +140,7 @@ export const createRouter = () => {
     router.post('/data/query', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collectionId, query, omitTotalCount } = await executeDataHooksFor(DataActions.BeforeQuery, dataPayloadFor(Query, req.body), requestContextFor(Query, req.body), customContext) as dataSource.QueryRequest
+            const { collectionId, query, omitTotalCount } = await executeDataHooksFor(DataActions.BeforeQuery, dataPayloadFor(Query, req.body), requestContextFor(Query, req.body, res.locals), customContext) as dataSource.QueryRequest
 
             const offset = query.paging ? query.paging.offset : 0
             const limit = query.paging ? query.paging.limit : 50
@@ -155,7 +155,7 @@ export const createRouter = () => {
                 omitTotalCount
             )
 
-            const dataAfterAction = await executeDataHooksFor(DataActions.AfterQuery, data, requestContextFor(Query, req.body), customContext)
+            const dataAfterAction = await executeDataHooksFor(DataActions.AfterQuery, data, requestContextFor(Query, req.body, res.locals), customContext)
             const responseParts = dataAfterAction.items.map(dataSource.QueryResponsePart.item)
 
             const metadata = dataSource.QueryResponsePart.pagingMetadata(responseParts.length, offset, dataAfterAction.totalCount)
@@ -169,14 +169,14 @@ export const createRouter = () => {
     router.post('/data/count', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collectionId, filter } = await executeDataHooksFor(DataActions.BeforeCount, dataPayloadFor(Count, req.body), requestContextFor(Count, req.body), customContext) as dataSource.CountRequest
+            const { collectionId, filter } = await executeDataHooksFor(DataActions.BeforeCount, dataPayloadFor(Count, req.body), requestContextFor(Count, req.body, res.locals), customContext) as dataSource.CountRequest
 
             const data = await schemaAwareDataService.count(
                 collectionId,
                 filterTransformer.transform(filter),
             )
 
-            const dataAfterAction = await executeDataHooksFor(DataActions.AfterCount, data, requestContextFor(Count, req.body), customContext)
+            const dataAfterAction = await executeDataHooksFor(DataActions.AfterCount, data, requestContextFor(Count, req.body, res.locals), customContext)
 
             const response = {
                 totalCount: dataAfterAction.totalCount
@@ -191,13 +191,13 @@ export const createRouter = () => {
     router.post('/data/insert', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collectionId, items, overwriteExisting } = await executeDataHooksFor(DataActions.BeforeInsert, dataPayloadFor(Insert, req.body), requestContextFor(Insert, req.body), customContext) as dataSource.InsertRequest
+            const { collectionId, items, overwriteExisting } = await executeDataHooksFor(DataActions.BeforeInsert, dataPayloadFor(Insert, req.body), requestContextFor(Insert, req.body, res.locals), customContext) as dataSource.InsertRequest
 
             const data = overwriteExisting ?
                             await schemaAwareDataService.bulkUpsert(collectionId, items) :
                             await schemaAwareDataService.bulkInsert(collectionId, items)
 
-            const dataAfterAction = await executeDataHooksFor(DataActions.AfterInsert, data, requestContextFor(Insert, req.body), customContext)
+            const dataAfterAction = await executeDataHooksFor(DataActions.AfterInsert, data, requestContextFor(Insert, req.body, res.locals), customContext)
             const responseParts = dataAfterAction.items.map(dataSource.InsertResponsePart.item)
 
             streamCollection(responseParts, res)
@@ -210,11 +210,11 @@ export const createRouter = () => {
         
         try {
             const customContext = {}
-            const { collectionId, items } = await executeDataHooksFor(DataActions.BeforeUpdate, dataPayloadFor(Update, req.body), requestContextFor(Update, req.body), customContext) as dataSource.UpdateRequest
+            const { collectionId, items } = await executeDataHooksFor(DataActions.BeforeUpdate, dataPayloadFor(Update, req.body), requestContextFor(Update, req.body, res.locals), customContext) as dataSource.UpdateRequest
 
             const data = await schemaAwareDataService.bulkUpdate(collectionId, items)
 
-            const dataAfterAction = await executeDataHooksFor(DataActions.AfterUpdate, data, requestContextFor(Update, req.body), customContext)
+            const dataAfterAction = await executeDataHooksFor(DataActions.AfterUpdate, data, requestContextFor(Update, req.body, res.locals), customContext)
 
             const responseParts = dataAfterAction.items.map(dataSource.UpdateResponsePart.item)
 
@@ -227,13 +227,13 @@ export const createRouter = () => {
     router.post('/data/remove', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collectionId, itemIds } = await executeDataHooksFor(DataActions.BeforeRemove, dataPayloadFor(Remove, req.body), requestContextFor(Remove, req.body), customContext) as dataSource.RemoveRequest
+            const { collectionId, itemIds } = await executeDataHooksFor(DataActions.BeforeRemove, dataPayloadFor(Remove, req.body), requestContextFor(Remove, req.body, res.locals), customContext) as dataSource.RemoveRequest
 
             const objectsBeforeRemove = await getItemsOneByOne(collectionId, itemIds)
 
             await schemaAwareDataService.bulkDelete(collectionId, itemIds)
 
-            const dataAfterAction = await executeDataHooksFor(DataActions.AfterRemove, { items: objectsBeforeRemove }, requestContextFor(Remove, req.body), customContext)
+            const dataAfterAction = await executeDataHooksFor(DataActions.AfterRemove, { items: objectsBeforeRemove }, requestContextFor(Remove, req.body, res.locals), customContext)
 
             const responseParts = dataAfterAction.items.map(dataSource.RemoveResponsePart.item)
 
@@ -246,14 +246,14 @@ export const createRouter = () => {
     router.post('/data/aggregate', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collectionId, initialFilter, group, finalFilter, sort, paging } = await executeDataHooksFor(DataActions.BeforeAggregate, dataPayloadFor(Aggregate, req.body), requestContextFor(Aggregate, req.body), customContext) as dataSource.AggregateRequest
+            const { collectionId, initialFilter, group, finalFilter, sort, paging } = await executeDataHooksFor(DataActions.BeforeAggregate, dataPayloadFor(Aggregate, req.body), requestContextFor(Aggregate, req.body, res.locals), customContext) as dataSource.AggregateRequest
 
             const offset = paging ? paging.offset : 0
             const limit = paging ? paging.limit : 50
 
             const data = await schemaAwareDataService.aggregate(collectionId, filterTransformer.transform(initialFilter), aggregationTransformer.transform({ group, finalFilter }), filterTransformer.transformSort(sort), offset, limit)
 
-            const dataAfterAction = await executeDataHooksFor(DataActions.AfterAggregate, data, requestContextFor(Aggregate, req.body), customContext)
+            const dataAfterAction = await executeDataHooksFor(DataActions.AfterAggregate, data, requestContextFor(Aggregate, req.body, res.locals), customContext)
 
             const responseParts = dataAfterAction.items.map(dataSource.AggregateResponsePart.item)
             const metadata = dataSource.AggregateResponsePart.pagingMetadata((dataAfterAction.items as Item[]).length, offset, data.totalCount)
@@ -267,9 +267,9 @@ export const createRouter = () => {
     router.post('/data/truncate', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collectionId } = await executeDataHooksFor(DataActions.BeforeTruncate, dataPayloadFor(Truncate, req.body), requestContextFor(Truncate, req.body), customContext) as dataSource.TruncateRequest
+            const { collectionId } = await executeDataHooksFor(DataActions.BeforeTruncate, dataPayloadFor(Truncate, req.body), requestContextFor(Truncate, req.body, res.locals), customContext) as dataSource.TruncateRequest
             await schemaAwareDataService.truncate(collectionId)
-            await executeDataHooksFor(DataActions.AfterTruncate, {}, requestContextFor(Truncate, req.body), customContext)
+            await executeDataHooksFor(DataActions.AfterTruncate, {}, requestContextFor(Truncate, req.body, res.locals), customContext)
             res.json({} as dataSource.TruncateResponse)
         } catch (e) {
             next(e)
@@ -282,9 +282,11 @@ export const createRouter = () => {
     router.post('/collections/get', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collectionIds } = await executeSchemaHooksFor(SchemaActions.BeforeGet, schemaPayloadFor(Get, req.body), requestContextFor(Get, req.body), customContext) as schemaSource.ListCollectionsRequest
+            const { collectionIds } = await executeSchemaHooksFor(SchemaActions.BeforeGet, schemaPayloadFor(Get, req.body), requestContextFor(Get, req.body, res.locals), customContext) as schemaSource.ListCollectionsRequest
+            console.log('requestContext', requestContextFor(Get, req.body, res.locals))
+            
             const data = await schemaService.list(collectionIds)
-            const dataAfterAction = await executeSchemaHooksFor(SchemaActions.AfterGet, data, requestContextFor(Get, req.body), customContext)
+            const dataAfterAction = await executeSchemaHooksFor(SchemaActions.AfterGet, data, requestContextFor(Get, req.body, res.locals), customContext)
             const responseParts = dataAfterAction.collections.map(collection => ({ collection })) 
             streamCollection(responseParts, res)
         } catch (e) {
@@ -296,9 +298,9 @@ export const createRouter = () => {
     router.post('/collections/create', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collection } = await executeSchemaHooksFor(SchemaActions.BeforeCreate, schemaPayloadFor(Create, req.body), requestContextFor(Create, req.body), customContext) as schemaSource.CreateCollectionRequest
+            const { collection } = await executeSchemaHooksFor(SchemaActions.BeforeCreate, schemaPayloadFor(Create, req.body), requestContextFor(Create, req.body, res.locals), customContext) as schemaSource.CreateCollectionRequest
             const data = await schemaService.create(collection)
-            const dataAfterAction = await executeSchemaHooksFor(SchemaActions.AfterCreate, data, requestContextFor(Create, req.body), customContext)
+            const dataAfterAction = await executeSchemaHooksFor(SchemaActions.AfterCreate, data, requestContextFor(Create, req.body, res.locals), customContext)
             res.json(dataAfterAction)
         } catch (e) {
             next(e)
@@ -308,9 +310,9 @@ export const createRouter = () => {
     router.post('/collections/update', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collection } = await executeSchemaHooksFor(SchemaActions.BeforeUpdate, schemaPayloadFor(UpdateSchema, req.body), requestContextFor(UpdateSchema, req.body), customContext) as schemaSource.UpdateCollectionRequest
+            const { collection } = await executeSchemaHooksFor(SchemaActions.BeforeUpdate, schemaPayloadFor(UpdateSchema, req.body), requestContextFor(UpdateSchema, req.body, res.locals), customContext) as schemaSource.UpdateCollectionRequest
             const data = await schemaService.update(collection)
-            const dataAfterAction = await executeSchemaHooksFor(SchemaActions.AfterUpdate, data, requestContextFor(UpdateSchema, req.body), customContext)
+            const dataAfterAction = await executeSchemaHooksFor(SchemaActions.AfterUpdate, data, requestContextFor(UpdateSchema, req.body, res.locals), customContext)
             res.json(dataAfterAction)
         } catch (e) {
             next(e)
@@ -320,9 +322,9 @@ export const createRouter = () => {
     router.post('/collections/delete', async(req, res, next) => {
         try {
             const customContext = {}
-            const { collectionId } = await executeSchemaHooksFor(SchemaActions.BeforeDelete, schemaPayloadFor(Delete, req.body), requestContextFor(Delete, req.body), customContext) as schemaSource.DeleteCollectionRequest
+            const { collectionId } = await executeSchemaHooksFor(SchemaActions.BeforeDelete, schemaPayloadFor(Delete, req.body), requestContextFor(Delete, req.body, res.locals), customContext) as schemaSource.DeleteCollectionRequest
             const data = await schemaService.delete(collectionId)
-            const dataAfterAction = await executeSchemaHooksFor(SchemaActions.AfterDelete, data, requestContextFor(Delete, req.body), customContext)
+            const dataAfterAction = await executeSchemaHooksFor(SchemaActions.AfterDelete, data, requestContextFor(Delete, req.body, res.locals), customContext)
             res.json(dataAfterAction)
         } catch (e) {
             next(e)

--- a/libs/velo-external-db-core/src/types.ts
+++ b/libs/velo-external-db-core/src/types.ts
@@ -32,11 +32,9 @@ export interface SchemaPayload {
 
 export interface RequestContext {
     operation: DataOperation | CollectionOperationSPI
-    collectionId: string;
-    instanceId?: string;
-    role?: string;
-    memberId?: string;
-    settings?: any;
+    collectionId?: string;
+    collectionIds?: string[];
+    metaSiteId: string;
 }
 
 export interface ServiceContext {

--- a/libs/velo-external-db-core/src/web/jwt-auth-middleware.spec.ts
+++ b/libs/velo-external-db-core/src/web/jwt-auth-middleware.spec.ts
@@ -17,7 +17,7 @@ describe('JWT Auth Middleware', () => {
 
     test('should authorize when JWT valid', async() => {
         const token = signedToken({ iss: TOKEN_ISSUER, siteId: ctx.metasite, aud: ctx.externalDatabaseId }, ctx.keyId)
-        await env.auth(driver.requestBodyWith(Uninitialized, Uninitialized, `Bearer ${token}`), null, ctx.next)
+        await env.auth(driver.requestBodyWith(Uninitialized, Uninitialized, `Bearer ${token}`), ctx.res, ctx.next)
 
         expectAuthorized()
     })
@@ -25,7 +25,7 @@ describe('JWT Auth Middleware', () => {
     test('should authorize when JWT valid, only with second public key', async() => {
         const token = signedToken({ iss: TOKEN_ISSUER, siteId: ctx.metasite, aud: ctx.externalDatabaseId }, ctx.keyId)
         env.auth = new JwtAuthenticator(ctx.externalDatabaseId, ctx.allowedMetasites, ctx.otherWixDataMock).authorizeJwt()
-        await env.auth(driver.requestBodyWith(Uninitialized, Uninitialized, `Bearer ${token}`), null, ctx.next)
+        await env.auth(driver.requestBodyWith(Uninitialized, Uninitialized, `Bearer ${token}`), ctx.res, ctx.next)
         expectAuthorized()
     })
 
@@ -99,7 +99,8 @@ describe('JWT Auth Middleware', () => {
         allowedMetasites: Uninitialized,
         next: Uninitialized,
         keyId: Uninitialized,
-        otherWixDataMock: Uninitialized
+        otherWixDataMock: Uninitialized,
+        res: Uninitialized,
     }
 
     const env = {
@@ -127,6 +128,7 @@ describe('JWT Auth Middleware', () => {
         const otherPublicKeys: PublicKeyMap = {}
         otherPublicKeys[otherKeyId] = authConfig.otherAuthPublicKey
         ctx.otherWixDataMock = new WixDataFacadeMock(otherPublicKeys, publicKeys)
+        ctx.res = { locals: {} }
         env.auth = new JwtAuthenticator(ctx.externalDatabaseId, ctx.allowedMetasites, new WixDataFacadeMock(publicKeys)).authorizeJwt()
     })
 })

--- a/libs/velo-external-db-core/src/web/jwt-auth-middleware.ts
+++ b/libs/velo-external-db-core/src/web/jwt-auth-middleware.ts
@@ -24,7 +24,7 @@ export class JwtAuthenticator {
             try {
                 const token = this.extractToken(req.header('authorization'))
                 this.publicKeys = this.publicKeys ?? await this.wixDataFacade.getPublicKeys(this.externalDatabaseId)
-                await this.verify(token)
+                res.locals['metaSiteId'] = await this.verify(token)
             } catch (err: any) {
                 console.error('Authorization failed: ' + err.message)
                 next(new UnauthorizedError('You are not authorized'))
@@ -68,6 +68,7 @@ export class JwtAuthenticator {
         if (siteId === undefined || !this.allowedMetasites.includes(siteId)) {
             throw new UnauthorizedError(`Unauthorized: ${siteId ? `site not allowed ${siteId}` : 'no siteId'}`)
         }
+        return siteId
     }
 
     private extractToken(header: string | undefined) {


### PR DESCRIPTION
fix #436.

Using `res.locals` to pass the `metaSiteId` from the middleware to all routes, I don't really like this solution, but I find it better than call to `authorize` twice and put that call in every route, if you have better idea feel free to suggest.