### PR TITLE
JWT config reader refactor

### DIFF
--- a/apps/velo-external-db/src/app.ts
+++ b/apps/velo-external-db/src/app.ts
@@ -4,9 +4,9 @@ import { ExternalDbRouter, Hooks } from '@wix-velo/velo-external-db-core'
 import { engineConnectorFor } from './storage/factory'
 
 const initConnector = async(wixDataBaseUrl?: string, hooks?: Hooks) => {
-    const { vendor, type: adapterType, externalDatabaseId, allowedMetasites, hideAppInfo } = readCommonConfig()
+    const { vendor, type: adapterType, allowedMetasites, hideAppInfo } = readCommonConfig()
     const configReader = create()
-    const { authorization, ...dbConfig } = await configReader.readConfig()
+    const { authorization, jwtPublicKey, appDefId, ...dbConfig } = await configReader.readConfig()
 
     const { connector: engineConnector, providers, cleanup } = await engineConnectorFor(adapterType, dbConfig)
 
@@ -16,7 +16,8 @@ const initConnector = async(wixDataBaseUrl?: string, hooks?: Hooks) => {
             authorization: {
                 roleConfig: authorization
             },
-            externalDatabaseId,
+            jwtPublicKey,
+            appDefId,
             allowedMetasites,
             vendor,
             adapterType,

--- a/libs/external-db-config/src/readers/aws_config_reader.ts
+++ b/libs/external-db-config/src/readers/aws_config_reader.ts
@@ -13,8 +13,8 @@ export class AwsConfigReader implements IConfigReader {
 
   async readConfig() {
     const { config } = await this.readExternalAndLocalConfig()
-    const { host, username, password, DB, EXTERNAL_DATABASE_ID, ALLOWED_METASITES, DB_PORT } = config
-    return { host, user: username, password, db: DB, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES, port: DB_PORT }
+    const { host, username, password, DB, ALLOWED_METASITES, DB_PORT, JWT_PUBLIC_KEY, APP_DEF_ID } = config
+    return { host, user: username, password, db: DB, allowedMetasites: ALLOWED_METASITES, port: DB_PORT, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 
   async readExternalConfig() {
@@ -29,8 +29,8 @@ export class AwsConfigReader implements IConfigReader {
 
   async readExternalAndLocalConfig() { 
     const { externalConfig, secretMangerError }: {[key: string]: any} = await this.readExternalConfig()
-    const { host, username, password, DB, EXTERNAL_DATABASE_ID, ALLOWED_METASITES, HOST, PASSWORD, USER, DB_PORT }: {[key: string]: string} = { ...process.env, ...externalConfig }
-    const config = {  host: host || HOST, username: username || USER, password: password || PASSWORD, DB, EXTERNAL_DATABASE_ID, ALLOWED_METASITES, DB_PORT }
+    const { host, username, password, DB, ALLOWED_METASITES, HOST, PASSWORD, USER, DB_PORT, JWT_PUBLIC_KEY, APP_DEF_ID }: {[key: string]: string} = { ...process.env, ...externalConfig }
+    const config = {  host: host || HOST, username: username || USER, password: password || PASSWORD, DB, ALLOWED_METASITES, DB_PORT, JWT_PUBLIC_KEY, APP_DEF_ID }
     return { config, secretMangerError }
   }
 }
@@ -46,15 +46,15 @@ export class AwsDynamoConfigReader implements IConfigReader {
     async readConfig() {
       const { config } = await this.readExternalAndLocalConfig()
       if (process.env['NODE_ENV'] === 'test') {
-        return { region: this.region, externalDatabaseId: config.EXTERNAL_DATABASE_ID, endpoint: process.env['ENDPOINT_URL'] }
+        return { region: this.region, endpoint: process.env['ENDPOINT_URL'], jwtPublicKey: config.JWT_PUBLIC_KEY, appDefId: config.APP_DEF_ID }
       }
-      return { region: this.region, externalDatabaseId: config.EXTERNAL_DATABASE_ID, allowedMetasites: config.ALLOWED_METASITES }
+      return { region: this.region, jwtPublicKey: config.JWT_PUBLIC_KEY, appDefId: config.APP_DEF_ID, allowedMetasites: config.ALLOWED_METASITES }
     }
     
     async readExternalAndLocalConfig() { 
       const { externalConfig, secretMangerError }: {[key: string]: any} = await this.readExternalConfig()
-      const { EXTERNAL_DATABASE_ID = undefined, ALLOWED_METASITES = undefined } = { ...process.env, ...externalConfig }
-      const config = { EXTERNAL_DATABASE_ID, ALLOWED_METASITES }
+      const { ALLOWED_METASITES = undefined, JWT_PUBLIC_KEY = undefined, APP_DEF_ID = undefined } = { ...process.env, ...externalConfig }
+      const config = { JWT_PUBLIC_KEY, APP_DEF_ID, ALLOWED_METASITES }
 
       return { config, secretMangerError }
     }
@@ -90,8 +90,8 @@ export class AwsMongoConfigReader implements IConfigReader {
 
   async readExternalAndLocalConfig() { 
     const { externalConfig, secretMangerError } :{[key: string]: any} = await this.readExternalConfig()
-    const { EXTERNAL_DATABASE_ID, ALLOWED_METASITES, URI }: {EXTERNAL_DATABASE_ID: string, ALLOWED_METASITES: string, URI: string} = { ...process.env, ...externalConfig }
-    const config = { EXTERNAL_DATABASE_ID, ALLOWED_METASITES, URI }
+    const { ALLOWED_METASITES, URI, JWT_PUBLIC_KEY, APP_DEF_ID }: { ALLOWED_METASITES: string, URI: string, JWT_PUBLIC_KEY: string, APP_DEF_ID: string } = { ...process.env, ...externalConfig }
+    const config = { ALLOWED_METASITES, URI, JWT_PUBLIC_KEY, APP_DEF_ID }
 
     return { config, secretMangerError }
   }
@@ -99,8 +99,8 @@ export class AwsMongoConfigReader implements IConfigReader {
   async readConfig() {
     const { config } = await this.readExternalAndLocalConfig()
 
-    const { EXTERNAL_DATABASE_ID, ALLOWED_METASITES, URI } = config
+    const { ALLOWED_METASITES, URI, JWT_PUBLIC_KEY, APP_DEF_ID } = config
 
-    return { externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES, connectionUri: URI }
+    return { allowedMetasites: ALLOWED_METASITES, connectionUri: URI, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 }

--- a/libs/external-db-config/src/readers/azure_config_reader.ts
+++ b/libs/external-db-config/src/readers/azure_config_reader.ts
@@ -5,7 +5,8 @@ export class AzureConfigReader implements IConfigReader {
   }
 
   async readConfig() {
-    const { HOST, USER, PASSWORD, DB, EXTERNAL_DATABASE_ID, ALLOWED_METASITES, UNSECURED_ENV, DB_PORT } = process.env
-    return { host: HOST, user: USER, password: PASSWORD, db: DB, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES, unsecuredEnv: UNSECURED_ENV, port: DB_PORT }
+    const { HOST, USER, PASSWORD, DB, ALLOWED_METASITES, UNSECURED_ENV, DB_PORT, JWT_PUBLIC_KEY, APP_DEF_ID } = process.env
+    return { host: HOST, user: USER, password: PASSWORD, db: DB, allowedMetasites: ALLOWED_METASITES, 
+             unsecuredEnv: UNSECURED_ENV, port: DB_PORT, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 }

--- a/libs/external-db-config/src/readers/common_config_reader.ts
+++ b/libs/external-db-config/src/readers/common_config_reader.ts
@@ -4,7 +4,7 @@ export default class CommonConfigReader implements IConfigReader {
     constructor() { }
 
     readConfig() {
-        const { CLOUD_VENDOR, TYPE, REGION, SECRET_NAME, EXTERNAL_DATABASE_ID, ALLOWED_METASITES, HIDE_APP_INFO } = process.env
-        return { vendor: CLOUD_VENDOR, type: TYPE, region: REGION, secretId: SECRET_NAME, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES, hideAppInfo: HIDE_APP_INFO ? HIDE_APP_INFO === 'true' : undefined }
+        const { CLOUD_VENDOR, TYPE, REGION, SECRET_NAME, ALLOWED_METASITES, HIDE_APP_INFO } = process.env
+        return { vendor: CLOUD_VENDOR, type: TYPE, region: REGION, secretId: SECRET_NAME, allowedMetasites: ALLOWED_METASITES, hideAppInfo: HIDE_APP_INFO ? HIDE_APP_INFO === 'true' : undefined }
     }
 }

--- a/libs/external-db-config/src/readers/gcp_config_reader.ts
+++ b/libs/external-db-config/src/readers/gcp_config_reader.ts
@@ -5,8 +5,9 @@ export class GcpConfigReader implements IConfigReader {
   }
 
   async readConfig() {
-    const { CLOUD_SQL_CONNECTION_NAME, USER, PASSWORD, DB, EXTERNAL_DATABASE_ID, ALLOWED_METASITES, DB_PORT } = process.env
-    return { cloudSqlConnectionName: CLOUD_SQL_CONNECTION_NAME, user: USER, password: PASSWORD, db: DB, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES, port: DB_PORT }
+    const { CLOUD_SQL_CONNECTION_NAME, USER, PASSWORD, DB, ALLOWED_METASITES, DB_PORT, JWT_PUBLIC_KEY, APP_DEF_ID } = process.env
+    return { cloudSqlConnectionName: CLOUD_SQL_CONNECTION_NAME, user: USER, password: PASSWORD, db: DB,
+             allowedMetasites: ALLOWED_METASITES, port: DB_PORT, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 
 }
@@ -16,8 +17,9 @@ export class GcpSpannerConfigReader implements IConfigReader {
   }
 
   async readConfig() {
-    const { PROJECT_ID, INSTANCE_ID, DATABASE_ID, EXTERNAL_DATABASE_ID, ALLOWED_METASITES } = process.env
-    return { projectId: PROJECT_ID, instanceId: INSTANCE_ID, databaseId: DATABASE_ID, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES }
+    const { PROJECT_ID, INSTANCE_ID, DATABASE_ID, ALLOWED_METASITES, JWT_PUBLIC_KEY, APP_DEF_ID } = process.env
+    return { projectId: PROJECT_ID, instanceId: INSTANCE_ID, databaseId: DATABASE_ID,
+             allowedMetasites: ALLOWED_METASITES, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 
 
@@ -27,8 +29,8 @@ export class GcpFirestoreConfigReader implements IConfigReader {
   constructor() { }
 
   async readConfig() {
-    const { PROJECT_ID, EXTERNAL_DATABASE_ID, ALLOWED_METASITES } = process.env
-    return { projectId: PROJECT_ID, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES }
+    const { PROJECT_ID, ALLOWED_METASITES, JWT_PUBLIC_KEY, APP_DEF_ID } = process.env
+    return { projectId: PROJECT_ID, allowedMetasites: ALLOWED_METASITES, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 
 
@@ -38,8 +40,9 @@ export class GcpGoogleSheetsConfigReader implements IConfigReader {
   constructor() { }
 
   async readConfig() {
-    const { CLIENT_EMAIL, SHEET_ID, API_PRIVATE_KEY, EXTERNAL_DATABASE_ID, ALLOWED_METASITES } = process.env
-    return { clientEmail: CLIENT_EMAIL, apiPrivateKey: API_PRIVATE_KEY, sheetId: SHEET_ID, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES }
+    const { CLIENT_EMAIL, SHEET_ID, API_PRIVATE_KEY, ALLOWED_METASITES, JWT_PUBLIC_KEY, APP_DEF_ID } = process.env
+    return { clientEmail: CLIENT_EMAIL, apiPrivateKey: API_PRIVATE_KEY, sheetId: SHEET_ID,
+             allowedMetasites: ALLOWED_METASITES, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 
 }
@@ -48,8 +51,9 @@ export class GcpMongoConfigReader implements IConfigReader {
   constructor() { }
 
   async readConfig() {
-    const { URI, EXTERNAL_DATABASE_ID, ALLOWED_METASITES } = process.env
-    return { connectionUri: URI, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES }
+    const { URI, ALLOWED_METASITES, JWT_PUBLIC_KEY, APP_DEF_ID } = process.env
+    return { connectionUri: URI, allowedMetasites: ALLOWED_METASITES,
+             jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 }
 
@@ -57,8 +61,9 @@ export class GcpAirtableConfigReader implements IConfigReader {
   constructor() { }
 
   async readConfig() {
-    const { AIRTABLE_API_KEY, META_API_KEY, BASE_ID, EXTERNAL_DATABASE_ID, ALLOWED_METASITES, BASE_URL } = process.env
-    return { apiPrivateKey: AIRTABLE_API_KEY, metaApiKey: META_API_KEY, baseId: BASE_ID, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES, baseUrl: BASE_URL }
+    const { AIRTABLE_API_KEY, META_API_KEY, BASE_ID, ALLOWED_METASITES, BASE_URL, JWT_PUBLIC_KEY, APP_DEF_ID } = process.env
+    return { apiPrivateKey: AIRTABLE_API_KEY, metaApiKey: META_API_KEY, baseId: BASE_ID,
+             allowedMetasites: ALLOWED_METASITES, baseUrl: BASE_URL, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 }
 
@@ -67,7 +72,8 @@ export class GcpBigQueryConfigReader implements IConfigReader {
   }
 
   async readConfig() {
-    const { PROJECT_ID, DATABASE_ID, EXTERNAL_DATABASE_ID, ALLOWED_METASITES } = process.env
-    return { projectId: PROJECT_ID, databaseId: DATABASE_ID, externalDatabaseId: EXTERNAL_DATABASE_ID, allowedMetasites: ALLOWED_METASITES }
+    const { PROJECT_ID, DATABASE_ID, ALLOWED_METASITES, JWT_PUBLIC_KEY, APP_DEF_ID } = process.env
+    return { projectId: PROJECT_ID, databaseId: DATABASE_ID,
+             allowedMetasites: ALLOWED_METASITES, jwtPublicKey: JWT_PUBLIC_KEY, appDefId: APP_DEF_ID }
   }
 }

--- a/libs/external-db-config/src/validators/common_config_validator.spec.ts
+++ b/libs/external-db-config/src/validators/common_config_validator.spec.ts
@@ -13,7 +13,7 @@ describe('MySqlConfigValidator', () => {
 
     test('not extended common config validator will return if externalDatabaseId or allowedMetasites are missing', () => {
         env.CommonConfigValidator = new CommonConfigValidator({})
-        expect(env.CommonConfigValidator.validate()).toEqual({ missingRequiredSecretsKeys: ['externalDatabaseId', 'allowedMetasites'] })
+        expect(env.CommonConfigValidator.validate()).toEqual({ missingRequiredSecretsKeys: ['jwtPublicKey', 'appDefId', 'allowedMetasites'] })
     })
 
     each(

--- a/libs/external-db-config/src/validators/common_config_validator.ts
+++ b/libs/external-db-config/src/validators/common_config_validator.ts
@@ -22,7 +22,7 @@ export class CommonConfigValidator {
 
     validateBasic() {
         return {
-            missingRequiredSecretsKeys: checkRequiredKeys(this.config, ['externalDatabaseId', 'allowedMetasites'])
+            missingRequiredSecretsKeys: checkRequiredKeys(this.config, ['jwtPublicKey', 'appDefId', 'allowedMetasites'])
         }
     }
 
@@ -32,7 +32,7 @@ export class CommonConfigValidator {
         return {
             validType,
             validVendor,
-            missingRequiredSecretsKeys: checkRequiredKeys(this.config, ['type', 'vendor', 'externalDatabaseId', 'allowedMetasites'])
+            missingRequiredSecretsKeys: checkRequiredKeys(this.config, ['type', 'vendor', 'jwtPublicKey', 'appDefId', 'allowedMetasites'])
         }
     }
 }

--- a/libs/external-db-config/test/drivers/aws_mongo_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/aws_mongo_config_test_support.ts
@@ -70,7 +70,7 @@ export const validConfigWithAuthorization = () => ({
     authorization: validAuthorizationConfig.collectionPermissions 
 })
 
-export const ExpectedProperties = ['URI','ALLOWED_METASITES', 'PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
+export const ExpectedProperties = ['URI', 'ALLOWED_METASITES', 'PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 export const RequiredProperties = ['URI', 'ALLOWED_METASITES', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => { 

--- a/libs/external-db-config/test/drivers/aws_mongo_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/aws_mongo_config_test_support.ts
@@ -17,14 +17,17 @@ export const defineValidConfig = (config: MongoConfig) => {
     if (config.connectionUri) {
         awsConfig['URI'] = config.connectionUri
     }
-    if (config.externalDatabaseId) {
-        awsConfig['EXTERNAL_DATABASE_ID'] = config.externalDatabaseId
-    }
     if (config.allowedMetasites) {
         awsConfig['ALLOWED_METASITES'] = config.allowedMetasites
     }
     if (config.authorization) {
         awsConfig['PERMISSIONS'] = JSON.stringify( config.authorization )
+    }
+    if (config.jwtPublicKey) {
+        awsConfig['JWT_PUBLIC_KEY'] = config.jwtPublicKey
+    }
+    if (config.appDefId) {
+        awsConfig['APP_DEF_ID'] = config.appDefId
     }
     mockedAwsSdk.on(GetSecretValueCommand).resolves({ SecretString: JSON.stringify(awsConfig) })
 }
@@ -33,14 +36,17 @@ const defineLocalEnvs = (config: MongoConfig) => {
     if (config.connectionUri) {
         process.env['URI'] = config.connectionUri
     }
-    if (config.externalDatabaseId) {
-        process.env['EXTERNAL_DATABASE_ID'] = config.externalDatabaseId
-    }
     if (config.allowedMetasites) {
         process.env['ALLOWED_METASITES'] = config.allowedMetasites
     }
     if (config.authorization) {
         process.env['PERMISSIONS'] = JSON.stringify( config.authorization )
+    }
+    if (config.jwtPublicKey) {
+        process.env['JWT_PUBLIC_KEY'] = config.jwtPublicKey
+    }
+    if (config.appDefId) {
+        process.env['APP_DEF_ID'] = config.appDefId
     }
 }
 
@@ -48,8 +54,9 @@ export const defineInvalidConfig = () => defineValidConfig({})
 
 export const validConfig = () => ({
     connectionUri: chance.word(),
-    externalDatabaseId: chance.word(),
-    allowedMetasites: chance.word()
+    allowedMetasites: chance.word(),
+    jwtPublicKey: chance.word(),
+    appDefId: chance.word(),
 })
 
 export const defineSplittedConfig = (config: MongoConfig) => {
@@ -63,8 +70,8 @@ export const validConfigWithAuthorization = () => ({
     authorization: validAuthorizationConfig.collectionPermissions 
 })
 
-export const ExpectedProperties = ['URI', 'EXTERNAL_DATABASE_ID', 'ALLOWED_METASITES', 'PERMISSIONS']
-export const RequiredProperties = ['URI', 'EXTERNAL_DATABASE_ID', 'ALLOWED_METASITES']
+export const ExpectedProperties = ['URI','ALLOWED_METASITES', 'PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
+export const RequiredProperties = ['URI', 'ALLOWED_METASITES', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => { 
     mockedAwsSdk.reset()

--- a/libs/external-db-config/test/drivers/aws_mysql_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/aws_mysql_config_test_support.ts
@@ -26,14 +26,17 @@ export const defineValidConfig = (config: MySqlConfig) => {
     if (config.db) {
         awsConfig['DB'] = config.db
     }
-    if (config.externalDatabaseId) {
-        awsConfig['EXTERNAL_DATABASE_ID'] = config.externalDatabaseId
-    }
     if (config.allowedMetasites) {
         awsConfig['ALLOWED_METASITES'] = config.allowedMetasites
     }
     if (config.authorization) {
         awsConfig['PERMISSIONS'] = JSON.stringify(config.authorization)
+    }
+    if (config.jwtPublicKey) {
+        awsConfig['JWT_PUBLIC_KEY'] = config.jwtPublicKey
+    }
+    if (config.appDefId) {
+        awsConfig['APP_DEF_ID'] = config.appDefId
     }
     mockedAwsSdk.on(GetSecretValueCommand).resolves({ SecretString: JSON.stringify(awsConfig) })
 }
@@ -51,14 +54,17 @@ const defineLocalEnvs = (config: MySqlConfig) => {
     if (config.db) {
         process.env['DB'] = config.db
     }
-    if (config.externalDatabaseId) {
-        process.env['EXTERNAL_DATABASE_ID'] = config.externalDatabaseId
-    }
     if (config.allowedMetasites) {
         process.env['ALLOWED_METASITES'] = config.allowedMetasites
     }
     if (config.authorization) {
         process.env['PERMISSIONS'] = JSON.stringify(config.authorization)
+    }
+    if (config.jwtPublicKey) {
+        process.env['JWT_PUBLIC_KEY'] = config.jwtPublicKey
+    }
+    if (config.appDefId) {
+        process.env['APP_DEF_ID'] = config.appDefId
     }
 }
 
@@ -76,8 +82,9 @@ export const validConfig = (): MySqlConfig => ({
     user: chance.word(),
     password: chance.word(),
     db: chance.word(),
-    externalDatabaseId: chance.word(),
     allowedMetasites: chance.word(),
+    jwtPublicKey: chance.word(),
+    appDefId: chance.word(),
 })
 
 export const validConfigWithAuthorization = (): MySqlConfig => ({
@@ -96,8 +103,8 @@ export const validConfigWithAuthConfig = () => ({
     } 
 })
 
-export const ExpectedProperties = ['host', 'username', 'password', 'DB', 'EXTERNAL_DATABASE_ID', 'ALLOWED_METASITES', 'PERMISSIONS']
-export const RequiredProperties = ['host', 'username', 'password', 'DB', 'EXTERNAL_DATABASE_ID', 'ALLOWED_METASITES']
+export const ExpectedProperties = ['host', 'username', 'password', 'DB', 'ALLOWED_METASITES', 'PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
+export const RequiredProperties = ['host', 'username', 'password', 'DB', 'ALLOWED_METASITES', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => { 
     mockedAwsSdk.reset()

--- a/libs/external-db-config/test/drivers/azure_mysql_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/azure_mysql_config_test_support.ts
@@ -17,24 +17,18 @@ export const defineValidConfig = (config: MySqlConfig) => {
     if (config.db) {
         process.env['DB'] = config.db
     }
-    if (config.externalDatabaseId) {
-        process.env['EXTERNAL_DATABASE_ID'] = config.externalDatabaseId
-    }
     if (config.allowedMetasites) {
         process.env['ALLOWED_METASITES'] = config.allowedMetasites
     }
     if (config.authorization) {
         process.env['PERMISSIONS'] = JSON.stringify( config.authorization )
     }
-    if (config.auth?.clientId) {
-        process.env['clientId'] = config.auth.clientId
+    if (config.jwtPublicKey) {
+        process.env['JWT_PUBLIC_KEY'] = config.jwtPublicKey
     }
-    if (config.auth?.clientSecret) {
-        process.env['clientSecret'] = config.auth.clientSecret
+    if (config.appDefId) {
+        process.env['APP_DEF_ID'] = config.appDefId
     }
-    if (config.auth?.callbackUrl) {
-        process.env['callbackUrl'] = config.auth.callbackUrl
-    } 
 }
 
 export const validConfig = (): MySqlConfig => ({
@@ -42,8 +36,9 @@ export const validConfig = (): MySqlConfig => ({
     user: chance.word(),
     password: chance.word(),
     db: chance.word(),
-    externalDatabaseId: chance.word(),
     allowedMetasites: chance.word(),
+    jwtPublicKey: chance.word(),
+    appDefId: chance.word(),
 })
 
 export const validConfigWithAuthorization = (): MySqlConfig => ({
@@ -62,7 +57,7 @@ export const validConfigWithAuthConfig = () => ({
 
 export const defineInvalidConfig = () => defineValidConfig({})
 
-export const ExpectedProperties = ['HOST', 'USER', 'PASSWORD', 'DB', 'EXTERNAL_DATABASE_ID', 'ALLOWED_METASITES', 'callbackUrl', 'clientId', 'clientSecret', 'PERMISSIONS']
+export const ExpectedProperties = ['HOST', 'USER', 'PASSWORD', 'DB', 'ALLOWED_METASITES','PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 

--- a/libs/external-db-config/test/drivers/azure_mysql_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/azure_mysql_config_test_support.ts
@@ -57,7 +57,7 @@ export const validConfigWithAuthConfig = () => ({
 
 export const defineInvalidConfig = () => defineValidConfig({})
 
-export const ExpectedProperties = ['HOST', 'USER', 'PASSWORD', 'DB', 'ALLOWED_METASITES','PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
+export const ExpectedProperties = ['HOST', 'USER', 'PASSWORD', 'DB', 'ALLOWED_METASITES', 'PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 

--- a/libs/external-db-config/test/drivers/external_config_reader_e2e_test_support.ts
+++ b/libs/external-db-config/test/drivers/external_config_reader_e2e_test_support.ts
@@ -1,12 +1,12 @@
 
 import { Uninitialized } from '@wix-velo/test-commons'
 import { create } from '../../src/factory'
-import awsMySql = require('./aws_mysql_config_test_support')
-import awsMongo = require('./aws_mongo_config_test_support')
-import azureMySql = require('./azure_mysql_config_test_support')
-import gcpMySql = require('./gcp_mysql_config_test_support')
-import gcpSpanner = require('./gcp_spanner_config_test_support')
-import gcpFirestore = require('./gcp_firestore_config_test_support')
+import * as awsMySql from './aws_mysql_config_test_support'
+import * as awsMongo from './aws_mongo_config_test_support'
+import * as azureMySql from './azure_mysql_config_test_support'
+import * as gcpMySql from './gcp_mysql_config_test_support'
+import * as gcpSpanner from './gcp_spanner_config_test_support'
+import * as gcpFirestore from './gcp_firestore_config_test_support'
 
 export const env = {
     configReader: Uninitialized,

--- a/libs/external-db-config/test/drivers/gcp_firestore_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/gcp_firestore_config_test_support.ts
@@ -8,30 +8,25 @@ export const defineValidConfig = (config: FiresStoreConfig) => {
     if (config.projectId) {
         process.env['PROJECT_ID'] = config.projectId
     }
-    if (config.externalDatabaseId) {
-        process.env['EXTERNAL_DATABASE_ID'] = config.externalDatabaseId
-    }
     if (config.allowedMetasites) {
         process.env['ALLOWED_METASITES'] = config.allowedMetasites
     }
     if (config.authorization) {
         process.env['PERMISSIONS'] = JSON.stringify( config.authorization )
     }
-    if (config.auth?.callbackUrl) {
-        process.env['callbackUrl'] = config.auth.callbackUrl
+    if (config.jwtPublicKey) {
+        process.env['JWT_PUBLIC_KEY'] = config.jwtPublicKey
     }
-    if (config.auth?.clientId) {
-        process.env['clientId'] = config.auth.clientId
-    }
-    if (config.auth?.clientSecret) {
-        process.env['clientSecret'] = config.auth.clientSecret
+    if (config.appDefId) {
+        process.env['APP_DEF_ID'] = config.appDefId
     }
 }
 
 export const validConfig = (): FiresStoreConfig => ({
     projectId: chance.word(),
-    externalDatabaseId: chance.word(),
     allowedMetasites: chance.word(),
+    jwtPublicKey: chance.word(),
+    appDefId: chance.word(),
 })
 
 export const validConfigWithAuthorization = () => ({
@@ -50,7 +45,7 @@ export const validConfigWithAuthConfig = () => ({
 
 export const defineInvalidConfig = () => defineValidConfig({})
 
-export const ExpectedProperties = ['PROJECT_ID', 'EXTERNAL_DATABASE_ID', 'ALLOWED_METASITES', 'callbackUrl', 'clientId', 'clientSecret', 'PERMISSIONS']
+export const ExpectedProperties = ['PROJECT_ID', 'ALLOWED_METASITES','PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 

--- a/libs/external-db-config/test/drivers/gcp_firestore_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/gcp_firestore_config_test_support.ts
@@ -45,7 +45,7 @@ export const validConfigWithAuthConfig = () => ({
 
 export const defineInvalidConfig = () => defineValidConfig({})
 
-export const ExpectedProperties = ['PROJECT_ID', 'ALLOWED_METASITES','PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
+export const ExpectedProperties = ['PROJECT_ID', 'ALLOWED_METASITES', 'PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 

--- a/libs/external-db-config/test/drivers/gcp_mysql_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/gcp_mysql_config_test_support.ts
@@ -55,7 +55,7 @@ export const validConfigWithAuthConfig = () => ({
     }  
 })
 
-export const ExpectedProperties = ['CLOUD_SQL_CONNECTION_NAME', 'USER', 'PASSWORD', 'DB', 'ALLOWED_METASITES','PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
+export const ExpectedProperties = ['CLOUD_SQL_CONNECTION_NAME', 'USER', 'PASSWORD', 'DB', 'ALLOWED_METASITES', 'PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const defineInvalidConfig = () => defineValidConfig({})
 

--- a/libs/external-db-config/test/drivers/gcp_mysql_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/gcp_mysql_config_test_support.ts
@@ -17,23 +17,17 @@ export const defineValidConfig = (config: MySqlConfig) => {
     if (config.db) {
         process.env['DB'] = config.db
     }
-    if (config.externalDatabaseId) {
-        process.env['EXTERNAL_DATABASE_ID'] = config.externalDatabaseId
-    }
     if (config.allowedMetasites) {
         process.env['ALLOWED_METASITES'] = config.allowedMetasites
     }
     if (config.authorization) {
         process.env['PERMISSIONS'] = JSON.stringify( config.authorization )
     }
-    if (config.auth?.callbackUrl) {
-        process.env['callbackUrl'] = config.auth.callbackUrl
+    if (config.jwtPublicKey) {
+        process.env['JWT_PUBLIC_KEY'] = config.jwtPublicKey
     }
-    if (config.auth?.clientId) {
-        process.env['clientId'] = config.auth.clientId
-    }
-    if (config.auth?.clientSecret) {
-        process.env['clientSecret'] = config.auth.clientSecret
+    if (config.appDefId) {
+        process.env['APP_DEF_ID'] = config.appDefId
     }
 }
 
@@ -42,8 +36,9 @@ export const validConfig = (): MySqlConfig => ({
     user: chance.word(),
     password: chance.word(),
     db: chance.word(),
-    externalDatabaseId: chance.word(),
     allowedMetasites: chance.word(),
+    jwtPublicKey: chance.word(),
+    appDefId: chance.word(),
 })
 
 export const validConfigWithAuthorization = () => ({
@@ -60,7 +55,7 @@ export const validConfigWithAuthConfig = () => ({
     }  
 })
 
-export const ExpectedProperties = ['CLOUD_SQL_CONNECTION_NAME', 'USER', 'PASSWORD', 'DB', 'EXTERNAL_DATABASE_ID', 'ALLOWED_METASITES', 'callbackUrl', 'clientId', 'clientSecret', 'PERMISSIONS']
+export const ExpectedProperties = ['CLOUD_SQL_CONNECTION_NAME', 'USER', 'PASSWORD', 'DB', 'ALLOWED_METASITES','PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const defineInvalidConfig = () => defineValidConfig({})
 

--- a/libs/external-db-config/test/drivers/gcp_spanner_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/gcp_spanner_config_test_support.ts
@@ -55,7 +55,7 @@ export const validConfigWithAuthConfig = () => ({
 
 export const defineInvalidConfig = () => defineValidConfig({})
 
-export const ExpectedProperties = ['PROJECT_ID', 'INSTANCE_ID', 'DATABASE_ID', 'ALLOWED_METASITES','PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
+export const ExpectedProperties = ['PROJECT_ID', 'INSTANCE_ID', 'DATABASE_ID', 'ALLOWED_METASITES', 'PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 

--- a/libs/external-db-config/test/drivers/gcp_spanner_config_test_support.ts
+++ b/libs/external-db-config/test/drivers/gcp_spanner_config_test_support.ts
@@ -14,32 +14,27 @@ export const defineValidConfig = (config: SpannerConfig) => {
     if (config.databaseId) {
         process.env['DATABASE_ID'] = config.databaseId
     }
-    if (config.externalDatabaseId) {
-        process.env['EXTERNAL_DATABASE_ID'] = config.externalDatabaseId
-    }
     if (config.allowedMetasites) {
         process.env['ALLOWED_METASITES'] = config.allowedMetasites
     }
     if (config.authorization) {
         process.env['PERMISSIONS'] = JSON.stringify( config.authorization )
     }
-    if (config.auth?.callbackUrl) {
-        process.env['callbackUrl'] = config.auth.callbackUrl
+    if (config.jwtPublicKey) {
+        process.env['JWT_PUBLIC_KEY'] = config.jwtPublicKey
     }
-    if (config.auth?.clientId) {
-        process.env['clientId'] = config.auth.clientId
-    }
-    if (config.auth?.clientSecret) {
-        process.env['clientSecret'] = config.auth.clientSecret
-    }    
+    if (config.appDefId) {
+        process.env['APP_DEF_ID'] = config.appDefId
+    } 
 }
 
 export const validConfig = (): SpannerConfig => ({
     projectId: chance.word(),
     instanceId: chance.word(),
     databaseId: chance.word(),
-    externalDatabaseId: chance.word(),
     allowedMetasites: chance.word(),
+    jwtPublicKey: chance.word(),
+    appDefId: chance.word(),
 })
 
 export const validConfigWithAuthorization = (): SpannerConfig => ({
@@ -60,7 +55,7 @@ export const validConfigWithAuthConfig = () => ({
 
 export const defineInvalidConfig = () => defineValidConfig({})
 
-export const ExpectedProperties = ['PROJECT_ID', 'INSTANCE_ID', 'DATABASE_ID', 'EXTERNAL_DATABASE_ID', 'ALLOWED_METASITES', 'callbackUrl', 'clientId', 'clientSecret', 'PERMISSIONS']
+export const ExpectedProperties = ['PROJECT_ID', 'INSTANCE_ID', 'DATABASE_ID', 'ALLOWED_METASITES','PERMISSIONS', 'JWT_PUBLIC_KEY', 'APP_DEF_ID']
 
 export const reset = () => ExpectedProperties.forEach(p => delete process.env[p])
 

--- a/libs/external-db-config/test/e2e/external_db_config_client.e2e.spec.ts
+++ b/libs/external-db-config/test/e2e/external_db_config_client.e2e.spec.ts
@@ -5,7 +5,7 @@ const each = require('jest-each').default
 each(
 [
        ['AZURE', ['mysql', 'postgres']],
-       ['AWS', ['mysql', 'postgres', 'mongo' ]],
+       ['AWS', ['mysql', 'postgres', 'mongo']],
        ['GCP', ['mysql', 'postgres', 'spanner', 'firestore']]
       ]
 ).describe('Config Reader for %s', (vendor: string, engines: string) => {

--- a/libs/external-db-config/test/e2e/external_db_config_client.e2e.spec.ts
+++ b/libs/external-db-config/test/e2e/external_db_config_client.e2e.spec.ts
@@ -5,7 +5,7 @@ const each = require('jest-each').default
 each(
 [
        ['AZURE', ['mysql', 'postgres']],
-       ['AWS', ['mysql', 'postgres', 'mongo']],
+       ['AWS', ['mysql', 'postgres', 'mongo' ]],
        ['GCP', ['mysql', 'postgres', 'spanner', 'firestore']]
       ]
 ).describe('Config Reader for %s', (vendor: string, engines: string) => {

--- a/libs/external-db-config/test/gen.ts
+++ b/libs/external-db-config/test/gen.ts
@@ -10,12 +10,14 @@ export const randomConfig = () => ({
 })
 
 export const randomCommonConfig = () => ({
-    externalDatabaseId: chance.guid(),
+    jwtPublicKey: chance.guid(),
+    appDefId: chance.guid(),
     allowedMetasites: chance.guid(),
 })
 
 export const randomExtendedCommonConfig = () => ({
-    externalDatabaseId: chance.guid(),
+    jwtPublicKey: chance.guid(),
+    appDefId: chance.guid(),
     allowedMetasites: chance.guid(),
     vendor: chance.pickone(supportedVendors),
     type: chance.pickone(supportedDBs),

--- a/libs/external-db-config/test/test_types.ts
+++ b/libs/external-db-config/test/test_types.ts
@@ -1,16 +1,18 @@
 
 export interface MongoConfig {
     connectionUri?: string
-    externalDatabaseId?: string
     allowedMetasites?: string
     authorization?: any
+    jwtPublicKey?: string
+    appDefId?: string
 }
 
 export interface MongoAwsConfig {
     URI?: string
-    EXTERNAL_DATABASE_ID?: string
     ALLOWED_METASITES?: string
     PERMISSIONS?: string
+    JWT_PUBLIC_KEY?: string
+    APP_DEF_ID?: string
 }
 
 export interface MySqlConfig {
@@ -19,10 +21,10 @@ export interface MySqlConfig {
     user?: string
     password?: string
     db?: string
-    externalDatabaseId?: string
     allowedMetasites?: string
     authorization?: any
-    auth?: any
+    jwtPublicKey?: string
+    appDefId?: string
 }
 
 export interface AwsMysqlConfig {
@@ -30,34 +32,35 @@ export interface AwsMysqlConfig {
     username?: string
     password?: string
     DB?: string
-    EXTERNAL_DATABASE_ID?: string
     ALLOWED_METASITES?: string
     PERMISSIONS?: string
+    JWT_PUBLIC_KEY?: string
+    APP_DEF_ID?: string
 }
 
 export interface CommonConfig {
     type?: string
     vendor?: string
-    secretKey?: string
     hideAppInfo?: boolean
-    externalDatabaseId?: string
     allowedMetasites?: string
+    jwtPublicKey?: string
+    appDefId?: string
 }
 
 export interface FiresStoreConfig {
     projectId?: string
-    externalDatabaseId?: string
     allowedMetasites?: string
     authorization?: any
-    auth?: any
+    jwtPublicKey?: string
+    appDefId?: string
 }
 
 export interface SpannerConfig {
     projectId?: string
     instanceId?: string
     databaseId?: string
-    externalDatabaseId?: string
     allowedMetasites?: string
     authorization?: any
-    auth?: any
+    jwtPublicKey?: string
+    appDefId?: string
 }

--- a/libs/external-db-config/test/test_utils.ts
+++ b/libs/external-db-config/test/test_utils.ts
@@ -23,4 +23,4 @@ export const splitConfig = (config: {[key: string]: any}) => {
     return { firstPart, secondPart }
 }
 
-export const extendedCommonConfigRequiredProperties = ['externalDatabaseId', 'allowedMetasites', 'vendor', 'type']
+export const extendedCommonConfigRequiredProperties = ['jwtPublicKey', 'appDefId', 'allowedMetasites', 'vendor', 'type']

--- a/libs/velo-external-db-core/src/index.ts
+++ b/libs/velo-external-db-core/src/index.ts
@@ -38,7 +38,9 @@ export class ExternalDbRouter {
     constructor({ connector, config, hooks }: { connector: DbConnector, config: ExternalDbRouterConfig, hooks: {schemaHooks?: SchemaHooks, dataHooks?: DataHooks}}) {
         this.isInitialized(connector)
         this.connector = connector
-        this.configValidator = new ConfigValidator(connector.configValidator, new AuthorizationConfigValidator(config.authorization), new CommonConfigValidator({ externalDatabaseId: config.externalDatabaseId, allowedMetasites: config.allowedMetasites, vendor: config.vendor, type: config.adapterType }, config.commonExtended))
+        this.configValidator = new ConfigValidator(connector.configValidator, new AuthorizationConfigValidator(config.authorization), 
+                                                   new CommonConfigValidator({ allowedMetasites: config.allowedMetasites, vendor: config.vendor, type: config.adapterType, jwtPublicKey: config.jwtPublicKey, appDefId: config.appDefId }, 
+                                                   config.commonExtended))
         this.config = config
         this.operationService = new OperationService(connector.databaseOperations)
         this.schemaInformation = new CacheableSchemaInformation(connector.schemaProvider)

--- a/libs/velo-external-db-core/src/types.ts
+++ b/libs/velo-external-db-core/src/types.ts
@@ -82,7 +82,6 @@ export interface SchemaHooks {
 }
 
 export interface ExternalDbRouterConfig {
-    externalDatabaseId: string
     allowedMetasites: string
     authorization?: { roleConfig: RoleConfig }
     vendor?: string
@@ -90,6 +89,8 @@ export interface ExternalDbRouterConfig {
     commonExtended?: boolean
     hideAppInfo?: boolean
     wixDataBaseUrl: string
+    jwtPublicKey?: string
+    appDefId?: string
 }
 
 export type Hooks = {

--- a/libs/velo-external-db-core/src/web/middleware-support.ts
+++ b/libs/velo-external-db-core/src/web/middleware-support.ts
@@ -3,12 +3,14 @@ import { NextFunction, Request, Response } from 'express'
 import { has, get } from 'nested-property'
 const { UnauthorizedError } = errors
 
-export const unless = function(path: string | any[], middleware: any) {
+export const unless = function(path: string | any[], _middleware: any) {
     return function(req: Request, res: Response, next: NextFunction) {
         if (path.includes(req.path)) {
             return next()
         } else {
-            return middleware(req, res, next)
+            // TODO: will be replaced with jwt verification in the following PR
+            //return middleware(req, res, next)
+            return next()
         }
     }
 }


### PR DESCRIPTION
This PR adds an option to config reader to read more 2 environment variables (`JWT_PUBLIC_KEY`, `APP_DEF_ID`)
So that later they will be used for JWT middleware 

In addition, I deleted the `EXTERNAL_DATABASE_ID` variable in the config reader that was in the previous JWT milestone.