### PR TITLE
Error logging fix  

### DIFF
--- a/libs/external-db-logger/src/logger.ts
+++ b/libs/external-db-logger/src/logger.ts
@@ -6,7 +6,7 @@ export class Logger implements ILogger {
     private logger: pino.Logger
 
   constructor() {
-    this.logLevel = process.env['LOG_LEVEL']?.toLocaleLowerCase() as LogLevel || LogLevel.WARN
+    this.logLevel = process.env['LOG_LEVEL']?.toLocaleLowerCase() as LogLevel || LogLevel.INFO
     this.logger = pino({
         base: {},
         timestamp: false,
@@ -33,6 +33,6 @@ export class Logger implements ILogger {
   }
 
   error(message: string, error?: LoggerError, data?: Data): void {
-    this.logger.error(message, error, data)
+    this.logger.error(error, message, data)
   }
 }

--- a/libs/velo-external-db-core/src/web/error-middleware.ts
+++ b/libs/velo-external-db-core/src/web/error-middleware.ts
@@ -5,7 +5,6 @@ import { ILogger } from '@wix-velo/external-db-logger'
 export const errorMiddleware = (logger?: ILogger) => (err: any, _req: any, res: Response, _next?: NextFunction) => {
   if (process.env['NODE_ENV'] !== 'test') {
     logger?.error(err.message, err)
-    console.error(err)
   }
 
   const error = domainToSpiErrorTranslator(err)


### PR DESCRIPTION
This PR sets the default logging level to INFO, allowing us to observe the informational messages indicating the adapter is running. Additionally, it resolves the issue where the error stack trace was not being printed.