### PR TITLE
feat: increase request body size limit for JSON and URL-encoded data

### DIFF
--- a/apps/velo-external-db/src/app.ts
+++ b/apps/velo-external-db/src/app.ts
@@ -37,8 +37,8 @@ export const createApp = async(wixDataBaseUrl?: string) => {
     const app = express()
     const hooks: Hooks = process.env.DEBUG ? { dataHooks: debuggingDataHooks } : undefined
     const initConnectorResponse = await initConnector(wixDataBaseUrl, hooks)
-    app.use(express.json({ limit: '4mb' }));
-    app.use(express.urlencoded({ limit: '4mb', extended: true }));
+    app.use(express.json({ limit: '4mb' }))
+    app.use(express.urlencoded({ limit: '4mb', extended: true }))
     app.use(initConnectorResponse.externalDbRouter.router)
     const server = app.listen(8080, () => initConnectorResponse.logger?.info('Listening on port 8080'))
 

--- a/apps/velo-external-db/src/app.ts
+++ b/apps/velo-external-db/src/app.ts
@@ -37,6 +37,8 @@ export const createApp = async(wixDataBaseUrl?: string) => {
     const app = express()
     const hooks: Hooks = process.env.DEBUG ? { dataHooks: debuggingDataHooks } : undefined
     const initConnectorResponse = await initConnector(wixDataBaseUrl, hooks)
+    app.use(express.json({ limit: '4mb' }));
+    app.use(express.urlencoded({ limit: '4mb', extended: true }));
     app.use(initConnectorResponse.externalDbRouter.router)
     const server = app.listen(8080, () => initConnectorResponse.logger?.info('Listening on port 8080'))
 


### PR DESCRIPTION
This pull request includes changes to the `apps/velo-external-db/src/app.ts` file to enhance the application's request handling capabilities.

Enhancements to request handling:

* [`apps/velo-external-db/src/app.ts`](diffhunk://#diff-1afdd28a5deb02e684fa79c999595f5e74cab405716ad90e55a66e8e1ddb8195R40-R41): Added middleware to handle JSON and URL-encoded payloads with a size limit of 4MB.