### PR TITLE
Github action: Update actions/cache to v4 to resolve deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: 20
 
       - name: Restore Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 20
 
       - name: Restore Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules


### PR DESCRIPTION
The `main.yml` workflow was failing due to the deprecated `actions/cache@v2`. This PR updates the action to `actions/cache@v4`. 
