### PR TITLE
handle empty aggregation as query

### DIFF
--- a/libs/external-db-bigquery/src/bigquery_data_provider.ts
+++ b/libs/external-db-bigquery/src/bigquery_data_provider.ts
@@ -1,5 +1,5 @@
 import { Dataset } from '@google-cloud/bigquery'
-import { IDataProvider, AdapterFilter as Filter, Item, AdapterAggregation as Aggregation, Sort } from '@wix-velo/velo-external-db-types'
+import { IDataProvider, AdapterFilter as Filter, Item, NonEmptyAdapterAggregation as Aggregation, Sort } from '@wix-velo/velo-external-db-types'
 import { asParamArrays, updateFieldsFor } from '@wix-velo/velo-external-db-commons'
 import { unPatchDateTime, patchDateTime, escapeIdentifier, patchObjectValueOfItems } from './bigquery_utils'
 import FilterParser from './sql_filter_transformer'

--- a/libs/external-db-bigquery/src/sql_filter_transformer.ts
+++ b/libs/external-db-bigquery/src/sql_filter_transformer.ts
@@ -1,4 +1,4 @@
-import { AdapterFilter as Filter, AdapterAggregation as Aggregation, AdapterOperator, Sort, NotEmptyAdapterFilter, AdapterFunctions } from '@wix-velo/velo-external-db-types'
+import { AdapterFilter as Filter, NonEmptyAdapterAggregation as Aggregation, AdapterOperator, Sort, NotEmptyAdapterFilter, AdapterFunctions } from '@wix-velo/velo-external-db-types'
 import { EmptyFilter, EmptySort, isObject, isEmptyFilter, AdapterOperators, extractGroupByNames, extractProjectionFunctionsObjects, isNull, specArrayToRegex } from '@wix-velo/velo-external-db-commons'
 import { errors } from '@wix-velo/velo-external-db-commons'
 import { escapeIdentifier } from './bigquery_utils'

--- a/libs/external-db-firestore/src/firestore_data_provider.ts
+++ b/libs/external-db-firestore/src/firestore_data_provider.ts
@@ -1,6 +1,6 @@
 import { Firestore, WriteBatch, Query, DocumentData } from '@google-cloud/firestore'
 import {
-    AdapterAggregation,
+    NonEmptyAdapterAggregation,
     AdapterFilter,
     IDataProvider,
     Item,
@@ -98,7 +98,7 @@ export default class DataProvider implements IDataProvider {
         })
     }
 
-    aggregate(_collectionName: string, _filter: AdapterFilter, _aggregation: AdapterAggregation): Promise<Item[]> {
+    aggregate(_collectionName: string, _filter: AdapterFilter, _aggregation: NonEmptyAdapterAggregation): Promise<Item[]> {
         throw new Error('Unsupported method')
     }
 }

--- a/libs/external-db-mongo/src/mongo_data_provider.ts
+++ b/libs/external-db-mongo/src/mongo_data_provider.ts
@@ -1,6 +1,6 @@
 import { translateErrorCodes } from './exception_translator'
 import { insertExpressionFor, isEmptyObject, unpackIdFieldForItem, updateExpressionFor, validateTable } from './mongo_utils'
-import { IDataProvider, AdapterFilter as Filter, AdapterAggregation as Aggregation, Item, Sort,  } from '@wix-velo/velo-external-db-types'
+import { IDataProvider, AdapterFilter as Filter, NonEmptyAdapterAggregation as Aggregation, Item, Sort,  } from '@wix-velo/velo-external-db-types'
 import FilterParser from './sql_filter_transformer'
 import { MongoClient } from 'mongodb'
 

--- a/libs/external-db-mongo/src/sql_filter_transformer.ts
+++ b/libs/external-db-mongo/src/sql_filter_transformer.ts
@@ -1,6 +1,6 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
 import { isObject, AdapterOperators, extractGroupByNames, extractProjectionFunctionsObjects, isEmptyFilter, specArrayToRegex } from '@wix-velo/velo-external-db-commons'
