### PR TITLE
Richcontent field type fix

### DIFF
--- a/libs/external-db-bigquery/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-bigquery/src/sql_schema_translator.spec.ts
@@ -72,7 +72,6 @@ describe('Sql Schema Column Translator', () => {
         describe('string fields', () => {
             test.each([
                 'string',
-                'richcontent',
                 'image',
                 'video',
                 'audio',
@@ -125,6 +124,7 @@ describe('Sql Schema Column Translator', () => {
                 'multiReference',
                 'arrayDocument',
                 'arrayString',
+                'richcontent',
               ])('%s', (subtype) => {
                 expect(env.schemaTranslator.columnToDbColumnSql({ name: ctx.fieldName, type: 'object', subtype })).toEqual({ mode: '', name: escapeId(ctx.fieldName), type: 'JSON' })
               })

--- a/libs/external-db-bigquery/src/sql_schema_translator.ts
+++ b/libs/external-db-bigquery/src/sql_schema_translator.ts
@@ -93,7 +93,6 @@ export default class SchemaColumnTranslator {
             case 'text_medium':
             case 'text_large':
             case 'text_language':
-            case 'text_richcontent':
             case 'text_image':
             case 'text_video':
             case 'text_audio':
@@ -114,6 +113,7 @@ export default class SchemaColumnTranslator {
             case 'object_multireference':
             case 'object_arraystring':
             case 'object_arraydocument':
+            case 'object_richcontent':
             case 'object_array':
                 return 'JSON'
 

--- a/libs/external-db-mssql/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-mssql/src/sql_schema_translator.spec.ts
@@ -70,7 +70,6 @@ describe('Sql Schema Column Translator', () => {
 
             test.each([
                 'string',
-                'richcontent',
                 'image',
                 'video',
                 'audio',

--- a/libs/external-db-mssql/src/sql_schema_translator.ts
+++ b/libs/external-db-mssql/src/sql_schema_translator.ts
@@ -86,7 +86,6 @@ export default class SchemaColumnTranslator {
                 return 'SMALLDATETIME'
 
             case 'text_string':
-            case 'text_richcontent':
             case 'text_image':
             case 'text_video':
             case 'text_audio':

--- a/libs/external-db-mysql/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-mysql/src/sql_schema_translator.spec.ts
@@ -69,7 +69,6 @@ describe('Sql Schema Column Translator', () => {
         describe('string fields', () => {
             test.each([
                 'string',
-                'richcontent',
                 'image',
                 'video',
                 'audio',
@@ -107,6 +106,7 @@ describe('Sql Schema Column Translator', () => {
                 'multiReference',
                 'arrayDocument',
                 'arrayString',
+                'richcontent',
               ])('%s', (subtype) => {
                 expect(env.schemaTranslator.columnToDbColumnSql({ name: ctx.fieldName, type: 'object', subtype })).toEqual(`${escapeId(ctx.fieldName)} JSON`)
               })

--- a/libs/external-db-mysql/src/sql_schema_translator.ts
+++ b/libs/external-db-mysql/src/sql_schema_translator.ts
@@ -94,7 +94,6 @@ export default class SchemaColumnTranslato {
                 return 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP'
 
             case 'text_string':
-            case 'text_richcontent':
             case 'text_image':
             case 'text_video':
             case 'text_audio':
@@ -126,6 +125,7 @@ export default class SchemaColumnTranslato {
             case 'object_arraystring':
             case 'object_arraydocument':
             case 'object_array':
+            case 'object_richcontent':
                 return 'JSON'
 
             default:

--- a/libs/external-db-postgres/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-postgres/src/sql_schema_translator.spec.ts
@@ -55,7 +55,6 @@ describe('Sql Schema Column Translator', () => {
         describe('string fields', () => {
             test.each([
                 'string',
-                'richcontent',
                 'image',
                 'video',
                 'audio',
@@ -103,6 +102,7 @@ describe('Sql Schema Column Translator', () => {
                 'multiReference',
                 'arrayDocument',
                 'arrayString',
+                'richcontent',
               ])('%s', (subtype) => {
                 expect(env.schemaTranslator.columnToDbColumnSql({ name: ctx.fieldName, type: 'object', subtype })).toEqual(`${escapeIdentifier(ctx.fieldName)} json`)
               })

--- a/libs/external-db-postgres/src/sql_schema_translator.ts
+++ b/libs/external-db-postgres/src/sql_schema_translator.ts
@@ -100,7 +100,6 @@ export default class SchemaColumnTranslator {
                 return 'timestamp'
 
             case 'text_string':
-            case 'text_richcontent':
             case 'text_image':
             case 'text_video':
             case 'text_audio':
@@ -128,6 +127,7 @@ export default class SchemaColumnTranslator {
             case 'object_arraystring':
             case 'object_arraydocument':
             case 'object_array':
+            case 'object_richcontent':
                 return 'json'
 
             default:

--- a/libs/external-db-spanner/src/sql_schema_translator.spec.ts
+++ b/libs/external-db-spanner/src/sql_schema_translator.spec.ts
@@ -57,7 +57,6 @@ describe('Sql Schema Column Translator', () => {
         describe('string fields', () => {
             test.each([
                 'string',
-                'richcontent',
                 'image',
                 'video',
                 'audio',
@@ -105,6 +104,7 @@ describe('Sql Schema Column Translator', () => {
                 'multiReference',
                 'arrayDocument',
                 'arrayString',
+                'richcontent',
               ])('%s', (subtype) => {
                 expect(env.schemaTranslator.columnToDbColumnSql({ name: ctx.fieldName, type: 'object', subtype })).toEqual(`${escapeId(ctx.fieldName)} JSON`)
               })

--- a/libs/external-db-spanner/src/sql_schema_translator.ts
+++ b/libs/external-db-spanner/src/sql_schema_translator.ts
@@ -82,7 +82,6 @@ export default class SchemaColumnTranslator implements ISpannerSchemaColumnTrans
                 return 'TIMESTAMP'
 
             case 'text_string':
-            case 'text_richcontent':
             case 'text_image':
             case 'text_video':
             case 'text_audio':
@@ -114,6 +113,7 @@ export default class SchemaColumnTranslator implements ISpannerSchemaColumnTrans
             case 'object_arraystring':
             case 'object_arraydocument':
             case 'object_array':
+            case 'object_richcontent':
                 return 'JSON'
 
             default:

--- a/libs/velo-external-db-core/src/utils/schema_utils.spec.ts
+++ b/libs/velo-external-db-core/src/utils/schema_utils.spec.ts
@@ -61,7 +61,7 @@ describe('Schema utils functions', () => {
             [VeloFieldTypeEnum.arrayDocument, FieldType.object],
             [VeloFieldTypeEnum.audio, FieldType.text],
             [VeloFieldTypeEnum.language, FieldType.text],
-            [VeloFieldTypeEnum.richContent, FieldType.text],
+            [VeloFieldTypeEnum.richContent, FieldType.object],
             [VeloFieldTypeEnum.mediaGallery, FieldType.object],
             [VeloFieldTypeEnum.address, FieldType.object],
             [VeloFieldTypeEnum.pageLink, FieldType.object],

--- a/libs/velo-external-db-core/src/utils/schema_utils.ts
+++ b/libs/velo-external-db-core/src/utils/schema_utils.ts
@@ -36,7 +36,6 @@ export const wixDataEnumToFieldType = (fieldEnum: collectionSpi.FieldType): stri
         case collectionSpi.FieldType.url:
         case collectionSpi.FieldType.richText:
         case collectionSpi.FieldType.language:
-        case collectionSpi.FieldType.richContent:
         case collectionSpi.FieldType.image:
         case collectionSpi.FieldType.video:
         case collectionSpi.FieldType.document:
@@ -63,6 +62,7 @@ export const wixDataEnumToFieldType = (fieldEnum: collectionSpi.FieldType): stri
         case collectionSpi.FieldType.reference:
         case collectionSpi.FieldType.object:
         case collectionSpi.FieldType.array:
+        case collectionSpi.FieldType.richContent:
             return FieldType.object
         default:
             // TODO: throw specific error


### PR DESCRIPTION
The PR fixes the mistake that `richcontent` field was defined as string and not as JSON