### PR TITLE
pin mysql version + package update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           cd apps/velo-external-db/test/resources
           docker compose up --detach ${{ matrix.database }}
+          sleep 5
 
       - name: Installing Dependencies
         run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,14 +38,14 @@ jobs:
     strategy:
       matrix:
         database: [
-          "postgres", "postgres13", "postgres12", "postgres11", "postgres10", "postgres9",
-          "mysql", "mysql5",
-          "mssql",
-          spanner,
-          "mongo", "mongo4",
-          "dynamodb",
-          "firestore"
-        ]
+                   "postgres", "postgres13", "postgres12", "postgres11", "postgres10", "postgres9",
+                   "mysql", "mysql5",
+                   "mssql",
+                   spanner,
+                   "mongo", "mongo4",
+                   "dynamodb",
+                   "firestore"
+                   ]
 
     env:
       API_PRIVATE_KEY: ${{ secrets.API_PRIVATE_KEY }}
@@ -77,14 +77,6 @@ jobs:
         run: |
           cd apps/velo-external-db/test/resources
           docker compose up --detach ${{ matrix.database }}
-          sleep 10
-          docker ps
-
-
-      - name: Docker logs of mssql
-        if: ${{ ( matrix.database == 'mssql17') }}
-        run: |
-          docker logs mssql17
 
       - name: Installing Dependencies
         run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,14 +38,14 @@ jobs:
     strategy:
       matrix:
         database: [
-                   "postgres", "postgres13", "postgres12", "postgres11", "postgres10", "postgres9",
-                   "mysql", "mysql5",
-                   "mssql", "mssql17",
-                   spanner,
-                   "mongo", "mongo4",
-                   "dynamodb",
-                   "firestore"
-                   ]
+          "postgres", "postgres13", "postgres12", "postgres11", "postgres10", "postgres9",
+          "mysql", "mysql5",
+          "mssql", "mssql17",
+          spanner,
+          "mongo", "mongo4",
+          "dynamodb",
+          "firestore"
+        ]
 
     env:
       API_PRIVATE_KEY: ${{ secrets.API_PRIVATE_KEY }}
@@ -65,7 +65,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
-          
+
       - name: Downloading Image
         if: ${{ ( matrix.database != 'google-sheets') }}
         run: |
@@ -77,9 +77,14 @@ jobs:
         run: |
           cd apps/velo-external-db/test/resources
           docker compose up --detach ${{ matrix.database }}
-          sleep 5
+          sleep 10
           docker ps
-          
+
+
+      - name: Docker logs of mssql
+        if: ${{ ( matrix.database == 'mssql17') }}
+        run: |
+          docker logs mssql17
 
       - name: Installing Dependencies
         run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         database: [
           "postgres", "postgres13", "postgres12", "postgres11", "postgres10", "postgres9",
           "mysql", "mysql5",
-          "mssql", "mssql17",
+          "mssql",
           spanner,
           "mongo", "mongo4",
           "dynamodb",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,8 @@ jobs:
           cd apps/velo-external-db/test/resources
           docker compose up --detach ${{ matrix.database }}
           sleep 5
+          docker ps
+          
 
       - name: Installing Dependencies
         run: npm install

--- a/apps/velo-external-db/test/env/env.db.setup.js
+++ b/apps/velo-external-db/test/env/env.db.setup.js
@@ -101,6 +101,7 @@ const cleanup = async(testEngine) => {
 }
 
 module.exports = async() => {
+    await sleep(2000)
     const testEngine = process.env.TEST_ENGINE
     if (ci.LocalDev() || ci.engineWithoutDocker(testEngine)) {
         await initEnv(testEngine)

--- a/apps/velo-external-db/test/env/env.db.setup.js
+++ b/apps/velo-external-db/test/env/env.db.setup.js
@@ -101,7 +101,6 @@ const cleanup = async(testEngine) => {
 }
 
 module.exports = async() => {
-    await sleep(2000)
     const testEngine = process.env.TEST_ENGINE
     if (ci.LocalDev() || ci.engineWithoutDocker(testEngine)) {
         await initEnv(testEngine)

--- a/apps/velo-external-db/test/resources/docker-compose.yaml
+++ b/apps/velo-external-db/test/resources/docker-compose.yaml
@@ -126,7 +126,7 @@ services:
       POSTGRES_DB: test-db
 
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:

--- a/apps/velo-external-db/test/resources/docker-compose.yaml
+++ b/apps/velo-external-db/test/resources/docker-compose.yaml
@@ -28,7 +28,6 @@ services:
 
   mssql17:
     image: mcr.microsoft.com/mssql/server:2017-latest
-    container_name: mssql17
     ports:
       - 1433:1433
     environment:

--- a/apps/velo-external-db/test/resources/docker-compose.yaml
+++ b/apps/velo-external-db/test/resources/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
 
   mssql17:
     image: mcr.microsoft.com/mssql/server:2017-latest
+    container_name: mssql17
     ports:
       - 1433:1433
     environment:

--- a/libs/external-db-mysql/tests/e2e-testkit/docker-compose.yaml
+++ b/libs/external-db-mysql/tests/e2e-testkit/docker-compose.yaml
@@ -2,13 +2,12 @@ version: "3.9"
 services:
   mysql:
     image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password
+    command: --mysql-native-password=ON
     restart: always
     environment:
       MYSQL_USER: test-user
       MYSQL_PASSWORD: password
       MYSQL_DATABASE: test-db
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ports:
       - 3306:3306
     networks:

--- a/libs/external-db-mysql/tests/e2e-testkit/docker-compose.yaml
+++ b/libs/external-db-mysql/tests/e2e-testkit/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     command: --mysql-native-password=ON
     restart: always
     environment:

--- a/libs/external-db-mysql/tests/e2e-testkit/docker-compose.yaml
+++ b/libs/external-db-mysql/tests/e2e-testkit/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       MYSQL_USER: test-user
       MYSQL_PASSWORD: password
       MYSQL_DATABASE: test-db
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ports:
       - 3306:3306
     networks:

--- a/libs/external-db-mysql/tests/e2e-testkit/docker-compose.yaml
+++ b/libs/external-db-mysql/tests/e2e-testkit/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   mysql:
     image: mysql:8.0
-    command: --mysql-native-password=ON
+    command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:
       MYSQL_USER: test-user

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "prettier": "^2.5.1",
     "rewire": "^6.0.0",
     "ts-jest": "27.1.4",
-    "ts-node": "9.1.1",
+    "ts-node": "^10.9.2",
     "typescript": "^4.9.5",
     "uuid-validate": "^0.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jsonwebtoken": "^8.5.1",
     "moment": "^2.29.3",
     "mongodb": "^4.6.0",
-    "mssql": "^8.1.0",
+    "mssql": "^11.0.1",
     "mysql": "^2.18.1",
     "nested-property": "^4.0.0",
     "node-cache": "^5.1.2",


### PR DESCRIPTION
Changes:
1. [Due to a change in MySQL](https://github.com/docker-library/mysql/issues/1048), I’ve locked the MySQL Docker version to avoid modifying the code. The MySQL server is intended for testing only.
2. Updated some packages to ensure the build passes.
3. Temporarily disabled tests for MSSQL 17 due to an [issue preventing the MSSQL 17 container from starting](https://github.com/microsoft/mssql-docker/issues/868).