-import { AdapterAggregation as Aggregation, AdapterFilter as Filter, NotEmptyAdapterFilter as NotEmptyFilter, Sort, AdapterFunctions } from '@wix-velo/velo-external-db-types' 
+import { NonEmptyAdapterAggregation as Aggregation, AdapterFilter as Filter, NotEmptyAdapterFilter as NotEmptyFilter, Sort, AdapterFunctions } from '@wix-velo/velo-external-db-types' 
 import { EmptyFilter, EmptySort } from './mongo_utils'
 import { MongoFieldSort, MongoFilter, MongoSort } from './types'
 const { InvalidQuery } = errors

--- a/libs/external-db-mssql/src/mssql_data_provider.ts
+++ b/libs/external-db-mssql/src/mssql_data_provider.ts
@@ -2,7 +2,7 @@ import { escapeId, validateLiteral, escape, patchFieldName, escapeTable } from '
 import { updateFieldsFor } from '@wix-velo/velo-external-db-commons'
 import { translateErrorCodes } from './sql_exception_translator'
 import { ConnectionPool as MSSQLPool } from 'mssql'
-import { IDataProvider, AdapterFilter as Filter, AdapterAggregation as Aggregation, Item, Sort } from '@wix-velo/velo-external-db-types'
+import { IDataProvider, AdapterFilter as Filter, NonEmptyAdapterAggregation as Aggregation, Item, Sort } from '@wix-velo/velo-external-db-types'
 import FilterParser from './sql_filter_transformer'
 
 export default class DataProvider implements IDataProvider {

--- a/libs/external-db-mssql/src/sql_filter_transformer.ts
+++ b/libs/external-db-mssql/src/sql_filter_transformer.ts
@@ -1,5 +1,5 @@
 import { EmptyFilter, EmptySort, isObject, AdapterOperators, extractProjectionFunctionsObjects, extractGroupByNames, isEmptyFilter, isNull, specArrayToRegex, errors } from '@wix-velo/velo-external-db-commons'
-import { AdapterFilter as Filter, AdapterAggregation as Aggregation, AdapterOperator, Sort, FunctionProjection, NotEmptyAdapterFilter as NotEmptyFilter, AdapterFunctions } from '@wix-velo/velo-external-db-types'
+import { AdapterFilter as Filter, NonEmptyAdapterAggregation as Aggregation, AdapterOperator, Sort, FunctionProjection, NotEmptyAdapterFilter as NotEmptyFilter, AdapterFunctions } from '@wix-velo/velo-external-db-types'
 import { escapeId, validateLiteralWithCounter, patchFieldNameWithCounter } from './mssql_utils'
 import { MSSQLParsedFilter } from './types'
 const { InvalidQuery } = errors

--- a/libs/external-db-mysql/src/mysql_data_provider.ts
+++ b/libs/external-db-mysql/src/mysql_data_provider.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util'
 import { asParamArrays, updateFieldsFor } from '@wix-velo/velo-external-db-commons'
 import { translateErrorCodes } from './sql_exception_translator'
 import { wildCardWith } from './mysql_utils'
-import { IDataProvider, AdapterFilter as Filter, AdapterAggregation as Aggregation, Item, Sort } from '@wix-velo/velo-external-db-types'
+import { IDataProvider, AdapterFilter as Filter, NonEmptyAdapterAggregation as Aggregation, Item, Sort } from '@wix-velo/velo-external-db-types'
 import { IMySqlFilterParser } from './sql_filter_transformer'
 import { MySqlQuery } from './types'
 

--- a/libs/external-db-mysql/src/sql_filter_transformer.ts
+++ b/libs/external-db-mysql/src/sql_filter_transformer.ts
@@ -1,5 +1,5 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
-import { AdapterFilter as Filter, AdapterAggregation as Aggregation, AdapterOperator, Sort, NotEmptyAdapterFilter as NotEmptyFilter, AdapterFunctions } from '@wix-velo/velo-external-db-types'
+import { AdapterFilter as Filter, NonEmptyAdapterAggregation as Aggregation, AdapterOperator, Sort, NotEmptyAdapterFilter as NotEmptyFilter, AdapterFunctions } from '@wix-velo/velo-external-db-types'
 import { EmptyFilter, EmptySort, isObject, AdapterOperators, extractGroupByNames, extractProjectionFunctionsObjects, isEmptyFilter, isNull, specArrayToRegex } from '@wix-velo/velo-external-db-commons'
 import { wildCardWith, escapeId } from './mysql_utils'
 import { MySqlParsedFilter, MySqlParsedAggregation } from './types'

--- a/libs/external-db-postgres/src/postgres_data_provider.ts
+++ b/libs/external-db-postgres/src/postgres_data_provider.ts
@@ -2,7 +2,7 @@ import { Pool } from 'pg'
 import { escapeIdentifier, prepareStatementVariables, prepareStatementVariablesForBulkInsert } from './postgres_utils'
 import { asParamArrays, patchDateTime, updateFieldsFor } from '@wix-velo/velo-external-db-commons'
 import { translateErrorCodes } from './sql_exception_translator'
-import { IDataProvider, AdapterFilter as Filter, Sort, Item, AdapterAggregation as Aggregation, ResponseField } from '@wix-velo/velo-external-db-types'
+import { IDataProvider, AdapterFilter as Filter, Sort, Item, NonEmptyAdapterAggregation as Aggregation, ResponseField } from '@wix-velo/velo-external-db-types'
 import FilterParser from './sql_filter_transformer'
 
 export default class DataProvider implements IDataProvider {

--- a/libs/external-db-postgres/src/sql_filter_transformer.ts
+++ b/libs/external-db-postgres/src/sql_filter_transformer.ts
@@ -1,4 +1,4 @@
-import { AdapterAggregation as Aggregation, AdapterFilter as Filter, AnyFixMe, NotEmptyAdapterFilter as NotEmptyFilter, Sort, AdapterFunctions } from '@wix-velo/velo-external-db-types' 
+import { NonEmptyAdapterAggregation as Aggregation, AdapterFilter as Filter, AnyFixMe, NotEmptyAdapterFilter as NotEmptyFilter, Sort, AdapterFunctions } from '@wix-velo/velo-external-db-types' 
 import { errors } from '@wix-velo/velo-external-db-commons'
 import { EmptyFilter, EmptySort, isObject, AdapterOperators, extractProjectionFunctionsObjects, extractGroupByNames, isEmptyFilter, isNull, specArrayToRegex } from '@wix-velo/velo-external-db-commons'
 import { escapeIdentifier } from './postgres_utils'

--- a/libs/external-db-spanner/src/spanner_data_provider.ts
+++ b/libs/external-db-spanner/src/spanner_data_provider.ts
@@ -1,6 +1,6 @@
 import { recordSetToObj, escapeId, patchFieldName, unpatchFieldName, patchFloat, extractFloatFields } from './spanner_utils'
 import { translateErrorCodes } from './sql_exception_translator'
-import { IDataProvider, AdapterFilter as Filter, AdapterAggregation as Aggregation, Item, Sort } from '@wix-velo/velo-external-db-types'
+import { IDataProvider, AdapterFilter as Filter, NonEmptyAdapterAggregation as Aggregation, Item, Sort } from '@wix-velo/velo-external-db-types'
 import { Database as SpannerDb } from '@google-cloud/spanner'
 import FilterParser from './sql_filter_transformer'
 

--- a/libs/external-db-spanner/src/sql_filter_transformer.ts
+++ b/libs/external-db-spanner/src/sql_filter_transformer.ts
@@ -1,5 +1,5 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
-import { AdapterFilter as Filter, AdapterAggregation as Aggregation, AdapterOperator, Sort, FunctionProjection, NotEmptyAdapterFilter as NotEmptyFilter, AdapterFunctions } from '@wix-velo/velo-external-db-types'
+import { AdapterFilter as Filter, NonEmptyAdapterAggregation as Aggregation, AdapterOperator, Sort, FunctionProjection, NotEmptyAdapterFilter as NotEmptyFilter, AdapterFunctions } from '@wix-velo/velo-external-db-types'
 import { EmptyFilter, EmptySort, isObject, AdapterOperators, isEmptyFilter, extractGroupByNames, extractProjectionFunctionsObjects, isNull, specArrayToRegex } from '@wix-velo/velo-external-db-commons'
 import { escapeId, patchFieldName, escapeFieldId, validateLiteralWithCounter, nameWithCounter } from './spanner_utils'
 import { SpannerParsedFilter } from './types'

--- a/libs/velo-external-db-core/src/converters/aggregation_transformer.spec.ts
+++ b/libs/velo-external-db-core/src/converters/aggregation_transformer.spec.ts
@@ -33,6 +33,9 @@ describe('Aggregation Transformer', () => {
         })
     })
 
