### PR TITLE
add default sort

### DIFF
--- a/libs/velo-external-db-core/src/router.ts
+++ b/libs/velo-external-db-core/src/router.ts
@@ -144,11 +144,12 @@ export const createRouter = () => {
 
             const offset = query.paging ? query.paging.offset : 0
             const limit = query.paging ? query.paging.limit : 50
+            const sort: dataSource.Sorting[] = query.sort ? query.sort : [{ fieldName: '_id', order: dataSource.SortOrder.ASC }]
 
             const data = await schemaAwareDataService.find(
                 collectionId,
                 filterTransformer.transform(query.filter),
-                filterTransformer.transformSort(query.sort),
+                filterTransformer.transformSort(sort),
                 offset,
                 limit,
                 query.fields,


### PR DESCRIPTION
in order to support paging the way wix-data expecting, we need to have default sort for each query.