### PR TITLE
fix dynamo build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,7 @@ jobs:
                    "mssql", "mssql17",
                    "mongo", "mongo4",
                    "firestore",
-                  #  TODO: fix dynamodbs tests
-                  #  "dynamodb",
+                   "dynamodb",
                    "google-sheets"
                    ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ schemas.json
 packages/.DS_Store
 .DS_Store
 .eslintcache
+.infracost
 
 # dependencies
 node_modules

--- a/apps/velo-external-db/test/resources/docker-compose.yaml
+++ b/apps/velo-external-db/test/resources/docker-compose.yaml
@@ -188,8 +188,8 @@ services:
       - 8000:8000
     environment:
       AWS_REGION: us-west-2
-      AWS_ACCESS_KEY_ID: TEST_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY: TEST_SECRET_ACCESS_KEY
+      AWS_ACCESS_KEY_ID: TestAccessKeyId
+      AWS_SECRET_ACCESS_KEY: TestSecretAccessKey
     networks:
       - backend
 

--- a/libs/external-db-dynamodb/tests/drivers/db_operations_test_support.ts
+++ b/libs/external-db-dynamodb/tests/drivers/db_operations_test_support.ts
@@ -40,6 +40,6 @@ export const misconfiguredDbOperationOptions = () => ([   ['pool connection with
                                         ])
 
 export const resetEnv = () => {
-    process.env['AWS_SECRET_ACCESS_KEY'] = 'TEST_SECRET_ACCESS_KEY'
-    process.env['AWS_ACCESS_KEY_ID'] = 'TEST_ACCESS_KEY_ID'
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'TestSecretAccessKey'
+    process.env['AWS_ACCESS_KEY_ID'] = 'TestAccessKeyId'
 }

--- a/libs/external-db-dynamodb/tests/e2e-testkit/docker-compose.yaml
+++ b/libs/external-db-dynamodb/tests/e2e-testkit/docker-compose.yaml
@@ -7,8 +7,8 @@ services:
       - 8000:8000
     environment:
       AWS_REGION: us-west-2
-      AWS_ACCESS_KEY_ID: TEST_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY: TEST_SECRET_ACCESS_KEY
+      AWS_ACCESS_KEY_ID: TestAccessKeyId
+      AWS_SECRET_ACCESS_KEY: TestSecretAccessKey
     networks:
       - backend
   

--- a/libs/external-db-dynamodb/tests/e2e-testkit/dynamodb_resources.ts
+++ b/libs/external-db-dynamodb/tests/e2e-testkit/dynamodb_resources.ts
@@ -30,8 +30,8 @@ export const setActive = () => {
 export const enviormentVariables = {
     TYPE: 'dynamodb',
     REGION: 'us-west-2',
-    AWS_SECRET_ACCESS_KEY: 'TEST_SECRET_ACCESS_KEY',
-    AWS_ACCESS_KEY_ID: 'TEST_ACCESS_KEY_ID',
+    AWS_SECRET_ACCESS_KEY: 'TestSecretAccessKey',
+    AWS_ACCESS_KEY_ID: 'TestAccessKeyId',
     ENDPOINT_URL: 'http://localhost:8000'
 }
 
@@ -39,7 +39,7 @@ const connectionConfig = () => ({ endpoint: 'http://localhost:8000',
                                   region: 'us-west-2',
                                })
 const accessOptions = () => ({
-                                credentials: { accessKeyId: 'TEST_ACCESS_KEY_ID', secretAccessKey: 'TEST_SECRET_ACCESS_KEY' }
+                                credentials: { accessKeyId: 'TestAccessKeyId', secretAccessKey: 'TestSecretAccessKey' }
                             })
 
 export const name = 'dynamodb'


### PR DESCRIPTION
After updating DynamoDB Local to version 2.0 or higher, you might notice that your applications are failing to authenticate with the service, resulting in the "The Access Key ID or Security Token is Invalid" error. This issue typically arises due to a change in the naming convention for the Access Key ID, which was introduced in DynamoDB Local version 2.0.0 and later.

https://repost.aws/articles/ARc4hEkF9CRgOrw8kSMe6CwQ/troubleshooting-the-access-key-id-or-security-token-is-invalid-error-after-upgrading-dynamodb-local-to-version-2-0-0-1-23-0-or-greater