### PR TITLE
Error SPI implementation

### DIFF
--- a/apps/velo-external-db/test/e2e/app_data_hooks.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_data_hooks.e2e.spec.ts
@@ -518,13 +518,14 @@ describe(`Velo External DB Data Hooks: ${currentDbImplementationName()}`, () => 
                 dataHooks: {
                     beforeAll: (_payload, _requestContext, _serviceContext) => {
                         const error = new Error('message')
+                        error['status'] = '409'
                         throw error
                     }
                 }
             })
 
             await expect(axios.post('/items/remove', hooks.writeRequestBodyWith(ctx.collectionName, [ctx.item]), authOwner)).rejects.toMatchObject(
-                errorResponseWith('WDE0054', 'message')
+                errorResponseWith('WDE0054', 'message', 409)
             )
         })
 
@@ -539,7 +540,7 @@ describe(`Velo External DB Data Hooks: ${currentDbImplementationName()}`, () => 
             })
 
             await expect(axios.post('/items/remove', hooks.writeRequestBodyWith(ctx.collectionName, [ctx.item]), authOwner)).rejects.toMatchObject(
-                errorResponseWith('WDE0054', 'message')
+                errorResponseWith('WDE0054', 'message', 500)
             )
         })
 
@@ -553,7 +554,7 @@ describe(`Velo External DB Data Hooks: ${currentDbImplementationName()}`, () => 
             })
 
             await expect(axios.post('/items/remove', hooks.writeRequestBodyWith(ctx.collectionName, [ctx.item]), authOwner)).rejects.toMatchObject(
-                errorResponseWith('WDE0054', 'message')
+                errorResponseWith('WDE0054', 'message', 500)
             )
         })
     })

--- a/apps/velo-external-db/test/e2e/app_data_hooks.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_data_hooks.e2e.spec.ts
@@ -518,14 +518,13 @@ describe(`Velo External DB Data Hooks: ${currentDbImplementationName()}`, () => 
                 dataHooks: {
                     beforeAll: (_payload, _requestContext, _serviceContext) => {
                         const error = new Error('message')
-                        error['status'] = '409'
                         throw error
                     }
                 }
             })
 
             await expect(axios.post('/items/remove', hooks.writeRequestBodyWith(ctx.collectionName, [ctx.item]), authOwner)).rejects.toMatchObject(
-                errorResponseWith(409, 'message')
+                errorResponseWith('WDE0054', 'message')
             )
         })
 
@@ -540,7 +539,7 @@ describe(`Velo External DB Data Hooks: ${currentDbImplementationName()}`, () => 
             })
 
             await expect(axios.post('/items/remove', hooks.writeRequestBodyWith(ctx.collectionName, [ctx.item]), authOwner)).rejects.toMatchObject(
-                errorResponseWith(500, 'message')
+                errorResponseWith('WDE0054', 'message')
             )
         })
 
@@ -554,7 +553,7 @@ describe(`Velo External DB Data Hooks: ${currentDbImplementationName()}`, () => 
             })
 
             await expect(axios.post('/items/remove', hooks.writeRequestBodyWith(ctx.collectionName, [ctx.item]), authOwner)).rejects.toMatchObject(
-                errorResponseWith(500, 'message')
+                errorResponseWith('WDE0054', 'message')
             )
         })
     })

