### PR TITLE
Add schema types to payload

### DIFF
--- a/libs/velo-external-db-core/package.json
+++ b/libs/velo-external-db-core/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@wix-velo/velo-external-db-core",
-  "version": "1.2.4",
+  "version": "1.2.5",
 	"type": "commonjs"
 }

--- a/libs/velo-external-db-core/src/types.ts
+++ b/libs/velo-external-db-core/src/types.ts
@@ -30,6 +30,8 @@ export interface Payload {
     itemIds?: string[];
     schemas?: AsWixSchema[];
     collectionName?: string;
+    column?: InputField;
+    columnName?: string;
 }
 
 enum ReadOperation {

--- a/libs/velo-external-db-core/src/types.ts
+++ b/libs/velo-external-db-core/src/types.ts
@@ -28,6 +28,8 @@ export interface Payload {
     items?: Item[];
     itemId?: string;
     itemIds?: string[];
+    schemas?: AsWixSchema[];
+    collectionName?: string;
 }
 
 enum ReadOperation {


### PR DESCRIPTION
The payload interface contains only data types, in V3 `schemaPayload` and `dataPayload` would be separate.