### PR TITLE
Feat: Add scheduled workflow for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:
 
+  schedule:
+    - cron: '0 7 * * 0' # Runs every Sunday at 7:00 AM UTC (which is 9:00 AM TLV)
+
 jobs:
   test_main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/main.yml` file to add a scheduled workflow trigger.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R9-R11): Added a `schedule` trigger to run the workflow every Sunday at 7:00 AM UTC.