### PR TITLE
jwt-verifier-decoder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
                    "mssql", "mssql17",
                    spanner,
                    "mongo", "mongo4",
-                   "dynamodb",
+                  #  "dynamodb",
                    "firestore"
                    ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
                    "mssql", "mssql17",
                    spanner,
                    "mongo", "mongo4",
-                  #  "dynamodb",
+                   "dynamodb",
                    "firestore"
                    ]
 

--- a/libs/test-commons/src/libs/auth-config.json
+++ b/libs/test-commons/src/libs/auth-config.json
@@ -3,6 +3,7 @@
     "kid": "7968bd02-7c7d-446e-83c5-5c993c20a140",
     "authPublicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdnP+fQMJYtljus9pnpEWT02T0uqF\nUacdoxL19vmQdii4DAj+S0pbJ/owcc7HsPvNwhJvIwFtk/4Cm+OYp7fXSQ==\n-----END PUBLIC KEY-----",
     "authPrivateKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEINoWtnYgw8ZcsZkgWDBxAcJF0ziCI4SOVuK17DrQFCWYoAoGCCqGSM49\nAwEHoUQDQgAEdnP+fQMJYtljus9pnpEWT02T0uqFUacdoxL19vmQdii4DAj+S0pb\nJ/owcc7HsPvNwhJvIwFtk/4Cm+OYp7fXSQ==\n-----END EC PRIVATE KEY-----",
-    "otherAuthPublicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEC0QSOeblgUZjrKzxsLwJ/gcTFV+/\nTIhuEDxhpNaAnY1AvqFuANfCJ++aCWMjmhp1Fy9BZ6pi/lxVJAF4fpMqtw==\n-----END PUBLIC KEY-----"
+    "otherAuthPublicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEC0QSOeblgUZjrKzxsLwJ/gcTFV+/\nTIhuEDxhpNaAnY1AvqFuANfCJ++aCWMjmhp1Fy9BZ6pi/lxVJAF4fpMqtw==\n-----END PUBLIC KEY-----",
+    "otherAuthPrivateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIBOQIBAAJAbcyXwdpGC435MK3+YrondHjQgU6ev6IIi0BUxstX2N0kWSIjZveu\nv7yrpLHmE5kiFmIK2QQJJB2fBgvFe1rREQIDAQABAkA+BAjTHQ3jCNVugVflO299\ngZ+C6X0Qj9xzimpXvhJoEgF2h46MymRdxhIBjFdk27RiNbCcxSO+/9ihXgpRFJYB\nAiEAuAyC3I9deFYhivwDyY8SylXtJM6amrM9VDYfWe6VqOkCIQCYuTkNRYgOoYZv\nx56c+ssbLsPi+wvegXMUFcGEEOZN6QIhAJSGxDRqHew21errZcMLCwbuQOorMOkX\nLK8A3lwdBfnBAh9YSryw74G486jE9qK8HkFNdbvJfVlfSXc+JVW7BAohAiEArZNb\nPzT+UboIuTYSyPElaCV8wLmJ88m5t+NwlNSfsqs=\n-----END RSA PRIVATE KEY-----"
   }
 }

