### PR TITLE
Query with object value - support Mysql and Postgres

### DIFF
--- a/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
+++ b/apps/velo-external-db/test/e2e/app_data.e2e.spec.ts
@@ -11,7 +11,7 @@ import * as matchers from '../drivers/schema_api_rest_matchers'
 import * as data from '../drivers/data_api_rest_test_support'
 import * as authorization from '../drivers/authorization_test_support'
 import { initApp, teardownApp, dbTeardown, setupDb, currentDbImplementationName, supportedOperations } from '../resources/e2e_resources'
-const { UpdateImmediately, DeleteImmediately, Truncate, Aggregate, FindWithSort, Projection, FilterByEveryField, QueryNestedFields, PrimaryKey, AtomicBulkInsert } = SchemaOperations
+const { UpdateImmediately, DeleteImmediately, Truncate, Aggregate, FindWithSort, Projection, FilterByEveryField, QueryNestedFields, PrimaryKey, AtomicBulkInsert, FindObject } = SchemaOperations
 
 const chance = Chance()
 
@@ -311,6 +311,20 @@ describe(`Velo External DB Data REST API: ${currentDbImplementationName()}`,  ()
                 [ctx.numberColumns[0].name]: null,
                 [ctx.numberColumns[1].name]: null,
             }]),
+            pagingMetadata: data.pagingMetadata(1, 1)
+        })
+    })
+
+    testIfSupportedOperationsIncludes(supportedOperations, [ FindObject ])('query on object fields', async() => {
+        await schema.givenCollection(ctx.collectionName, [ctx.objectColumn], authOwner)
+        await data.givenItems([ctx.objectItem], ctx.collectionName, authAdmin)
+
+        const filter = {
+            [ctx.objectColumn.name]: ctx.objectItem[ctx.objectColumn.name]
+        }
+
+        await expect(data.queryCollectionAsArray(ctx.collectionName, [], undefined, authOwner, filter)).resolves.toEqual({
+            items: expect.toIncludeSameMembers([ctx.objectItem]),
             pagingMetadata: data.pagingMetadata(1, 1)
         })
     })

--- a/libs/external-db-mysql/src/sql_filter_transformer.spec.ts
+++ b/libs/external-db-mysql/src/sql_filter_transformer.spec.ts
@@ -271,7 +271,20 @@ describe('Sql Parser', () => {
                 })
             })
 
-            describe('handle queries on nested fields', () => {
+            describe('handle queries on objects', () => {
+                test('correctly transform fully object match query', () => {
+                    const filter = {
+                        operator: eq,
+                        fieldName: ctx.fieldName,
+                        value: { a: 1, b: 2, c: 3 }
+                    }
+
+                    expect( env.filterParser.parseFilter(filter) ).toEqual([{
+                        filterExpr: `JSON_CONTAINS(${escapeId(ctx.fieldName)}, ?)`,
+                        parameters: [JSON.stringify(filter.value)]
+                    }])
+                })
+                
                 test('correctly transform nested field query', () => {
                     const operator = ctx.filterWithoutInclude.operator
                     const filter = {

--- a/libs/external-db-postgres/src/postgres_data_provider.ts
+++ b/libs/external-db-postgres/src/postgres_data_provider.ts
@@ -19,6 +19,8 @@ export default class DataProvider implements IDataProvider {
         const { sortExpr } = this.filterParser.orderBy(sort)
         const projectionExpr = this.filterParser.selectFieldsFor(projection)
         const sql = `SELECT ${projectionExpr} FROM ${escapeIdentifier(collectionName)} ${filterExpr} ${sortExpr} OFFSET $${offset} LIMIT $${offset + 1}`
+        console.log({ sqlExpression: sql, parameters: [...parameters, skip, limit] })
+        
         const resultSet = await this.pool.query(sql, [...parameters, skip, limit])
                                     .catch( err => translateErrorCodes(err, collectionName) )
         return resultSet.rows

--- a/libs/external-db-postgres/src/sql_filter_transformer.spec.ts
+++ b/libs/external-db-postgres/src/sql_filter_transformer.spec.ts
@@ -280,7 +280,23 @@ describe('Sql Parser', () => {
             })
         })
 
-        describe('handle queries on nested fields', () => {
+        describe('handle queries on object fields', () => {
+            test('correctly transform fully object match query', () => {
+                const filter = {
+                    operator: eq,
+                    fieldName: ctx.fieldName,
+                    value: { a: 1, b: 2, c: 3 }
+                }
+
+                const parsedFilter = env.filterParser.parseFilter(filter, ctx.offset)
+
+                expect( parsedFilter ).toEqual([{
+                    filterExpr: `${escapeIdentifier(ctx.fieldName)}::jsonb @> $${ctx.offset}::jsonb`,
+                    parameters: [JSON.stringify(filter.value)],
+                    filterColumns: [],
+                    offset: ctx.offset + 1,
+                }])
+            })
             test('correctly transform nested field query', () => {
                 const operator = ctx.filterWithoutInclude.operator
                 const filter = {

--- a/libs/external-db-spanner/src/supported_operations.ts
+++ b/libs/external-db-spanner/src/supported_operations.ts
@@ -1,6 +1,6 @@
 import { AllSchemaOperations } from '@wix-velo/velo-external-db-commons'
 import { SchemaOperations } from '@wix-velo/velo-external-db-types'
 //change column types - https://cloud.google.com/spanner/docs/schema-updates#supported_schema_updates
-const notSupportedOperations = [SchemaOperations.ChangeColumnType, SchemaOperations.NonAtomicBulkInsert]
+const notSupportedOperations = [SchemaOperations.ChangeColumnType, SchemaOperations.NonAtomicBulkInsert, SchemaOperations.FindObject]
 
 export const supportedOperations = AllSchemaOperations.filter(op => !notSupportedOperations.includes(op))


### PR DESCRIPTION
today, we are allowing querying nested fields, but not full objects - i.e. 
this wouldn't work:
` {fieldName: { $eq: {someKey: "a"}}}`
this is working:
` {fieldName.someKey: { $eq: "a"}}`

we need to support it in order to support filtering encrypted fields (and filtering any other object field and find by value that is an object)