--- a/apps/velo-external-db/test/e2e/app_schema.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_schema.e2e.spec.ts
@@ -115,8 +115,9 @@ describe(`Schema REST API: ${currentDbImplementationName()}`,  () => {
         })
 
         describe('error handling', () => {
-            if (['mysql', 'postgres', 'mssql'].includes(currentDbImplementationName())) {
-                test('should throw "CollectionChangeNotSupported" error on failed collection alteration', async() => {
+            const CouldFailOnColumnTypeChangeDbs = ['mysql', 'postgres', 'mssql']
+            if (CouldFailOnColumnTypeChangeDbs.includes(currentDbImplementationName())) {
+                testIfSupportedOperationsIncludes(supportedOperations, [ ChangeColumnType ])('should throw "CollectionChangeNotSupported" error on failed collection alteration', async() => {
                     await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
                     await data.givenItems([ctx.item], ctx.collectionName, authOwner)
                     const collection = await schema.retrieveSchemaFor(ctx.collectionName, authOwner)

--- a/apps/velo-external-db/test/e2e/app_schema.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_schema.e2e.spec.ts
@@ -115,7 +115,7 @@ describe(`Schema REST API: ${currentDbImplementationName()}`,  () => {
         })
 
         describe('error handling', () => {
-            if (['mysql', 'postgres'].includes(currentDbImplementationName())) {
+            if (['mysql', 'postgres', 'mssql'].includes(currentDbImplementationName())) {
                 test('should throw "CollectionChangeNotSupported" error on failed collection alteration', async() => {
                     await schema.givenCollection(ctx.collectionName, [ctx.column], authOwner)
                     await data.givenItems([ctx.item], ctx.collectionName, authOwner)

--- a/apps/velo-external-db/test/e2e/app_schema_hooks.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_schema_hooks.e2e.spec.ts
@@ -251,14 +251,13 @@ describe(`Velo External DB Schema Hooks: ${currentDbImplementationName()}`, () =
                 schemaHooks: {
                     beforeAll: (_payload, _requestContext, _serviceContext) => {
                         const error = new Error('message')
-                        error['status'] = '409'
                         throw error
                     }
                 }
             })
 
             await expect(axiosClient.post('/collections/delete', hooks.collectionWriteRequestBodyWith({ id: ctx.collectionId, fields: [] }), authOwner)).rejects.toMatchObject(
-                errorResponseWith(409, 'message')
+                errorResponseWith('WDE0054', 'message')
             )
         })
 
@@ -273,7 +272,7 @@ describe(`Velo External DB Schema Hooks: ${currentDbImplementationName()}`, () =
             })
 
             await expect(axiosClient.post('/collections/delete', hooks.collectionWriteRequestBodyWith({ id: ctx.collectionId, fields: [] }), authOwner)).rejects.toMatchObject(
-                errorResponseWith(500, 'message')
+                errorResponseWith('WDE0054', 'message')
             )
         })
 
@@ -287,7 +286,7 @@ describe(`Velo External DB Schema Hooks: ${currentDbImplementationName()}`, () =
             })
 
             await expect(axiosClient.post('/collections/delete', hooks.collectionWriteRequestBodyWith({ id: ctx.collectionId, fields: [] }), authOwner)).rejects.toMatchObject(
-                errorResponseWith(500, 'message')
+                errorResponseWith('WDE0054', 'message')
             )
         })
     })

--- a/apps/velo-external-db/test/e2e/app_schema_hooks.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_schema_hooks.e2e.spec.ts
@@ -251,13 +251,14 @@ describe(`Velo External DB Schema Hooks: ${currentDbImplementationName()}`, () =
                 schemaHooks: {
                     beforeAll: (_payload, _requestContext, _serviceContext) => {
                         const error = new Error('message')
+                        error['status'] = 409
                         throw error
                     }
                 }
             })
 
             await expect(axiosClient.post('/collections/delete', hooks.collectionWriteRequestBodyWith({ id: ctx.collectionId, fields: [] }), authOwner)).rejects.toMatchObject(
-                errorResponseWith('WDE0054', 'message')
+                errorResponseWith('WDE0054', 'message', 409)
             )
         })
 
@@ -272,7 +273,7 @@ describe(`Velo External DB Schema Hooks: ${currentDbImplementationName()}`, () =
             })
 
             await expect(axiosClient.post('/collections/delete', hooks.collectionWriteRequestBodyWith({ id: ctx.collectionId, fields: [] }), authOwner)).rejects.toMatchObject(
-                errorResponseWith('WDE0054', 'message')
+                errorResponseWith('WDE0054', 'message', 500)
             )
         })
 
@@ -286,7 +287,7 @@ describe(`Velo External DB Schema Hooks: ${currentDbImplementationName()}`, () =
             })
 
             await expect(axiosClient.post('/collections/delete', hooks.collectionWriteRequestBodyWith({ id: ctx.collectionId, fields: [] }), authOwner)).rejects.toMatchObject(
-                errorResponseWith('WDE0054', 'message')
+                errorResponseWith('WDE0054', 'message', 500)
             )
         })
     })