--- a/libs/velo-external-db-core/src/web/jwt-verifier-decoder-middleware.spec.ts
+++ b/libs/velo-external-db-core/src/web/jwt-verifier-decoder-middleware.spec.ts
@@ -1,0 +1,62 @@
+import * as Chance from 'chance'
+import { Request, Response } from 'express'
+import { Uninitialized, gen as genCommon } from '@wix-velo/test-commons'
+import { JWTVerifierDecoderMiddleware } from './jwt-verifier-decoder-middleware'
+import * as driver from './jwt-verifier-test-support'
+import { errors } from '@wix-velo/velo-external-db-commons'
+
+const { UnauthorizedError } = errors
+const chance = Chance()
+
+describe('Jwt Verifier Decoder Middleware', () => {
+    test('given valid token, should decode and override request body', async() => {
+        driver.givenValidToken(ctx.token, ctx.decodedToken)
+        env.JwtVerifierDecoderMiddleware.verifyAndDecodeMiddleware()(ctx.req, ctx.res, ctx.next)
+        expect(ctx.req.body).toEqual(ctx.decodedToken)
+    })
+
+    test('given invalid token, should throw error', async() => {
+        driver.givenInvalidToken(ctx.token, ctx.errorMsgFromVerifier)
+        env.JwtVerifierDecoderMiddleware.verifyAndDecodeMiddleware()(ctx.req, ctx.res, ctx.next)
+        expect(ctx.next).toHaveBeenCalledWith(new UnauthorizedError(ctx.errorMsgFromVerifier))
+    })
+    
+    interface Env {
+        JwtVerifierDecoderMiddleware: JWTVerifierDecoderMiddleware
+    }
+    const env: Env = {
+        JwtVerifierDecoderMiddleware: Uninitialized,
+    }
+
+    interface Ctx {
+        token: string,
+        req: Request
+        res: Response
+        next: jest.Mock
+        decodedToken: Record<string, unknown>
+        errorMsgFromVerifier: string
+    }
+
+    const ctx: Ctx = {
+        token: Uninitialized,
+        req: Uninitialized,
+        res: Uninitialized,
+        next: Uninitialized,
+        decodedToken: Uninitialized,
+        errorMsgFromVerifier: Uninitialized,
+    }
+
+    beforeEach(() => {
+        ctx.token = chance.string()
+        ctx.req = {
+            ...genCommon.randomObject(),
+            body: ctx.token,
+        } as Request
+        ctx.res = genCommon.randomObject() as Response
+        ctx.next = jest.fn()
+        ctx.decodedToken = genCommon.randomObject()
+        ctx.errorMsgFromVerifier = chance.string()
+
+        env.JwtVerifierDecoderMiddleware = new JWTVerifierDecoderMiddleware(driver.jwtVerifier)
+    })
+})

--- a/libs/velo-external-db-core/src/web/jwt-verifier-decoder-middleware.ts
+++ b/libs/velo-external-db-core/src/web/jwt-verifier-decoder-middleware.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from 'express'
+import { JWTVerifier } from './jwt-verifier'
+
+export class JWTVerifierDecoderMiddleware {
+    private jwtVerifier: JWTVerifier
+
+    constructor(jwtVerifier: any) {
+        this.jwtVerifier = jwtVerifier
+    }
+
+    verifyAndDecodeMiddleware() {
+        return (req: Request, res: Response, next: NextFunction) => {
+            try {
+                req.body = this.jwtVerifier.verifyAndDecode(req.body)
+                next()
+            }
+            catch (error) {
+                next(error)
+            }
+        }
+    }
+}

--- a/libs/velo-external-db-core/src/web/jwt-verifier-test-support.ts
+++ b/libs/velo-external-db-core/src/web/jwt-verifier-test-support.ts
@@ -1,0 +1,19 @@
+import { when } from 'jest-when'
+import { errors } from '@wix-velo/velo-external-db-commons'
+
+const { UnauthorizedError } = errors
+export const jwtVerifier = {
+    verifyAndDecode: jest.fn(),
+}
+
+export const givenValidToken = (token: string, decodedToken: any) => {
+    when(jwtVerifier.verifyAndDecode).calledWith(token).mockReturnValue(decodedToken)
+}
+
+export const givenInvalidToken = (token: string, errorMsgFromVerifier: string) => {
+    when(jwtVerifier.verifyAndDecode).calledWith(token).mockImplementation(() => { throw new UnauthorizedError(errorMsgFromVerifier) })
+}
+
+export const reset = () => {
+    jwtVerifier.verifyAndDecode.mockClear()
+}