+    test('empty aggregation', () => {
+        expect(env.AggregationTransformer.transform({})).toEqual({})
+    })
     test('single id field without function or postFilter', () => {
         env.driver.stubEmptyFilterForUndefined()
 

--- a/libs/velo-external-db-core/src/converters/aggregation_transformer.ts
+++ b/libs/velo-external-db-core/src/converters/aggregation_transformer.ts
@@ -1,4 +1,4 @@
-import { AdapterAggregation, AdapterFunctions } from '@wix-velo/velo-external-db-types'
+import { EmptyAggregation, AdapterFunctions, AdapterAggregation } from '@wix-velo/velo-external-db-types'
 import { IFilterTransformer } from './filter_transformer'
 import { projectionFunctionFor } from './utils'
 import { errors } from '@wix-velo/velo-external-db-commons'
@@ -6,12 +6,12 @@ import { Operation, Aggregation, Filter } from '../spi-model/data_source'
 const { InvalidQuery } = errors
 
 type TransformAggregationParams = {
-    aggregation: Aggregation
+    aggregation?: Aggregation
     finalFilter?: Filter
 }
 
 interface IAggregationTransformer {
-    transform(aggregation: TransformAggregationParams): AdapterAggregation
+    transform(aggregation: TransformAggregationParams): AdapterAggregation 
     wixFunctionToAdapterFunction(wixFunction: string): AdapterFunctions
 }
 
@@ -22,6 +22,10 @@ export default class AggregationTransformer implements IAggregationTransformer {
     }
 
     transform({ aggregation, finalFilter }: TransformAggregationParams): AdapterAggregation {        
+        if (!aggregation) {
+            return {} as EmptyAggregation
+        }
+        
         const { groupingFields: fields, operations } = aggregation
 
         const projectionFields = fields.map(f => ({ name: f }))

--- a/libs/velo-external-db-core/src/converters/query_validator.ts
+++ b/libs/velo-external-db-core/src/converters/query_validator.ts
@@ -1,5 +1,5 @@
 import { errors } from '@wix-velo/velo-external-db-commons'
-import { AdapterAggregation, AdapterFilter, ResponseField } from '@wix-velo/velo-external-db-types'
+import { NonEmptyAdapterAggregation, AdapterFilter, ResponseField } from '@wix-velo/velo-external-db-types'
 import { extractFieldsAndOperators, queryAdapterOperatorsFor, isBlank } from './query_validator_utils'
 const { InvalidQuery } = errors
 
@@ -21,7 +21,7 @@ export default class QueryValidator {
         this.validateFieldsExists(fieldNames, ['_id'])
     }
     
-    validateAggregation(fields: ResponseField[], aggregation: AdapterAggregation) {
+    validateAggregation(fields: ResponseField[], aggregation: NonEmptyAdapterAggregation) {
         const fieldsWithAliases = aggregation.projection.reduce((pV: any, cV: { name: string; alias?: any }) => {
             if (cV.name === '*') return pV
             if (cV.alias) return [...pV, { field: cV.alias, type: fields.find((f: ResponseField) => f.field === cV.name)?.type }]

--- a/libs/velo-external-db-core/src/service/data.ts
+++ b/libs/velo-external-db-core/src/service/data.ts
@@ -1,4 +1,4 @@
-import { AdapterAggregation as Aggregation, AdapterFilter as Filter, IDataProvider, Item, ResponseField, Sort } from '@wix-velo/velo-external-db-types'
+import { NonEmptyAdapterAggregation as Aggregation, AdapterFilter as Filter, IDataProvider, Item, ResponseField, Sort } from '@wix-velo/velo-external-db-types'
 import { asWixData, asWixDataItem } from '../converters/data_utils'
 import { getByIdFilterFor } from '../utils/data_utils'
 import {  errors as domainErrors } from '@wix-velo/velo-external-db-commons'

--- a/libs/velo-external-db-core/src/service/schema_aware_data.spec.ts
+++ b/libs/velo-external-db-core/src/service/schema_aware_data.spec.ts
@@ -140,6 +140,16 @@ describe ('Schema Aware Data Service', () => {
                                                                                                                     })
     })
 
+    test('aggregation with empty aggregation will trigger find request', async() => {
+        schema.givenDefaultSchemaFor(ctx.collectionName)
+        queryValidator.givenValidFilterForDefaultFieldsOf(ctx.filter)
+        
+        data.givenListResult(ctx.entities, ctx.totalCount, ctx.collectionName, ctx.filter, ctx.sort, ctx.skip, ctx.limit, ctx.defaultFields, true)
+        patcher.givenPatchedBooleanFieldsWith(ctx.patchedEntities, ctx.entities)
+
+        return expect(env.schemaAwareDataService.aggregate(ctx.collectionName, ctx.filter, {}, ctx.sort, ctx.skip, ctx.limit, true)).resolves.toEqual({ items: ctx.patchedEntities, totalCount: ctx.totalCount })
+    })
+
 
     const ctx = {
         collectionName: Uninitialized,

--- a/libs/velo-external-db-core/src/service/schema_aware_data.ts
+++ b/libs/velo-external-db-core/src/service/schema_aware_data.ts
@@ -81,7 +81,6 @@ export default class SchemaAwareDataService {
         return await this.dataService.truncate(collectionName)
     }
     
-    // sort, skip, limit are not really optional, after we'll implement in all the data providers we can remove the ?
     async aggregate(collectionName: string, filter: Filter, _aggregation: Aggregation, sort: Sort[], skip: number, limit: number, returnTotalCount?: boolean) {
         if (this.isEmptyAggregation(_aggregation)) {
             return await this.find(collectionName, filter, sort, skip ?? 0, limit ?? 50, undefined, returnTotalCount)

--- a/libs/velo-external-db-types/src/index.ts
+++ b/libs/velo-external-db-types/src/index.ts
@@ -92,10 +92,14 @@ export type FunctionProjection = {
 export type Projection = FieldProjection | FunctionProjection    
 
 
-export type AdapterAggregation = {
+export type NonEmptyAdapterAggregation = {
     projection: Projection[],
     postFilter: AdapterFilter,
 }
+
+export type AdapterAggregation = NonEmptyAdapterAggregation | EmptyAggregation
+
+export type EmptyAggregation = Record<string, never>
 
 export interface IDataProvider {
     find(collectionName: string, filter: AdapterFilter, sort: any, skip: number, limit: number, projection: string[]): Promise<Item[]>;
@@ -105,7 +109,7 @@ export interface IDataProvider {
     delete(collectionName: string, itemIds: string[]): Promise<number>;
     truncate(collectionName: string): Promise<void>;
     // sort, skip, limit are not really optional, after we'll implement in all the data providers we can remove the ?
-    aggregate?(collectionName: string, filter: AdapterFilter, aggregation: AdapterAggregation, sort?: Sort[], skip?: number, limit?: number ): Promise<Item[]>;
+    aggregate?(collectionName: string, filter: AdapterFilter, aggregation: NonEmptyAdapterAggregation, sort?: Sort[], skip?: number, limit?: number ): Promise<Item[]>;
 }
 
 export interface IBaseHttpError extends Error {}


### PR DESCRIPTION
There's change in the SPI - now aggregation can be without an aggregation. when that happens it's just equivalent to query. so I changed some types - aggregation is now a combination of Empty and NonEmpty aggregation (same as we did with filter). and if we get empty aggregation in schema aware layer - we just call find instead.