--- a/libs/external-db-mssql/src/mssql_schema_provider.ts
+++ b/libs/external-db-mssql/src/mssql_schema_provider.ts
@@ -96,7 +96,7 @@ export default class SchemaProvider implements ISchemaProvider {
     async changeColumnType(collectionName: string, column: InputField): Promise<void> {
         await validateSystemFields(column.name)
         await this.sql.query(`ALTER TABLE ${escapeTable(collectionName)} ALTER COLUMN ${escapeId(column.name)} ${this.sqlSchemaTranslator.dbTypeFor(column)}`)
-                      .catch(translateErrorCodes)
+                      .catch(err => translateErrorCodes(err, collectionName, column.name))
     }
 
     private appendAdditionalRowDetails(row: { field: string} & FieldAttributes): ResponseField {

--- a/libs/external-db-mssql/src/sql_exception_translator.ts
+++ b/libs/external-db-mssql/src/sql_exception_translator.ts
@@ -1,7 +1,8 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
-const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist, CollectionAlreadyExists, DbConnectionError, ItemAlreadyExists } = errors
+const { CollectionDoesNotExists, FieldAlreadyExists, FieldDoesNotExist, CollectionAlreadyExists, 
+    DbConnectionError, ItemAlreadyExists, CollectionChangeNotSupportedError } = errors
 
-export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string) => {
+export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string, fieldName?: string) => {
     if (err.number) {
         switch (err.number) {
             case 4902:
@@ -14,6 +15,8 @@ export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string
                 return new FieldDoesNotExist('Collection does not contain a field with this name', collectionName)
             case 2714:
                 return new CollectionAlreadyExists('Collection already exists', collectionName)
+            case 8114:
+                return new CollectionChangeNotSupportedError(`${err.message}`, collectionName, fieldName)
             default:
                 return new Error(`default ${err.message}`)
         }
@@ -30,8 +33,8 @@ export const notThrowingTranslateErrorCodes = (err: any, collectionName?: string
     }
 }
 
-export const translateErrorCodes = (err: any, collectionName?: string) => {
-    throw notThrowingTranslateErrorCodes(err, collectionName)
+export const translateErrorCodes = (err: any, collectionName?: string, fieldName?: string) => {
+    throw notThrowingTranslateErrorCodes(err, collectionName, fieldName)
 }
 
 

--- a/libs/external-db-postgres/src/sql_exception_translator.ts
+++ b/libs/external-db-postgres/src/sql_exception_translator.ts
@@ -32,7 +32,7 @@ export const notThrowingTranslateErrorCodes = (err: any, collectionName: string,
         case 'EAI_AGAIN':
             return new DbConnectionError('Database host is unavailable.')
         case '22P02':
-            return new CollectionChangeNotSupportedError(err.messag, collectionName, fieldName)
+            return new CollectionChangeNotSupportedError(`${err.message}`, collectionName, fieldName)
         default :
             console.error(err)
             return new UnrecognizedError(`${err.code}, ${err.message}`)

--- a/libs/external-db-testkit/src/lib/auth_test_support.ts
+++ b/libs/external-db-testkit/src/lib/auth_test_support.ts
@@ -58,7 +58,7 @@ export const authOwnerWithWrongAppId= { transformRequest: axios.defaults
 
                                     
 
-export const errorResponseWith = (code: any, message: string) => ({ response: { data: { data: { description: expect.stringContaining(message) }, code } } })
+export const errorResponseWith = (code: any, message: string, httpStatusCode: number) => ({ response: { data: { data: { description: expect.stringContaining(message) }, code  }, status: httpStatusCode } })
 
 export const collectionChangeNotSupportedErrorResponseWith = (fieldsName: string[]) => ({ response: { data: { data: { errors: fieldsName.map(f => ({ fieldKey: f, message: expect.any(String) })) }, code: 'WDE0119' } } })
 

--- a/libs/external-db-testkit/src/lib/auth_test_support.ts
+++ b/libs/external-db-testkit/src/lib/auth_test_support.ts
@@ -59,3 +59,6 @@ export const authOwnerWithWrongAppId= { transformRequest: axios.defaults
                                     
 
 export const errorResponseWith = (code: any, message: string) => ({ response: { data: { data: { description: expect.stringContaining(message) }, code } } })
+
+export const collectionChangeNotSupportedErrorResponseWith = (fieldsName: string[]) => ({ response: { data: { data: { errors: fieldsName.map(f => ({ fieldKey: f, message: expect.any(String) })) }, code: 'WDE0119' } } })
+

--- a/libs/external-db-testkit/src/lib/auth_test_support.ts
+++ b/libs/external-db-testkit/src/lib/auth_test_support.ts
@@ -58,4 +58,4 @@ export const authOwnerWithWrongAppId= { transformRequest: axios.defaults
 
                                     
 
-export const errorResponseWith = (status: any, message: string) => ({ response: { data: { description: expect.stringContaining(message) }, status } })
+export const errorResponseWith = (code: any, message: string) => ({ response: { data: { data: { description: expect.stringContaining(message) }, code } } })

--- a/libs/velo-external-db-core/src/spi-model/errors.ts
+++ b/libs/velo-external-db-core/src/spi-model/errors.ts
@@ -142,6 +142,15 @@ export class FieldAlreadyExistsError extends BaseWixError {
     }
 }
 
+export class UnsupportedSchemaOperation extends BaseWixError {
+    data: { collectionId: string, operation: string }
+
+    constructor(collectionName: string, operation: string, message: string) {
+        super(message, HttpStatusCode.INVALID_ARGUMENT, ApiErrors.WDE0119, collectionName)
+        this.data = { collectionId: collectionName, operation }
+    }
+}
+
 
 export enum ApiErrors {
     // Unknown error

--- a/libs/velo-external-db-core/src/spi-model/errors.ts
+++ b/libs/velo-external-db-core/src/spi-model/errors.ts
@@ -1,320 +1,146 @@
-export class ErrorMessage {
-    static unknownError(description?: string, status?: number) {
-        return HttpError.create({
-            code: ApiErrors.WDE0054,
-            description
-        } as ErrorMessage, status || HttpStatusCode.INTERNAL)
-    }
-
-    static operationTimeLimitExceeded(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0028,
-            description
-        } as ErrorMessage, HttpStatusCode.RESOURCE_EXHAUSTED)
-    }
-
-    static invalidUpdate(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0007,
-            description
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static operationIsNotSupportedByCollection(collectionName: string, operation: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0119,
-            description,
-            data: {
-                collectionName,
-                operation
-            } as UnsupportedByCollectionDetails
-        } as ErrorMessage, HttpStatusCode.FAILED_PRECONDITION)
-    }
-
-    static operationIsNotSupportedByDataSource(collectionName: string, operation: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0120,
-            description,
-            data: {
-                collectionName,
-                operation
-            } as UnsupportedByCollectionDetails
-        } as ErrorMessage, HttpStatusCode.FAILED_PRECONDITION)
-    }
-
-    static itemAlreadyExists(itemId: string, collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0074,
-            description,
-            data: {
-                itemId,
-                collectionId: collectionName
-            } as InvalidItemDetails
-        } as ErrorMessage, HttpStatusCode.ALREADY_EXISTS)
-    }
-
-    static uniqIndexConflict(itemId: string, collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0123,
-            description,
-            data: {
-                itemId,
-                collectionId: collectionName
-            } as InvalidItemDetails
-        } as ErrorMessage, HttpStatusCode.ALREADY_EXISTS)
-    }
-
-    static documentTooLargeToIndex(itemId: string, collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0133,
-            description,
-            data: {
-                itemId,
-                collectionId: collectionName
-            } as InvalidItemDetails
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static dollarPrefixedFieldNameNotAllowed(itemId: string, collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0134,
-            description,
-            data: {
-                itemId,
-                collectionId: collectionName
-            } as InvalidItemDetails
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static requestPerMinuteQuotaExceeded(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0014,
-            description
-        } as ErrorMessage, HttpStatusCode.RESOURCE_EXHAUSTED)
-    }
-
-    static processingTimeQuotaExceeded(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0122,
-            description
-        } as ErrorMessage, HttpStatusCode.RESOURCE_EXHAUSTED)
-    }
-
-    static storageSpaceQuotaExceeded(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0091,
-            description
-        } as ErrorMessage, HttpStatusCode.RESOURCE_EXHAUSTED)
-    }
-
-    static documentIsTooLarge(itemId: string, collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0009,
-            description,
-            data: {
-                itemId,
-                collectionId: collectionName
-            } as InvalidItemDetails
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static itemNotFound(itemId: string, collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0073,
-            description,
-            data: {
-                itemId,
-                collectionId: collectionName
-            } as InvalidItemDetails
-        } as ErrorMessage, HttpStatusCode.NOT_FOUND)
-    }
-
-    static collectionNotFound(collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0025,
-            description,
-            data: {
-                collectionId: collectionName
-            } as InvalidCollectionDetails
-        } as ErrorMessage, HttpStatusCode.NOT_FOUND)
-    }
-
-    static collectionDeleted(collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0026,
-            description,
-            data: {
-                collectionId: collectionName
-            } as InvalidCollectionDetails
-        } as ErrorMessage, HttpStatusCode.NOT_FOUND)
-    }
-
-    static propertyDeleted(collectionName: string, propertyName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0024,
-            description,
-            data: {
-                collectionId: collectionName,
-                propertyName
-            } as InvalidPropertyDetails
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static userDoesNotHavePermissionToPerformAction(collectionName: string, operation: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0027,
-            description,
-            data: {
-                collectionName,
-                operation
-            } as PermissionDeniedDetails
-        } as ErrorMessage, HttpStatusCode.PERMISSION_DENIED)
-    }
-
-    static genericRequestValidationError(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0075,
-            description
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static notAMultiReferenceProperty(collectionName: string, propertyName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0020,
-            description,
-            data: {
-                collectionId: collectionName,
-                propertyName
-            } as InvalidPropertyDetails
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    } 
-
-    static datasetIsTooLargeToSort(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0092,
-            description
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static payloadIsToolarge(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0109,
-            description
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static sortingByMultipleArrayFieldsIsNotSupported(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0121,
-            description
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static offsetPagingIsNotSupported(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0082,
-            description
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-
-    static referenceAlreadyExists(collectionName: string, propertyName: string, referencingItemId: string, referencedItemId: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0029,
-            description,
-            data: {
-                collectionName,
-                propertyName,
-                referencingItemId,
-                referencedItemId
-            } as InvalidReferenceDetails
-        } as ErrorMessage, HttpStatusCode.ALREADY_EXISTS)
-    }
-
-    static unknownErrorWhileBuildingCollectionIndex(collectionName: string, itemId?: string, details?: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0112,
-            description,
-            data: {
-                collectionName,
-                itemId,
-                details,
-            } as IndexingFailureDetails
-        } as ErrorMessage, HttpStatusCode.ALREADY_EXISTS)
-    }
-
-    static duplicateKeyErrorWhileBuildingCollectionIndex(collectionName: string, itemId?: string, details?: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0113,
-            description,
-            data: {
-                collectionName,
-                itemId,
-                details,
-            } as IndexingFailureDetails
-        } as ErrorMessage, HttpStatusCode.ALREADY_EXISTS)
-    }
-
-    static documentTooLargeWhileBuildingCollectionIndex(collectionName: string, itemId?: string, details?: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0114,
-            description,
-            data: {
-                collectionName,
-                itemId,
-                details,
-            } as IndexingFailureDetails
-        } as ErrorMessage, HttpStatusCode.ALREADY_EXISTS)
-    }
-
-    static collectionAlreadyExists(collectionName: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0104,
-            description,
-            data: {
-                collectionId: collectionName
-            } as InvalidCollectionDetails
-        } as ErrorMessage, HttpStatusCode.ALREADY_EXISTS)
-    }
-
-    static invalidProperty(collectionName: string, propertyName?: string, description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0147,
-            description,
-            data: {
-                collectionId: collectionName,
-                propertyName
-            } as InvalidPropertyDetails
-        } as ErrorMessage, HttpStatusCode.INVALID_ARGUMENT)
-    }
-    static unauthorized(description?: string) {
-        return HttpError.create({
-            code: ApiErrors.WDE0027,
-            description
-        } as ErrorMessage, HttpStatusCode.UNAUTHENTICATED)
-    }
-}
-
-export interface HttpError {
-    message: ErrorMessage,
+class BaseWixError extends Error {
+    collctionName: string
     httpCode: HttpStatusCode
-}
+    applicationCode: ApiErrors
 
-export class HttpError {
-    static create(message: ErrorMessage, httpCode: HttpStatusCode) {
-        return {
-            message,
-            httpCode
-        } as HttpError
+    constructor(message: string, httpCode: HttpStatusCode, applicationCode: ApiErrors, collectionName: string) {
+        super(message)
+        this.httpCode = httpCode
+        this.applicationCode = applicationCode
+        this.collctionName = collectionName
     }
 }
 
-export interface ErrorMessage {
-    code: ApiErrors,
-    description?: string,
-    data: object
+export class CollectionNotFoundError extends BaseWixError {
+    data: { collectionId: string }
+
+    constructor(collectionName: string, message: string) {
+        super(message, HttpStatusCode.NOT_FOUND, ApiErrors.WDE0025, collectionName)
+        this.data = { collectionId: collectionName }
+    }
+}
+
+export class CollectionAlreadyExistsError extends BaseWixError {
+    data: { collectionId: string }
+
+    constructor(collectionName: string, message: string) {
+        super(message, HttpStatusCode.ALREADY_EXISTS, ApiErrors.WDE0104, collectionName)
+        this.data = { collectionId: collectionName }
+    }
+}
+
+export class ItemNotFoundError extends BaseWixError {
+    data: { itemId: string }
+
+    constructor(collectionName: string, itemId: string, message: string) {
+        super(message, HttpStatusCode.NOT_FOUND, ApiErrors.WDE0073, collectionName)
+        this.data = { itemId }
+    }
+}
+
+export class ItemAlreadyExistsError extends BaseWixError {
+    data: { itemId: string }
+
+    constructor(collectionName: string, itemId: string, message: string) {
+        super(message, HttpStatusCode.ALREADY_EXISTS, ApiErrors.WDE0074, collectionName)
+        this.data = { itemId }
+    }
+}
+
+export class ReferenceNotFoundError extends BaseWixError {
+    referringItemId: string
+    referencedItemId: string
+    data: { referringItemId: string, referencedItemId: string }
+
+    constructor(message: string, collectionName: string, referringItemId: string, referencedItemId: string) {
+        super(message, HttpStatusCode.NOT_FOUND, ApiErrors.WDE0029, collectionName)
+        this.referringItemId = referringItemId
+        this.referencedItemId = referencedItemId
+        this.data = { referringItemId, referencedItemId }
+    }
+}
+
+export class ReferenceAlreadyExistsError extends BaseWixError {
+    referringItemId: string
+    referencedItemId: string
+    data: { referringItemId: string, referencedItemId: string }
+
+    constructor(message: string, collectionName: string, referringItemId: string, referencedItemId: string) {
+        super(message, HttpStatusCode.ALREADY_EXISTS, ApiErrors.WDE0029, collectionName)
+        this.referringItemId = referringItemId
+        this.referencedItemId = referencedItemId
+        this.data = { referringItemId, referencedItemId }
+    }
+}
+
+export interface ValidationViolation {
+    fieldPath: string;
+    rejectedValue: string;
+    message: string;
+}
+
+export class ValidationError extends BaseWixError {
+    violations: ValidationViolation[]
+    data: { violations: ValidationViolation[] }
+
+    constructor(message: string, collectionName: string, fieldPath: string, rejectedValue: string) {
+        super(message, HttpStatusCode.INVALID_ARGUMENT, ApiErrors.WDE0075, collectionName)
+        this.violations = [{ fieldPath, rejectedValue, message }]
+        this.data = { violations: this.violations }
+    }
+}
+
+export interface CollectionChangeNotSupportedErrorItem {
+    fieldKey: string;
+    message: string;
+}
+
+export class CollectionChangeNotSupportedError extends BaseWixError {
+    errors: CollectionChangeNotSupportedErrorItem[]
+    data: { errors: CollectionChangeNotSupportedErrorItem[] }
+
+    constructor(collectionName: string, fieldKey: string, message: string) {
+        super(message, HttpStatusCode.INVALID_ARGUMENT, ApiErrors.WDE0119, collectionName)
+        this.errors = [{ fieldKey, message }]
+        this.data = { errors: this.errors }
+    }
+}
+
+export class UnknownError extends BaseWixError {
+    data: { description: string }
+    constructor(message: string) {
+        super(message, HttpStatusCode.INTERNAL, ApiErrors.WDE0054, '')
+        this.data = { description: message }
+    }
 }
 
 
+export class InvalidPropertyError extends BaseWixError {
+    data: { collectionId: string, propertyName: string }
+
+    constructor(collectionName: string, propertyName: string, message: string) {
+        super(message, HttpStatusCode.INVALID_ARGUMENT, ApiErrors.WDE0147, collectionName)
+        this.data = { collectionId: collectionName, propertyName }
+    }
+}
+
+
+export class UnauthorizedError extends BaseWixError {
+    data: { description: string }
+    constructor(message: string) {
+        super(message, HttpStatusCode.UNAUTHENTICATED, ApiErrors.WDE0027, '')
+        this.data = { description: message }
+    }
+}
+
+export class FieldAlreadyExistsError extends BaseWixError {
+    data: { collectionId: string, fieldName: string }
+
+    constructor(collectionName: string, fieldName: string, message: string) {
+        super(message, HttpStatusCode.ALREADY_EXISTS, ApiErrors.WDE0123, collectionName)
+        this.data = { collectionId: collectionName, fieldName }
+    }
+}
 
 
 export enum ApiErrors {
@@ -428,35 +254,3 @@ export enum HttpStatusCode {
     // DATA_LOSS = 14; // 500
     // UNIMPLEMENTED = 15; // 501
   }
-
-
-interface UnsupportedByCollectionDetails {
-    collectionName: string
-    operation: string
-}
-interface InvalidItemDetails {
-    itemId: string
-    collectionId: string
-}
-interface InvalidCollectionDetails {
-    collectionId: string
-}
-interface InvalidPropertyDetails {
-    collectionId: string
-    propertyName: string
-}
-interface PermissionDeniedDetails {
-    collectionName: string
-    operation: string
-}
-interface InvalidReferenceDetails {
-    collectionName: string
-    propertyName: string
-    referencingItemId: string
-    referencedItemId: string
-}
-interface IndexingFailureDetails {
-    collectionName: string
-    itemId?: string
-    details?: string
-}

--- a/libs/velo-external-db-core/src/spi-model/errors.ts
+++ b/libs/velo-external-db-core/src/spi-model/errors.ts
@@ -108,8 +108,8 @@ export class CollectionChangeNotSupportedError extends BaseWixError {
 
 export class UnknownError extends BaseWixError {
     data: { description: string }
-    constructor(message: string) {
-        super(message, HttpStatusCode.INTERNAL, ApiErrors.WDE0054, '')
+    constructor(message: string, httpCode: number =  HttpStatusCode.INTERNAL) {
+        super(message, httpCode, ApiErrors.WDE0054, '')
         this.data = { description: message }
     }
 }

--- a/libs/velo-external-db-core/src/web/domain-to-spi-error-translator.ts
+++ b/libs/velo-external-db-core/src/web/domain-to-spi-error-translator.ts
@@ -1,7 +1,7 @@
 import { errors as domainErrors } from '@wix-velo/velo-external-db-commons' 
 import { ItemAlreadyExistsError, CollectionNotFoundError, ItemNotFoundError, CollectionAlreadyExistsError, CollectionChangeNotSupportedError, UnknownError, InvalidPropertyError, UnauthorizedError, FieldAlreadyExistsError } from '../spi-model/errors'
 
-export const domainToSpiErrorTranslator = (err: domainErrors.BaseHttpError) => {
+export const domainToSpiErrorTranslator = (err: any) => {
     switch(err.constructor) {
       case domainErrors.ItemAlreadyExists: 
         const itemAlreadyExists = err as domainErrors.ItemAlreadyExists
@@ -40,7 +40,7 @@ export const domainToSpiErrorTranslator = (err: domainErrors.BaseHttpError) => {
         return new UnauthorizedError(unauthorizedError.message)
       
       default:
-        return new UnknownError(err.message)
+        return new UnknownError(err.message, err.status)
     }
   }
 

--- a/libs/velo-external-db-core/src/web/domain-to-spi-error-translator.ts
+++ b/libs/velo-external-db-core/src/web/domain-to-spi-error-translator.ts
@@ -1,5 +1,6 @@
 import { errors as domainErrors } from '@wix-velo/velo-external-db-commons' 
-import { ItemAlreadyExistsError, CollectionNotFoundError, ItemNotFoundError, CollectionAlreadyExistsError, CollectionChangeNotSupportedError, UnknownError, InvalidPropertyError, UnauthorizedError, FieldAlreadyExistsError } from '../spi-model/errors'
+import { ItemAlreadyExistsError, CollectionNotFoundError, ItemNotFoundError, CollectionAlreadyExistsError, CollectionChangeNotSupportedError, 
+  UnknownError, InvalidPropertyError, UnauthorizedError, FieldAlreadyExistsError, UnsupportedSchemaOperation } from '../spi-model/errors'
 
 export const domainToSpiErrorTranslator = (err: any) => {
     switch(err.constructor) {
@@ -19,9 +20,9 @@ export const domainToSpiErrorTranslator = (err: any) => {
         const fieldDoesNotExist = err as domainErrors.FieldDoesNotExist
         return new InvalidPropertyError(fieldDoesNotExist.collectionName, fieldDoesNotExist.propertyName, fieldDoesNotExist.message)
   
-      // case domainErrors.UnsupportedSchemaOperation:
-      //   const unsupportedSchemaOperation = err as domainErrors.UnsupportedSchemaOperation
-      //   return ErrorMessage.operationIsNotSupportedByCollection(unsupportedSchemaOperation.collectionName, unsupportedSchemaOperation.operation, unsupportedSchemaOperation.message)
+      case domainErrors.UnsupportedSchemaOperation:
+        const unsupportedSchemaOperation = err as domainErrors.UnsupportedSchemaOperation
+        return new UnsupportedSchemaOperation(unsupportedSchemaOperation.collectionName, unsupportedSchemaOperation.operation, unsupportedSchemaOperation.message)
       
       case domainErrors.CollectionAlreadyExists:
         const collectionAlreadyExists = err as domainErrors.CollectionAlreadyExists

--- a/libs/velo-external-db-core/src/web/domain-to-spi-error-translator.ts
+++ b/libs/velo-external-db-core/src/web/domain-to-spi-error-translator.ts
@@ -1,48 +1,56 @@
 import { errors as domainErrors } from '@wix-velo/velo-external-db-commons' 
-import { ErrorMessage } from '../spi-model/errors'
+import { ItemAlreadyExistsError, CollectionNotFoundError, ItemNotFoundError, CollectionAlreadyExistsError, CollectionChangeNotSupportedError, UnknownError, InvalidPropertyError, UnauthorizedError, FieldAlreadyExistsError } from '../spi-model/errors'
 
-export const domainToSpiErrorTranslator = (err: any) => {
+export const domainToSpiErrorTranslator = (err: domainErrors.BaseHttpError) => {
     switch(err.constructor) {
       case domainErrors.ItemAlreadyExists: 
-        const itemAlreadyExists: domainErrors.ItemAlreadyExists = err
-        return ErrorMessage.itemAlreadyExists(itemAlreadyExists.itemId, itemAlreadyExists.collectionName, itemAlreadyExists.message)
+        const itemAlreadyExists = err as domainErrors.ItemAlreadyExists
+        return new ItemAlreadyExistsError(itemAlreadyExists.collectionName, itemAlreadyExists.itemId, itemAlreadyExists.message)
   
       case domainErrors.CollectionDoesNotExists:
-        const collectionDoesNotExists: domainErrors.CollectionDoesNotExists = err
-        return ErrorMessage.collectionNotFound(collectionDoesNotExists.collectionName, collectionDoesNotExists.message)
+        const collectionDoesNotExists = err as domainErrors.CollectionDoesNotExists
+        return new CollectionNotFoundError(collectionDoesNotExists.collectionName, collectionDoesNotExists.message)
       
       case domainErrors.FieldAlreadyExists:
-        const fieldAlreadyExists: domainErrors.FieldAlreadyExists = err
-        return ErrorMessage.itemAlreadyExists(fieldAlreadyExists.fieldName, fieldAlreadyExists.collectionName, fieldAlreadyExists.message)
+        const fieldAlreadyExists = err as domainErrors.FieldAlreadyExists
+        return new FieldAlreadyExistsError(fieldAlreadyExists.collectionName, fieldAlreadyExists.fieldName, fieldAlreadyExists.message)
       
       case domainErrors.FieldDoesNotExist:
-        const fieldDoesNotExist: domainErrors.FieldDoesNotExist = err
-        return ErrorMessage.invalidProperty(fieldDoesNotExist.collectionName, fieldDoesNotExist.propertyName, fieldDoesNotExist.message)
+        const fieldDoesNotExist = err as domainErrors.FieldDoesNotExist
+        return new InvalidPropertyError(fieldDoesNotExist.collectionName, fieldDoesNotExist.propertyName, fieldDoesNotExist.message)
   
-      case domainErrors.UnsupportedSchemaOperation:
-        const unsupportedSchemaOperation: domainErrors.UnsupportedSchemaOperation = err
-        return ErrorMessage.operationIsNotSupportedByCollection(unsupportedSchemaOperation.collectionName, unsupportedSchemaOperation.operation, unsupportedSchemaOperation.message)
+      // case domainErrors.UnsupportedSchemaOperation:
+      //   const unsupportedSchemaOperation = err as domainErrors.UnsupportedSchemaOperation
+      //   return ErrorMessage.operationIsNotSupportedByCollection(unsupportedSchemaOperation.collectionName, unsupportedSchemaOperation.operation, unsupportedSchemaOperation.message)
+      
+      case domainErrors.CollectionAlreadyExists:
+        const collectionAlreadyExists = err as domainErrors.CollectionAlreadyExists
+        return new CollectionAlreadyExistsError(collectionAlreadyExists.collectionName, collectionAlreadyExists.message)
       
       case domainErrors.ItemDoesNotExists:
-        const itemDoesNotExists: domainErrors.ItemDoesNotExists = err
-        return ErrorMessage.itemNotFound(itemDoesNotExists.itemId, itemDoesNotExists.collectionName, itemDoesNotExists.message)
-    
+        const itemDoesNotExists = err as domainErrors.ItemDoesNotExists
+        return new ItemNotFoundError(itemDoesNotExists.collectionName, itemDoesNotExists.itemId, itemDoesNotExists.message)
+
+      case domainErrors.CollectionChangeNotSupportedError:
+        const collectionChangeNotSupportedError = err as domainErrors.CollectionChangeNotSupportedError
+        return new CollectionChangeNotSupportedError(collectionChangeNotSupportedError.collectionName, collectionChangeNotSupportedError.fieldName, collectionChangeNotSupportedError.message)
+
       case domainErrors.UnauthorizedError:
-        const unauthorizedError: domainErrors.UnauthorizedError = err
-        return ErrorMessage.unauthorized(unauthorizedError.message)
-        
+        const unauthorizedError = err as domainErrors.UnauthorizedError
+        return new UnauthorizedError(unauthorizedError.message)
+      
       default:
-        return ErrorMessage.unknownError(err.message, err.status)  
+        return new UnknownError(err.message)
     }
   }
 
   export const domainToSpiErrorObjectTranslator = (err: any) => {
-    const { message, httpCode } = domainToSpiErrorTranslator(err)
+    const error = domainToSpiErrorTranslator(err)
     return { 
       error: {
-        errorCode: httpCode,
-        errorMessage: message.description,
-        data: message.data
+        errorCode: error.httpCode,
+        errorMessage: error.message,
+        data: error.data,
       }
     }
   }

--- a/libs/velo-external-db-core/src/web/error-middleware.spec.ts
+++ b/libs/velo-external-db-core/src/web/error-middleware.spec.ts
@@ -26,22 +26,24 @@ describe('Error Middleware', () => {
       errorMiddleware(err, null, ctx.res)
 
       expect(ctx.res.status).toHaveBeenCalledWith(500)
-      expect(ctx.res.send).toHaveBeenCalledWith( { description: err.message, code: 'WDE0054' } )
+      expect(ctx.res.send).toHaveBeenCalledWith( { data: { description: err.message }, code: 'WDE0054' } )
     })
 
-    test('converts exceptions to http error response', () => {
-      Object.values(errors)
-            .forEach(Exception => {
-              const err = new Exception(chance.word())
+    test.each(Object.entries(errors))('converts %s to http error response', (ExceptionName, ExceptionClass) => {
+              const err = new ExceptionClass(chance.word())
               errorMiddleware(err, null, ctx.res)
               const spiError = domainToSpiErrorTranslator(err)
-              // expect(ctx.res.status).toHaveBeenCalledWith(err.status)
-              expect(ctx.res.send).toHaveBeenCalledWith( spiError.message )
+
+              expect(ctx.res.status).toHaveBeenCalledWith(spiError.httpCode)
+              expect(ctx.res.send).toHaveBeenCalledWith({
+                data: spiError.data,
+                code: spiError.applicationCode
+              })
 
               ctx.res.status.mockClear()
               ctx.res.send.mockClear()
 
       })
-    })
+
   })
 })

--- a/libs/velo-external-db-core/src/web/error-middleware.ts
+++ b/libs/velo-external-db-core/src/web/error-middleware.ts
@@ -6,6 +6,9 @@ export const errorMiddleware = (err: any, _req: any, res: Response, _next?: Next
     console.error(err)
   }
 
-  const errorMsg = domainToSpiErrorTranslator(err)
-  res.status(errorMsg.httpCode).send(errorMsg.message)
+  const error = domainToSpiErrorTranslator(err)
+  res.status(error.httpCode).send({
+    data: error.data,
+    code: error.applicationCode
+  })
 }


### PR DESCRIPTION
This PR refactors the errors class and introduces a new `CollectionChangeNotSupported` error for MySQL, PostgreSQL, and MSSQL.

A few important notes about the new error:

- NoSQL databases will never throw the `CollectionChangeNotSupported` error.
- While Spanner can support partial column type changes, this functionality is not supported in the adapter due to the lack of support for many of the column changes that the adapter offers in Spanner.