--- a/libs/velo-external-db-core/src/web/jwt-verifier.spec.ts
+++ b/libs/velo-external-db-core/src/web/jwt-verifier.spec.ts
@@ -1,0 +1,80 @@
+import * as jwt from 'jsonwebtoken'
+import * as Chance from 'chance'
+import { Uninitialized, authConfig } from '@wix-velo/test-commons'
+import { errors } from '@wix-velo/velo-external-db-commons'
+import { JWTVerifier, TOKEN_ISSUER } from './jwt-verifier'
+
+const { UnauthorizedError } = errors
+const chance = Chance()
+
+describe('JWT Verifier', () => {
+    test('should authorize when JWT valid', async() => {
+        const token = signedToken({ ...ctx.basicValidPayload, data: ctx.data })
+        const decoded = env.jwtVerifier.verifyAndDecode(token)
+        expect(decoded).toEqual(ctx.requestPayload)
+    })
+
+    test('should throw when JWT is missing', async() => {
+        expect(() => env.jwtVerifier.verifyAndDecode('')).toThrow(UnauthorizedError)
+    })
+
+    describe('should throw when JWT is invalid', () => {
+        test('invalid issuer', async() => {
+            const token = signedToken({ ...ctx.basicValidPayload, iss: 'hacker.com', data: ctx.data })
+            expect(() => env.jwtVerifier.verifyAndDecode(token)).toThrow(UnauthorizedError)
+        })
+        
+        test('invalid audience', async() => {
+            const token = signedToken({ ...ctx.basicValidPayload, aud: 'wrong', data: ctx.data })
+            expect(() => env.jwtVerifier.verifyAndDecode(token)).toThrow(UnauthorizedError)
+        })
+
+        test('expired signature', async() => {
+            const token = signedToken({ ...ctx.basicValidPayload, data: ctx.data }, '0ms')
+            expect(() => env.jwtVerifier.verifyAndDecode(token)).toThrow(UnauthorizedError)
+        })
+
+        test('wrong privateKey', async() => {
+            const token = signTokenWith({ ...ctx.basicValidPayload, data: ctx.data }, authConfig.otherAuthPrivateKey, '10000ms')
+            expect(() => env.jwtVerifier.verifyAndDecode(token)).toThrow(UnauthorizedError)
+        })
+    })
+
+    interface Ctx {
+        basicValidPayload: Record<string, unknown>
+        appDefId: string
+        requestPayload: string
+        data: Record<string, unknown>
+    }
+
+    const ctx: Ctx = {
+        basicValidPayload: Uninitialized,
+        appDefId: Uninitialized,
+        requestPayload: Uninitialized,
+        data: Uninitialized,
+    }
+
+    interface Env {
+        jwtVerifier: JWTVerifier
+    }
+
+    const env: Env = {
+        jwtVerifier: Uninitialized,
+    }
+
+    beforeEach(() => {
+        ctx.appDefId = chance.word()
+        ctx.requestPayload = chance.word()
+        ctx.basicValidPayload = { iss: TOKEN_ISSUER, aud: ctx.appDefId }
+        ctx.data = { request: ctx.requestPayload }
+        env.jwtVerifier = new JWTVerifier(authConfig.authPublicKey, ctx.appDefId)
+    })
+})
+
+const signedToken = (payload: Record<string, unknown>, expiration = '10000ms') => signTokenWith(payload, authConfig.authPrivateKey, expiration)
+
+
+const signTokenWith = (payload: Record<string, unknown>, privateKey: string, expiration: string) => {
+    const options: jwt.SignOptions = { algorithm: 'RS256', expiresIn: expiration }
+    return jwt.sign(payload, privateKey, options)
+}

--- a/libs/velo-external-db-core/src/web/jwt-verifier.ts
+++ b/libs/velo-external-db-core/src/web/jwt-verifier.ts
@@ -1,0 +1,36 @@
+import { verify } from 'jsonwebtoken'
+import { errors } from '@wix-velo/velo-external-db-commons'
+
+const { UnauthorizedError } = errors
+export const TOKEN_ISSUER = 'wix.com'
+
+export class JWTVerifier {
+    private publicKey: string
+    private appDefId: string
+
+    constructor(publicKey: string, appDefId: string) {
+        this.publicKey = publicKey
+        this.appDefId = appDefId
+    }
+
+    verifyAndDecode(jwtToken: string) {
+        if (!jwtToken) {
+            throw new UnauthorizedError('Unauthorized')
+        }
+
+        try {
+            const decodedToken: any = verify(jwtToken, this.publicKey, {
+                issuer: TOKEN_ISSUER,
+                audience: this.appDefId,
+            })
+
+            if (decodedToken && decodedToken.data && decodedToken.data.request) {
+                return decodedToken.data.request
+            } else {
+                throw new UnauthorizedError('Authorization failed')
+            }
+        } catch (error: any) {
+            throw new UnauthorizedError(`Authorization failed: ${error.message}`)
+        }
+    }
+}


### PR DESCRIPTION
Implementing the standard JWT verify & decode of SPI implementer ([see here](https://dev.wix.com/docs/rest/articles/getting-started/service-provider-interface#validating-request-signatures)).

Implemented as middleware that overrides the request body.

Still for now not using the middleware, because it would require changes in the all the e2e tests (need to encode every request), but it's ready and tested.
I think it would be better to use the middleware on another PR after merging the data SPI implementation in order to avoid too many conflicts.

what we need to do next?
1. add to config reader / config validator the publicKey, appDefId.
2. initialize the jwtVerifier with these params.
3. enable the middleware on every request + change e2es (encode every request)