### PR TITLE
Refactor/split GitHub actions workflows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,15 @@
+name: CI - Push
+
+on:
+  push:
+    branches:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  run_tests:
+    uses: ./.github/workflows/test-workflow.yml
+    with:
+      branch: ${{ github.ref_name }}
+    secrets: inherit
+

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,16 @@
+name: CI - Scheduled
+
+on:
+  schedule:
+    - cron: '0 7 * * 0' # Runs every Sunday at 7:00 AM UTC (which is 9:00 AM TLV)
+
+jobs:
+  run_tests:
+    strategy:
+      matrix:
+        branch: [adapter-v2]
+    uses: ./.github/workflows/test-workflow.yml
+    with:
+      branch: ${{ matrix.branch }}
+    secrets: inherit
+

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -99,3 +99,67 @@ jobs:
           cd apps/velo-external-db/test/resources
           docker compose down
 
+  # test_bigquery:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       database: ["bigquery"]
+
+  #   steps:
+  #     - uses: actions/checkout@v2
+
+  #     - name: Use Node.js 14
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 14
+
+  #     - name: Restore Dependencies
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           node_modules
+  #           */*/node_modules
+  #         key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
+
+  #     - name: Downloading Docker Compose V2
+  #       if: ${{ ( matrix.database != 'bigquery') }}
+  #       run: |
+  #         curl -sfL https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
+  #         docker compose version
+
+  #     - name: Downloading Image
+  #       if: ${{ ( matrix.database != 'bigquery') }}
+  #       run: |
+  #         cd packages/velo-external-db/test/resources
+  #         docker compose pull --quiet ${{ matrix.database }}
+
+  #     - name: Start Container
+  #       if: ${{ ( matrix.database != 'bigquery') }}
+  #       run: |
+  #         cd packages/velo-external-db/test/resources
+  #         docker compose up --detach ${{ matrix.database }}
+
+  #     - id: auth
+  #       if: ${{ ( matrix.database == 'bigquery') }}
+  #       uses: google-github-actions/auth@v0.4.0
+  #       with:
+  #         credentials_json: ${{ secrets.ACTIONS_GCP_CREDENTIALS }}
+
+  #     - name: Set up Cloud SDK
+  #       if: ${{ ( matrix.database == 'bigquery') }}
+  #       uses: google-github-actions/setup-gcloud@v0.2.1
+
+  #     - name: Installing Dependencies
+  #       run: npm install
+
+  #     - name: Install dependencies of the homemade packages.
+  #       run: npm run build:dev
+
+  #     - name: Testing
+  #       run: npm run test:${{ matrix.database }}
+
+  #     - name: Stop Container
+  #       if: ${{ ( matrix.database != 'bigquery') }}
+  #       run: |
+  #         cd packages/velo-external-db/test/resources
+  #         docker compose down

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,19 +1,20 @@
-name: CI
+name: Test Workflow
 
 on:
-  push:
-    branches: "*"
-
-  workflow_dispatch:
-
-  schedule:
-    - cron: '0 7 * * 0' # Runs every Sunday at 7:00 AM UTC (which is 9:00 AM TLV)
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Branch to checkout and test'
+        required: true
+        type: string
 
 jobs:
   test_main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.branch }}
       - name: Use Node.js 20
         uses: actions/setup-node@v2
         with:
@@ -55,6 +56,8 @@ jobs:
       CLIENT_EMAIL: ${{ secrets.CLIENT_EMAIL }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Use Node.js 20
         uses: actions/setup-node@v2
@@ -96,67 +99,3 @@ jobs:
           cd apps/velo-external-db/test/resources
           docker compose down
 
-  # test_bigquery:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       database: ["bigquery"]
-
-  #   steps:
-  #     - uses: actions/checkout@v2
-
-  #     - name: Use Node.js 14
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 14
-
-  #     - name: Restore Dependencies
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           node_modules
-  #           */*/node_modules
-  #         key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
-
-  #     - name: Downloading Docker Compose V2
-  #       if: ${{ ( matrix.database != 'bigquery') }}
-  #       run: |
-  #         curl -sfL https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
-  #         docker compose version
-
-  #     - name: Downloading Image
-  #       if: ${{ ( matrix.database != 'bigquery') }}
-  #       run: |
-  #         cd packages/velo-external-db/test/resources
-  #         docker compose pull --quiet ${{ matrix.database }}
-
-  #     - name: Start Container
-  #       if: ${{ ( matrix.database != 'bigquery') }}
-  #       run: |
-  #         cd packages/velo-external-db/test/resources
-  #         docker compose up --detach ${{ matrix.database }}
-
-  #     - id: auth
-  #       if: ${{ ( matrix.database == 'bigquery') }}
-  #       uses: google-github-actions/auth@v0.4.0
-  #       with:
-  #         credentials_json: ${{ secrets.ACTIONS_GCP_CREDENTIALS }}
-
-  #     - name: Set up Cloud SDK
-  #       if: ${{ ( matrix.database == 'bigquery') }}
-  #       uses: google-github-actions/setup-gcloud@v0.2.1
-
-  #     - name: Installing Dependencies
-  #       run: npm install
-
-  #     - name: Install dependencies of the homemade packages.
-  #       run: npm run build:dev
-
-  #     - name: Testing
-  #       run: npm run test:${{ matrix.database }}
-
-  #     - name: Stop Container
-  #       if: ${{ ( matrix.database != 'bigquery') }}
-  #       run: |
-  #         cd packages/velo-external-db/test/resources
-  #         docker compose down


### PR DESCRIPTION
### Summary
This PR refactors the CI workflow by splitting test execution logic into separate, modular GitHub Actions workflows. The previous configuration combined push and scheduled events in a single file, which prevented running scheduled tests on different branches.

**Context:** The main branch contains adapter v3 (in development), while the adapter-v2 branch contains the production version. This split allows scheduled tests to run against the production branch (adapter-v2) while push-triggered tests continue to run against feature branches and main.


### Changes

- Created `.github/workflows/push.yml` - Handles CI runs on push events and manual triggers, delegating test execution to the reusable workflow.
- Created `.github/workflows/schedule.yml` - Handles scheduled CI runs (every Sunday at midnight), supporting matrix testing for specific branches.
- Renamed `.github/workflows/main.yml` → `.github/workflows/test-workflow.yml `- Converted to a reusable workflow (workflow_call) that accepts a branch input parameter, enabling flexible branch selection for test execution.
Updated checkout step - Modified test-workflow.yml to use the provided branch input, ensuring the correct branch is tested across all trigger scenarios.